### PR TITLE
Change irc link to slack channel

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -172,7 +172,7 @@
       <div class="buttons">
         <a href="https://helm.sh/docs" class="button -cta ga-track" data-click-category="documentation"><i class="icon -left ion-document-text"></i> Read the Docs</a>
         <a href="https://github.com/helm/helm-classic" class="button -gh ga-track" data-click-category="footer_github"><i class="icon -left ion-social-github"></i> GitHub</a>
-        <a href="irc://chat.freenode.net/helm" class="button -irc light ga-track" data-click-category="irc"><i class="icon -left ion-chatboxes"></i> #helm</a>
+        <a href="http://slack.kubernetes.io/" class="button -irc light ga-track" data-click-category="slack"><i class="icon -left ion-chatboxes"></i> #helm</a>
       </div>
     </section>
 


### PR DESCRIPTION
The conversation and help seems to be at the slack channel, not at the IRC (in fact, it is empty).
Change the link to avoid confusion.