### PR TITLE
Blog usability & clarifications

### DIFF
--- a/helm.sh/README.md
+++ b/helm.sh/README.md
@@ -41,13 +41,14 @@ This is a quick start guide for creating new blog post entries. Blog posts are
 created via pull requests. The following steps are used to add them.
 
 1) Add a new file to the `_posts` directory whose name is the published date and the title. The files must be markdown formatted. See the existing titles for examples of the format
-2) Add the header meta-data to the file. It should be in the format (note the permalink structure):
+2) Add the header meta-data to the file using this format (note the permalink structure). Recommended but optional fields are `authorname` which should be name(s) and `author` which should be handle(s); these are displayed verbatim. `authorlink` is the link used by both `authorname` and `author`.
 ```yaml
 ---
 layout: post
 title: "A Fancy Title"
 permalink: "/blog/2018/fancy-title/"
-author: "Captain Awesome"
+authorname: "Captain Awesome"
+author: "@captainawesome"
 authorlink: "https://example.com"
 ---
 ```

--- a/helm.sh/_layouts/post.html
+++ b/helm.sh/_layouts/post.html
@@ -30,7 +30,7 @@
 
                       {{ content }}
 
-                      <p class="author"><a href="{{ page.authorlink }}" target="_blank">{{ page.authorname }}<br> <small>- {{ page.author }}</a></small></p>
+                      <p class="author"><a href="{{ page.authorlink }}" target="_blank">{{ page.authorname }}<br> <small>{{ page.author }}</a></small></p>
                     </article>
                   </section>
 

--- a/helm.sh/_posts/2018-06-01-cncf.md
+++ b/helm.sh/_posts/2018-06-01-cncf.md
@@ -2,15 +2,16 @@
 layout: post
 title: "Helm Enters the CNCF"
 permalink: "/helm-enters-the-cncf/"
+authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"
 ---
 
-Today we are happy to announce that Helm has become an official top-level [CNCF](https://www.cncf.io/) project, joining the ranks of Prometheus, Linkerd, OpenTracing, and others. Helm will enter the CNCF as an incubating project as we continue to work on the next-generation Helm 3 cloud-native package manager.
+Today we are happy to announce that Helm has become an official top-level [CNCF](https://www.cncf.io/) project, joining the ranks of Prometheus, Linkerd, OpenTracing, and others. Helm will enter the CNCF as an incubating project as we continue to work on the next-generation Helm 3 cloud-native package manager.  <!--more-->
 
 We are grateful to the Helm community, which has diligently contributed to the core Helm project, to the official charts repository, Monocular, to Chart Museum, and to other Helm-related projects. As a CNCF project, we look forward to expanding the Helm ecosystem. Over the coming months, we will be re-organizing as we ease our way out of the Kubernetes org and into CNCF.
 
-Helm began as an internal hackathon project at Deis, and we made our first public release at the original KubeCon. Now, only a few short years later, the Helm ecosystem has seen 3,500 contributors spanning 566 companies. We have made more than 50 releases, and see over 50,000 downloads per month. And last February, we had the [inagural Helm Summit](https://www.youtube.com/playlist?list=PLVt9l4b66d5EjjJ_VBe_5tEiJrAGLsDb-), where 179 developers, operators, and SREs gathered in Portland, Oregon to talk about the future of the project.
+Helm began as an internal hackathon project at Deis, and we made our first public release at the original KubeCon. Now, only a few short years later, the Helm ecosystem has seen 3,500 contributors spanning 566 companies. We have made more than 50 releases, and see over 50,000 downloads per month. And last February, we had the [inaugural Helm Summit](https://www.youtube.com/playlist?list=PLVt9l4b66d5EjjJ_VBe_5tEiJrAGLsDb-), where 179 developers, operators, and SREs gathered in Portland, Oregon to talk about the future of the project.
 
 Thank you for making the Helm community a welcoming place where people from all skill levels can participate in this emerging cloud-native landscape! We are excited to improve Helm as the package manager for the cloud-native landscape.
 

--- a/helm.sh/_posts/2018-07-23-bring-helm-home.md
+++ b/helm.sh/_posts/2018-07-23-bring-helm-home.md
@@ -2,11 +2,12 @@
 layout: post
 title: "Bringing Helm Home"
 permalink: "/blog/bringing-helm-home/"
+authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"
 ---
 
-Earlier this summer, we announced that [Helm joined the CNCF](https://www.cncf.io/blog/2018/06/01/cncf-to-host-helm/) as an official incubating project. Part of that transition involves moving the Helm project out of the Kubernetes GitHub org and into its org. We’re excited to announce that we’ve completed that process. As of last week, we have moved the Helm code repository to [https://github.com/helm/helm](https://github.com/helm/helm).
+Earlier this summer, we announced that [Helm joined the CNCF](https://www.cncf.io/blog/2018/06/01/cncf-to-host-helm/) as an official incubating project. Part of that transition involves moving the Helm project out of the Kubernetes GitHub org and into its org. We’re excited to announce that we’ve completed that process. As of last week, we have moved the Helm code repository to [https://github.com/helm/helm](https://github.com/helm/helm).  <!--more-->
 
 Fun fact: This is the same GitHub repository where the Helm project first started. When we started Helm in 2015, we created the Helm organization in GitHub. But thanks to the enthusiastic support of the Kubernetes community, we migrated the entire codebase into the Kubernetes org in 2016. As a separate CNCF project with its own vibrant and growing ecosystem, it makes sense to once again have Helm back home in its own GitHub org.
 

--- a/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
+++ b/helm.sh/_posts/2018-07-24-helm-emeritus-rimus.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Helm Emeritus Maintainer Rimas Mocevicius"
 permalink: "/helm-emeritus-maintainer-rimas-mocevicius/"
+authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"
 ---

--- a/helm.sh/_posts/2018-08-27-helm-switch-dco.md
+++ b/helm.sh/_posts/2018-08-27-helm-switch-dco.md
@@ -2,12 +2,11 @@
 layout: post
 title: "Helm Moves To DCO"
 permalink: "/blog/helm-dco/"
-author: "Matt Farina"
+authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 ---
 
-When Helm was part of the Kubernetes project it, like the rest of Kubernetes, used the [CNCF Contributor License Agreement (CLA)](https://github.com/cncf/cla). This served Helm well for years. But, most of the CNCF projects use a [Developers Certificate of Origin (DCO)](https://developercertificate.org/) instead of a CLA. The exceptions are Kubernetes and gRPC. Upon Helm becoming a CNCF project itself we were asked if we wanted to move Helm to a DCO. After some careful consideration and a little research, the Helm maintainers voted to move to a DCO.
-
+When Helm was part of the Kubernetes project it, like the rest of Kubernetes, used the [CNCF Contributor License Agreement (CLA)](https://github.com/cncf/cla). This served Helm well for years. But, most of the CNCF projects use a [Developers Certificate of Origin (DCO)](https://developercertificate.org/) instead of a CLA. The exceptions are Kubernetes and gRPC. Upon Helm becoming a CNCF project itself we were asked if we wanted to move Helm to a DCO. After some careful consideration and a little research, the Helm maintainers voted to move to a DCO.  <!--more-->
 ## What Does This Solve? Why Switch?
 
 Making a change like this should have a good reason and we have one. It is often easier to get started contributing under a DCO than a CLA.

--- a/helm.sh/_posts/2018-09-07-new-gov-and-elections.md
+++ b/helm.sh/_posts/2018-09-07-new-gov-and-elections.md
@@ -2,11 +2,11 @@
 layout: post
 title: "New Governance And Elections"
 permalink: "/blog/new-gov-and-elections/"
-author: "Matt Farina"
+authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 ---
 
-Being a top level incubating CNCF project requires having a governance structure to ensure that there is a publicly documented process for making decisions regarding the project and the community. While Helm was under Kubernetes, we relied on Kubernetes governance. As part of the transition to CNCF, the Helm project is required to have its own governance structure. To handle this we set up a [provisional governance](https://github.com/helm/community/blob/aa0586011786dfbc3993e7edd959a841241c96e3/governance/provisional-governance.md) with a goal of creating a long term one. After a few months we are happy to announce that the new governance structure as been written and approved.
+Being a top level incubating CNCF project requires having a governance structure to ensure that there is a publicly documented process for making decisions regarding the project and the community. While Helm was under Kubernetes, we relied on Kubernetes governance. As part of the transition to CNCF, the Helm project is required to have its own governance structure. To handle this we set up a [provisional governance](https://github.com/helm/community/blob/aa0586011786dfbc3993e7edd959a841241c96e3/governance/provisional-governance.md) with a goal of creating a long term one. After a few months we are happy to announce that the new governance structure has been written and approved.  <!--more-->
 
 The gist of the new governance is that it organizes those responsible into a couple groups (org and project maintainers), spells out their responsibilities, and provides for decision making processes. You can read all the details in the [governance doc (here)](https://github.com/helm/community/blob/master/governance/governance.md).
 

--- a/helm.sh/_posts/2018-09-25-chart-testing-intro.md
+++ b/helm.sh/_posts/2018-09-25-chart-testing-intro.md
@@ -2,11 +2,11 @@
 layout: post
 title: "Using the Community Chart Testing Tools Yourself"
 permalink: "/blog/chart-testing-intro/"
-author: "Matt Farina"
+authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 ---
 
-The Helm community charts, [available as the stable and incubator repositories](https://github.com/helm/charts), have long had testing. That testing has grown and improved a significant amount in the past year; from Helm linting and testing if an application runs in a cluster to now include YAML linting, some validation on maintainers, `Chart.yaml` schema validation, tests on chart version increments, and more.
+The Helm community charts, [available as the stable and incubator repositories](https://github.com/helm/charts), have long had testing. That testing has grown and improved a significant amount in the past year; from Helm linting and testing if an application runs in a cluster to now include YAML linting, some validation on maintainers, `Chart.yaml` schema validation, tests on chart version increments, and more.  <!--more-->
 
 These testing tools are useful for more than the community charts. They could be used in development workflows, in other testing systems, and for private charts. To make the testing more accessible we (mostly [Reinhard Nägele](https://github.com/unguiculus/)) refactored the tools into a container image that can be run outside of the community charts testing infrastructure.
 

--- a/helm.sh/_posts/2018-10-04-helm-org-maintainers.md
+++ b/helm.sh/_posts/2018-10-04-helm-org-maintainers.md
@@ -2,11 +2,11 @@
 layout: post
 title: "Introducing the Helm Org Maintainers"
 permalink: "/blog/intro-helm-org-maintainers/"
-author: "Matt Farina & Matt Butcher"
+authorname: "Matt Farina & Matt Butcher"
 authorlink: "https://helm.sh"
 ---
 
-The first major action under the [new Helm governance](https://www.helm.sh/blog/new-gov-and-elections/index.html) was to elect a set of [Helm Org Maintainers](https://github.com/helm/community/blob/52161625acabf4187ae052f4e5fdd36daea91684/governance/governance.md#helm-org-maintainers). In the initial election we were looking to select 7 people to represent Helm core, charts, and other projects under the Helm umbrella. The election is now complete and I would like to introduce the first set of Org Maintainers.
+The first major action under the [new Helm governance](https://www.helm.sh/blog/new-gov-and-elections/index.html) was to elect a set of [Helm Org Maintainers](https://github.com/helm/community/blob/52161625acabf4187ae052f4e5fdd36daea91684/governance/governance.md#helm-org-maintainers). In the initial election we were looking to select 7 people to represent Helm core, charts, and other projects under the Helm umbrella. The election is now complete and I would like to introduce the first set of Org Maintainers.  <!--more-->
 
 In alphabetical order, by first name, they are:
 

--- a/helm.sh/blog/index.html
+++ b/helm.sh/blog/index.html
@@ -16,11 +16,9 @@ categories:
 
         {% if post.content contains '<!--more-->' %}
           {{post.content | split:'<!--more-->' | first}}
-          <a href="{{post.url}}" class="text-link">Read More <span class="ss-navigateright"></span></a>
+          <a href="{{post.url}}index.html" aria-label="Read More" class="text-link"><i class="fa fa-arrow-right custom"></i></a>
         {% else %}
           {{post.content}}
-
-          <p class="author"><a href="{{ post.authorlink }}" target="_blank">{{ post.authorname }}<br> <small>- {{ post.author }}</a></small></p>
         {% endif %}
       </article>
 
@@ -32,11 +30,11 @@ categories:
   <div class="row">
     <div class="small-12 large-10 large-offset-1 columns">
       {% if paginator.previous_page %}
-        <a href="{{paginator.previous_page_path}}" class="button secondary">Newer <i class="fa fa fa-long-arrow-left"></i></a>
+        <a href="{{paginator.previous_page_path}}index.html" aria-label="Newer" class="button secondary">Newer <i class="fa fa fa-long-arrow-left"></i></a>
       {% endif %}
 
       {% if paginator.next_page %}
-        <a href="{{paginator.next_page_path}}" class="button secondary">Older <i class="fa fa-long-arrow-right"></i></a>
+        <a href="{{paginator.next_page_path}}index.html" aria-label="Older" class="button secondary">Older <i class="fa fa-long-arrow-right"></i></a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
- Found that the helm blog was a bit difficult to read since we weren't using the "read more" function that was configured in the Jekyll installation, making some posts very very long on the main blog page. I added a "read more" break to most posts (except a very short one), designated with a small right arrow and some aria accessibility clarifications.

- Noted that `author` and `authorname` were used inconsistently; I normalized and documented them. I removed a hyphen which ends up trailing awkwardly if someone doesn't use `author`, and added some missing author names.

- Fixed the broken links to Older/Newer posts (which had to do with blobstore not automatically checking `index.html`) and also fixed a couple of typos.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>