### PR TITLE
Remove helm.sh links from "supported by Microsoft" logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ categories:
 
   <section class="billboard">
     <div class="container">
-      <a href="https://helm.sh"><img src="{{site.baseurl}}/assets/images/helm-logo-microsoft.svg" alt="Helm supported by Microsoft" class="helm-logo"></a>
+      <img src="{{site.baseurl}}/assets/images/helm-logo-microsoft.svg" alt="Helm supported by Microsoft" class="helm-logo">
 
       <h1>The package manager for Kubernetes</h1>
       <h2>Helm is the best way to find, share, and use software built for Kubernetes.</h2>
@@ -162,7 +162,7 @@ categories:
         </div>
         <div class="row helm-contrib-logos">
           <div class="small-12 medium-12 large-12 columns">
-            <a href="https://helm.sh.com/"><img src="{{site.baseurl}}/assets/images/helm-logo-microsoft.svg" alt="Helm supported by Microsoft" class="helm-logo"></a>
+            <img src="{{site.baseurl}}/assets/images/helm-logo-microsoft.svg" alt="Helm supported by Microsoft" class="helm-logo">
           </div>
           <hr>
           <div class="small-12 medium-6 large-3 columns">


### PR DESCRIPTION
Removing the urls from the "supported by Microsoft" logos.
One of the links was broken, and there's no need to link to the current page for those logos anyway.