### PR TITLE
update build task to remove readme.md as homepage

### DIFF
--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -197,6 +197,7 @@ gulp.task('clone', function() {
     return del([
       templatefiles,
       'source/docs/index.md',
+      'source/docs/readme.md',
       'source/docs/chart_template_guide/tmp/',
       '!source/docs/chart_template_guide/index.md'
     ], {force: true});


### PR DESCRIPTION
Required to enable [#4041](https://github.com/kubernetes/helm/pull/4041).

This PR ensures the site homepage doesn't get overwritten by the docs README.md