### PR TITLE
Update docs menu to fix #49 and #54

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -19,11 +19,6 @@ defaultContentLanguage = "en"
 
 
 [[menu.main]]
-  name = "Home"
-  url = "https://docs.helm.sh"
-  identifier = "home"
-  weight = 1
-[[menu.main]]
   name = "Using Helm"
   url = "using_helm"
   identifier = "using_helm"

--- a/docs/themes/helmdocs/layouts/partials/offcanvas.html
+++ b/docs/themes/helmdocs/layouts/partials/offcanvas.html
@@ -1,16 +1,25 @@
 <aside class="left-off-canvas-menu" id="off-canvas-navigation" data-topbar>
   <div class="drawer-wrap">
 
-  <ul class="off-canvas-list">
-      <li><a href="{{ .Site.BaseURL }}">Helm Docs Home</a></li>
+    <ul class="off-canvas-list current sidebar-main">
+      <li>
+        <a class="sidebar-nav-item" href="{{ .Site.BaseURL | safeHTMLAttr }}">
+          <span class="ripple">Docs Home <span></span></span>
+        </a>
+      </li>
       {{ range .Site.Menus.main }}
-      <li><a class="sidebar-nav-item{{if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} active{{end}}" href="{{.URL}}">
+      <li class="sidebar-nav-item toctree-l1 {{if $.IsMenuCurrent "main" . }} active {{end}}">
+        <a class="reference internal" href="{{ .URL | safeHTMLAttr }}" state="">
           <span class="ripple">{{ .Name }} <span></span></span>
         </a>
         {{ if .HasChildren }}
-        <ul>
+        <ul class="current">
           {{ range .Children.ByWeight }}
-            <li{{if $.IsMenuCurrent "main" . }} class="active"{{end}}><a href="#{{.URL}}">{{ .Name }}</a></li>
+          <li class="toctree-l2 {{if $.IsMenuCurrent "main" . }} active {{end}}">
+            <a href="../../{{ .Parent | safeHTMLAttr }}/#{{ .URL | safeHTMLAttr }}" title="Switch to {{ .Name }}">
+              {{ .Name }}
+            </a>
+          </li>
           {{ end }}
         </ul>
         {{end}}

--- a/docs/themes/helmdocs/layouts/partials/sidebar.html
+++ b/docs/themes/helmdocs/layouts/partials/sidebar.html
@@ -8,6 +8,11 @@
 
   <nav class="sidebar-nav">
     <ul class="current sidebar-main">
+      <li>
+        <a class="sidebar-nav-item" href="{{ .Site.BaseURL | safeHTMLAttr }}">
+          <span class="ripple">Docs Home <span></span></span>
+        </a>
+      </li>
       {{ range .Site.Menus.main }}
       <li class="sidebar-nav-item toctree-l1 {{if $.IsMenuCurrent "main" . }} active {{end}}">
         <a class="reference internal" href="{{ .URL | safeHTMLAttr }}" state="">


### PR DESCRIPTION
* update the offcanvas template to fix the docs menu for mobile and small screens (closes #54) 
* remove the home link from the menu (config.toml)
* add the home link into theme templates, as a relative `site.BaseUrl` value (closes #49)