### PR TITLE
[Blog] update org maintainers

### DIFF
--- a/helm.sh/_posts/2018-10-04-helm-org-maintainers.md
+++ b/helm.sh/_posts/2018-10-04-helm-org-maintainers.md
@@ -12,10 +12,12 @@ In alphabetical order, by first name, they are:
 
 * Adam Reese (adamreese)
 * Adnan Abdulhussein (prydonius)
+* Josh Dolitsky (jdolitsky)
 * Matt Butcher (technosophos)
 * Matt Farina (mattfarina)
 * Matt Fisher (bacongobbler)
 * Reinhard Nägele (unguiculus)
+* Scott Rigby (scottrigby)
 * Vic Iglesias (viglesiasce)
 
 Thanks to everyone who ran. Helm is off to a great start under the CNCF and this is another step in our journey.


### PR DESCRIPTION
Add Josh Dolitsky and Scott Rigby

Signed-off-by: Roc Chan <roc@imroc.io>