### PR TITLE
[#82] assign content type to css href in head

### DIFF
--- a/helm.sh/_includes/head.html
+++ b/helm.sh/_includes/head.html
@@ -17,7 +17,7 @@
 
   <link rel="alternate" type="application/rss+xml" title="Deis Sitemap" href="//deis.com/sitemap.xml" />
 
-  <link rel="stylesheet" href="{{ '/assets/css/app.min.css' | prepend: site.baseurl }}" />
+  <link rel="stylesheet" type="text/css" href="{{ '/assets/css/app.min.css' | prepend: site.baseurl }}" />
   {% if page.canonical %}
     <link rel="canonical" href="{{ page.canonical }}" />
   {% else %}


### PR DESCRIPTION
Small edit related to #82. Not sure if this will completely fix the issue.