### PR TITLE
remove rbac pipeline link replace

### DIFF
--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -267,7 +267,6 @@ gulp.task('clone', function(cb) {
       .pipe(replace('#tiller_ssl', '#using-ssl-between-helm-and-tiller'))
       // update rbac links
       .pipe(replace('#rbac', '#role-based-access-control'))
-      .pipe(replace('rbac', '#role-based-access-control'))
       .pipe(gulp.dest('source/docs/'))
   });
 


### PR DESCRIPTION
It turns out that this is messing with the core documentation. Any time "rbac" is mentioned,
it is immediately replaced with #role-based-access-control which is messing with the doc
text in certain areas.

See https://docs.helm.sh/using_helm/#example-service-account-with-cluster-admin-role for an example