### PR TITLE
[helm.sh] edit ruby versioning for build task

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -31,7 +31,7 @@ events.on("exec", (e, p) => {
   buildHelmSh.timeout = timeout
   buildHelmSh.storage.enabled = true
   buildHelmSh.tasks = [
-    "apt-get update -y && apt-get install -yq ruby ruby-dev",
+    "apt-get update -y && apt-get install -yq ruby2.2 ruby2.2dev",
     "npm install -g gulp",
     "gem install bundler",
     "gem install nokogiri -v '1.8.1'", // This is a temporary fix for an install problem

--- a/helm.sh/Gemfile
+++ b/helm.sh/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.2.5"
+ruby "2.2"
 
 gem 'jekyll'
 gem 'jekyll-paginate'


### PR DESCRIPTION
Updates the brigade.js and Gemfile to use the same version of Ruby.

The mismatch is triggering errors in the build task in #103.