### PR TITLE
fix(index): used bash for "get.helm.sh" script

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -28,7 +28,7 @@
           </aside>
           <article class="console">
             <code>
-              <div class="line"><span id="get-helm-sh" class="code-term ga-track" data-click-category="curl_select">curl -s https://get.helm.sh | sh</span></div>
+              <div class="line"><span id="get-helm-sh" class="code-term ga-track" data-click-category="curl_select">curl -s https://get.helm.sh | bash</span></div>
             </code>
             <p>or <a href="https://bintray.com/deis/helm/helm/_latestVersion#files" class="button -download ga-track" data-click-category="download">Download</a></p>
           </article>


### PR DESCRIPTION
using `sh` gives errors on some Linux OSes