### PR TITLE
Update build scripts

### DIFF
--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -256,11 +256,22 @@ gulp.task('clone', function() {
   });
 
 
-// 'gulp' default task to build the site assets
-gulp.task('default', function(callback) {
+  gulp.task('copyall', function () {
+    return gulp.src('static/src/**/*')
+      .pipe(gulp.dest('app/src'))
+      .pipe(notify({message: 'Copied all.'}));
+  });
+
+
+// gulp clonedocs - use in conjunction with gulp build
+gulp.task('clonedocs', function(callback) {
   runSequence('clean',
-              ['clone'],
-              ['styles', 'scripts', 'images', 'copy', 'copyall'],
+              'clone',
+              callback);
+});
+gulp.task('build', function(callback) {
+  runSequence(['styles', 'scripts', 'images', 'copy'],
+              'copyall',
               'redirect-inject',
               'redirect-subfolder',
               ['reorg-using', 'reorg-charts'],
@@ -272,11 +283,21 @@ gulp.task('default', function(callback) {
               callback);
 });
 
-
-gulp.task('copyall', function () {
-  return gulp.src('static/src/**/*')
-    .pipe(gulp.dest('app/src'))
-    .pipe(notify({message: 'Copied all.'}));
+// 'gulp' default task to build the site assets
+gulp.task('default', function(callback) {
+  runSequence('clean',
+              'clone',
+              ['styles', 'scripts', 'images', 'copy'],
+              'copyall',
+              'redirect-inject',
+              'redirect-subfolder',
+              ['reorg-using', 'reorg-charts'],
+              'template-rename',
+              'template-move',
+              'template-concat',
+              'template-del',
+              'redirect-anchor',
+              callback);
 });
 
 

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -285,18 +285,8 @@ gulp.task('build', function(callback) {
 
 // 'gulp' default task to build the site assets
 gulp.task('default', function(callback) {
-  runSequence('clean',
-              'clone',
-              ['styles', 'scripts', 'images', 'copy'],
-              'copyall',
-              'redirect-inject',
-              'redirect-subfolder',
-              ['reorg-using', 'reorg-charts'],
-              'template-rename',
-              'template-move',
-              'template-concat',
-              'template-del',
-              'redirect-anchor',
+  runSequence('clonedocs',
+              'build',
               callback);
 });
 

--- a/docs/script/deploy
+++ b/docs/script/deploy
@@ -7,6 +7,7 @@ build_dest=$1
 
 npm install
 bower install --config.interactive=false
-gulp
+gulp clonedocs
+gulp build
 
 hugo -d ${build_dest}

--- a/docs/script/install
+++ b/docs/script/install
@@ -5,4 +5,5 @@ set -e
 
 npm install
 bower install
-gulp
+gulp clonedocs
+gulp build


### PR DESCRIPTION
There's an issue with `gulp` tasks sequencing that's [affecting some builds (#51)](https://github.com/helm/helm-www/issues/51), where the directory setup does not complete.

This PR splits the gulp tasks so that the directory setup waits for the fetching of the docs to complete before running, to ensure the correct sequence is followed.