### PR TITLE
[helm.sh] blog post - emeritus maintainer rimas mocevicius

### DIFF
--- a/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
+++ b/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
@@ -7,3 +7,5 @@ authorlink: "https://twitter.com/technosophos"
 ---
 
 Rimas Mocevicius ([rimusz](https://github.com/rimusz)) has become the fourth Helm Emeritus Maintainer. Rimas is one of the three original founders of Helm. Author of [CoreOS Essentials](https://rimusz.net/coreos-essential-book/) (Packt, 2016) and creator of [Kube Solo](https://github.com/TheNewNormal/kube-solo-osx), Rimas is a long-time member of the Kubernetes ecosystem. Rimas was an active contributor on Helm Classic, and has been a leading voice in the community ever since.
+
+Check out Rimas' latest blog post on [Tillerless Helm](https://rimusz.net/tillerless-helm).

--- a/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
+++ b/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: "Helm Emeritus Maintainer Rimus Mocevicius"
-permalink: "/helm-emeritus-maintainer-rimus-mocevicius/"
+title: "Helm Emeritus Maintainer Rimas Mocevicius"
+permalink: "/helm-emeritus-maintainer-rimas-mocevicius/"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"
 ---
 
-Rimus Mocevicius ([rimusz](https://github.com/rimusz)) has become the fourth Helm Emeritus Maintainer. Rimus is one of the three original founds of Helm. Author of [CoreOS Essentials](https://rimusz.net/coreos-essential-book/) (Packt, 2016) and creator of [Kube Solo](https://github.com/TheNewNormal/kube-solo-osx), Rimus is a long-time member of the Kubernetes ecosystem. Rimus was an active contributor on Helm Classic, and has been a leading voice in the community ever since.
+Rimas Mocevicius ([rimusz](https://github.com/rimusz)) has become the fourth Helm Emeritus Maintainer. Rimas is one of the three original founders of Helm. Author of [CoreOS Essentials](https://rimusz.net/coreos-essential-book/) (Packt, 2016) and creator of [Kube Solo](https://github.com/TheNewNormal/kube-solo-osx), Rimas is a long-time member of the Kubernetes ecosystem. Rimas was an active contributor on Helm Classic, and has been a leading voice in the community ever since.

--- a/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
+++ b/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "Helm Emeritus Maintainer Rimus Mocevicius"
+permalink: "/helm-emeritus-maintainer-rimus-mocevicius/"
+author: "@technosophos"
+authorlink: "https://twitter.com/technosophos"
+---
+
+Rimus Mocevicius ([rimusz](https://github.com/rimusz)) has become the fourth Helm Emeritus Maintainer. Rimus is one of the three original founds of Helm. Author of [CoreOS Essentials](https://rimusz.net/coreos-essential-book/) (Packt, 2016) and creator of [Kube Solo](https://github.com/TheNewNormal/kube-solo-osx), Rimus is a long-time member of the Kubernetes ecosystem. Rimus was an active contributor on Helm Classic, and has been a leading voice in the community ever since.


### PR DESCRIPTION
Adds a new blog post: 

> Rimus Mocevicius (rimusz) has become the fourth Helm Emeritus Maintainer. 