### PR TITLE
doc(repo): add repo example

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -96,6 +96,23 @@
             </code>
           </article>
         </div>
+
+        <div class="code-steps__item container group">
+          <aside class="description">
+            <h2>Manage Repos</h2>
+            <p>Add your own source for charts.</p>
+          </aside>
+          <article class="console">
+            <code>
+              <div class="line"><span class="code-term">$ helm repo add mycharts https://github.com/dev/mycharts</span></div>
+              <div class="line">---> Cloning into '/Users/dev/.helm/cache/mycharts'...</div>
+              <div class="line"><span class="code-term">~ $ helm repo list</span></div>
+              <div class="line">charts          https://github.com/helm/charts</div>
+              <div class="line">mycharts        https://github.com/mycharts/charts</div>
+            </code>
+          </article>
+        </div>
+
         <div class="code-steps__item container group">
           <aside class="description">
             <h2>Go Forth</h2>


### PR DESCRIPTION
With 0.2.0, we should call out `repo` command, since that is an important feature!

/cc @jackfrancis 