### PR TITLE
Update contributors/maintainers line

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@ categories:
               <a target="_blank" href="https://www.codecentric.de"><img src="{{site.baseurl}}/assets/images/logowall/codecentric.png" alt="codecentric AG"></a>
             </div>
 
-            <p><small>...and many other wonderful <a href="https://github.com/kubernetes/helm/blob/master/OWNERS" target="_blank">core contributors</a>.</small></p>
+            <p><small>...and many other wonderful <a href="https://github.com/kubernetes/helm/blob/master/OWNERS" target="_blank">helm</a> and <a href="https://github.com/kubernetes/charts/blob/master/OWNERS" target="_blank">charts</a> core maintainers.</small></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Update to #65 and #67.

Added charts link per discussion in https://github.com/helm/helm-www/pull/65#issuecomment-344450733.

Changed string from "contributors" to "maintainers" per existing language in CONTRIBUTING.md files in each repo (I think the idea is that "contributors" are much wider community than maintainers, and it's open to anyone to contribute).