### PR TITLE
Broken URL Patching

### DIFF
--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -274,6 +274,8 @@ gulp.task('clone', function(cb) {
       .pipe(replace('using_helm/rbac', 'using_helm/#role-based-access-control'))
       .pipe(replace('(rbac', '(#role-based-access-control'))
       .pipe(replace('##best-practices-for-securing-helm-and-tiller', '#best-practices-for-securing-helm-and-tiller'))
+      .pipe(replace('](securing-your-helm-installation.md#role-based-access-control)', '](#rbac)'))
+
       .pipe(gulp.dest('source/docs/'))
   });
 

--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -224,7 +224,7 @@ gulp.task('clone', function(cb) {
   });
 
   // links
-  gulp.task('redirect-anchor', function() {
+  gulp.task('redirect-anchor-temp', function() {
     return gulp.src('source/docs/**/*.md')
       .pipe(foreach(function(stream, file){
         var anchorurl = (/(\)\])(.*)\.md/, "g")[1];
@@ -242,7 +242,7 @@ gulp.task('clone', function(cb) {
       .pipe(gulp.dest('source/docs/helm/'))
   });
 
-  gulp.task('redirect-anchor', function() {
+  gulp.task('redirect-anchor-replace', function() {
     return gulp.src('source/docs/**/*.md')
       // update quickstart and install links
       .pipe(replace(/\]\(.*install\.md/, '](../using_helm/#installing-helm'))
@@ -253,7 +253,7 @@ gulp.task('clone', function(cb) {
       // update charts urls
       .pipe(replace('chart_repository', 'developing_charts'))
       // update internal links from '*.md' to '#*'
-      .pipe(replace(/(\]\()(.*)(\.md\))/g, '](./#$2)'))
+      .pipe(replace(/(\]\()(?!https)(.*)(\.md\))/g, '](./#$2)'))
       // update the provenance urls
       .pipe(replace('#provenance', '#helm-provenance-and-integrity'))
       // update the image paths in 'developing_charts'
@@ -266,8 +266,8 @@ gulp.task('clone', function(cb) {
       // update tiller ssl link
       .pipe(replace('#tiller_ssl', '#using-ssl-between-helm-and-tiller'))
       // update rbac links
-      .pipe(replace('#rbac', '#role-based-access-control'))
-      .pipe(replace('/rbac', '/#role-based-access-control'))
+      .pipe(replace('using_helm/#rbac', 'using_helm/#role-based-access-control'))
+      .pipe(replace('using_helm/rbac', 'using_helm/#role-based-access-control'))
       .pipe(gulp.dest('source/docs/'))
   });
 
@@ -295,7 +295,7 @@ gulp.task('build', function(callback) {
               'template-move',
               'template-concat',
               'template-del',
-              'redirect-anchor',
+              'redirect-anchor-replace',
               callback);
 });
 

--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -244,16 +244,17 @@ gulp.task('clone', function(cb) {
 
   gulp.task('redirect-anchor-replace', function() {
     return gulp.src('source/docs/**/*.md')
+      // update internal links from '*.md' to '#*'
+        // omitting external links
+      .pipe(replace(/(\]\()(?!http)(.*)(\.md\))/g, '](./#$2)'))
       // update quickstart and install links
       .pipe(replace(/\]\(.*install\.md/, '](../using_helm/#installing-helm'))
       .pipe(replace('#Install-Helm', '#installing-helm'))
       .pipe(replace('#quickstart]', '#quickstart-guide]'))
-      .pipe(replace('#install]', '#installing-helm]'))
+      .pipe(replace('#install)', '#installing-helm)'))
       .pipe(replace('#using_helm', '#using-helm'))
       // update charts urls
       .pipe(replace('chart_repository', 'developing_charts'))
-      // update internal links from '*.md' to '#*'
-      .pipe(replace(/(\]\()(?!https)(.*)(\.md\))/g, '](./#$2)'))
       // update the provenance urls
       .pipe(replace('#provenance', '#helm-provenance-and-integrity'))
       // update the image paths in 'developing_charts'
@@ -265,10 +266,21 @@ gulp.task('clone', function(cb) {
       .pipe(replace('securing_installation', 'securing-your-helm-installation'))
       // update tiller ssl link
       .pipe(replace('#tiller_ssl', '#using-ssl-between-helm-and-tiller'))
+      .pipe(replace('(tiller_ssl', '(#using-ssl-between-helm-and-tiller'))
+      // related
+      .pipe(replace('(related.md#', '(../related/#'))
       // update rbac links
-      .pipe(replace('using_helm/#rbac', 'using_helm/#role-based-access-control'))
+      .pipe(replace('#rbac', '#role-based-access-control'))
       .pipe(replace('using_helm/rbac', 'using_helm/#role-based-access-control'))
+      .pipe(replace('(rbac', '(#role-based-access-control'))
+      .pipe(replace('##best-practices-for-securing-helm-and-tiller', '#best-practices-for-securing-helm-and-tiller'))
       .pipe(gulp.dest('source/docs/'))
+  });
+
+  gulp.task('redirect-underscores', function() {
+    return gulp.src('source/docs/helm/*.md')
+    .pipe(replace('_', '-'))
+    .pipe(gulp.dest('source/docs/helm/'))
   });
 
 
@@ -296,6 +308,7 @@ gulp.task('build', function(callback) {
               'template-concat',
               'template-del',
               'redirect-anchor-replace',
+              'redirect-underscores',
               callback);
 });
 

--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -267,6 +267,7 @@ gulp.task('clone', function(cb) {
       .pipe(replace('#tiller_ssl', '#using-ssl-between-helm-and-tiller'))
       // update rbac links
       .pipe(replace('#rbac', '#role-based-access-control'))
+      .pipe(replace('/rbac', '/#role-based-access-control'))
       .pipe(gulp.dest('source/docs/'))
   });
 

--- a/docs.helm.sh/gulpfile.js
+++ b/docs.helm.sh/gulpfile.js
@@ -111,7 +111,7 @@ gulp.task('clean', function () {
 
 // Clone Docs for Hugo
 gulp.task('clone', function(cb) {
-  git.clone('https://github.com/kubernetes/helm', {args: './source', quiet: false}, function(err) {
+  git.clone('https://github.com/helm/helm', {args: './source', quiet: false}, function(err) {
     // handle err
     cb(err);
   });
@@ -257,7 +257,7 @@ gulp.task('clone', function(cb) {
       // update the provenance urls
       .pipe(replace('#provenance', '#helm-provenance-and-integrity'))
       // update the image paths in 'developing_charts'
-      .pipe(replace('](images/', '](https://raw.githubusercontent.com/kubernetes/helm/master/docs/images/'))
+      .pipe(replace('](images/', '](https://raw.githubusercontent.com/helm/helm/master/docs/images/'))
       .pipe(replace('.png)', '.png)'))
       // update tips and tricks link
       .pipe(replace('charts_tips_and_tricks', 'chart-development-tips-and-tricks'))


### PR DESCRIPTION
## Broken Links

This PR cleans up a bunch of 404 link issues, updating the gulp task which adapts the markdown doc files to better suit the Hugo site generator. Closes the following issues:

Closes #64 #92 #131 #157 #161.

--

## See Also links

These links on the Helm Command docs ([example](https://docs.helm.sh/helm/#see-also)) haven't been working in Hugo due to differences between the source and how Hugo formats things. This PR adds a task to circumvent the issue, a regex that swaps the `_` for `-` in links on those docs.

Closes #60 and #133.