### PR TITLE
[helm.sh] update the url in the site config

### DIFF
--- a/helm.sh/_config.yml
+++ b/helm.sh/_config.yml
@@ -4,7 +4,7 @@ email: ""
 description: > # this means to ignore newlines until "baseurl:"
   Helm: The Kubernetes Package Manager
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "https://helm.sh" # the base hostname & protocol for your site
+url: "https://www.helm.sh" # the base hostname & protocol for your site
 twitter_username: opendeis
 github_username:  deis
 


### PR DESCRIPTION
This should ensure the full `www.helm.sh` path is used for assets, to fix the CORS issue [#3954](https://github.com/kubernetes/helm/issues/3954).