### PR TITLE
[docs.helm.sh] #143 restore title tag in head

### DIFF
--- a/docs.helm.sh/themes/helmdocs/layouts/partials/header.html
+++ b/docs.helm.sh/themes/helmdocs/layouts/partials/header.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>{{replace .Title "_" " " | title }}</title>
+  <title>Helm Docs | {{ .Title }}</title>
 
   <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
   <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">

--- a/docs.helm.sh/themes/helmdocs/layouts/partials/topbar.html
+++ b/docs.helm.sh/themes/helmdocs/layouts/partials/topbar.html
@@ -1,6 +1,6 @@
 <nav class="top-bar">
   <div class="breadcrumb">
-    <a href="../">{{replace .Title "_" " " | title }}</a>
+    <a href="../">{{ .Title }}</a>
   </div>
   <ul class="inline right text-right">
     <li><a href="https://helm.sh" target="_blank" title="Find out more about Helm."><i class="fa fa-home"></i> Helm.sh</a></li>


### PR DESCRIPTION
Updates the `title` tag in the hugo theme `head`, to properly output the site / section [title](https://gohugo.io/functions/title/#readout).

Fixes #143.