### PR TITLE
Remove negative margin to prevent footer overlap and double-scrolling

### DIFF
--- a/docs.helm.sh/themes/helmdocs/static/src/sass/docs-footer.scss
+++ b/docs.helm.sh/themes/helmdocs/static/src/sass/docs-footer.scss
@@ -1,6 +1,4 @@
 .main {
-  margin-bottom: -5em;
-
   &.footer-expanded {
     margin-bottom:  -11em;
   }


### PR DESCRIPTION
It's a small detail, but this CSS rule causes the footers to overlap, which results in an annoying double-scrolling in some of the longer pages.

<img width="527" alt="screen shot 2018-12-12 at 12 40 21 pm" src="https://user-images.githubusercontent.com/775380/49887754-209c2700-fe0b-11e8-9db9-77584838f30f.png">

<img width="599" alt="screen shot 2018-12-12 at 12 39 36 pm" src="https://user-images.githubusercontent.com/775380/49887772-2bef5280-fe0b-11e8-8c54-8a9eab0f3565.png">
