### PR TITLE
[helm.sh] update ruby image and version

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -31,7 +31,8 @@ events.on("exec", (e, p) => {
   buildHelmSh.timeout = timeout
   buildHelmSh.storage.enabled = true
   buildHelmSh.tasks = [
-    "apt-get update -y && apt-get install -yq ruby ruby-dev",
+    "curl -sL https://deb.nodesource.com/setup_9.x | bash -",
+    "apt-get install -y nodejs",
     "npm install -g gulp",
     "gem install bundler",
     "gem install nokogiri -v '1.8.1'", // This is a temporary fix for an install problem

--- a/brigade.js
+++ b/brigade.js
@@ -27,11 +27,11 @@ events.on("exec", (e, p) => {
   ];
 
   // This job renders helm.sh
-  const buildHelmSh = new Job("helm-sh", "node:9");
+  const buildHelmSh = new Job("helm-sh", "ruby:2.3");
   buildHelmSh.timeout = timeout
   buildHelmSh.storage.enabled = true
   buildHelmSh.tasks = [
-    "apt-get update -y && apt-get install -yq ruby2.2 ruby2.2dev",
+    "apt-get update -y && apt-get install -yq ruby ruby-dev",
     "npm install -g gulp",
     "gem install bundler",
     "gem install nokogiri -v '1.8.1'", // This is a temporary fix for an install problem

--- a/helm.sh/Gemfile
+++ b/helm.sh/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.2"
+ruby "2.3"
 
 gem 'jekyll'
 gem 'jekyll-paginate'


### PR DESCRIPTION
This is a follow up to #105 - switching the docker image for helm.sh from node to ruby. 