### PR TITLE
feat(go-imports): configure vanity go import path

### DIFF
--- a/helm.sh/rootfs/Dockerfile
+++ b/helm.sh/rootfs/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-ARG plugins=http.cors,http.ipfilter,http.minify
+ARG plugins=http.cors,http.ipfilter,http.minify,http.gopkg
 ARG BUILD_DATE
 
 RUN apk upgrade --no-cache --available \

--- a/helm.sh/rootfs/etc/caddy/Caddyfile
+++ b/helm.sh/rootfs/etc/caddy/Caddyfile
@@ -2,6 +2,8 @@
   root /svc
   tls off
   status 200 /healthz
+
+  gopkg /helm https://github.com/helm/helm
 }
 :2015/docs {
   redir / https://helm-classic.readthedocs.io/en/latest{uri}


### PR DESCRIPTION
Enable `go get helm.sh/helm/...` using http.gopkg caddy plugin.
Docs at https://caddyserver.com/docs/http.gopkg