### PR TITLE
Typo fix - doc site name

### DIFF
--- a/docs.helm.sh/themes/helmdocs/layouts/index.html
+++ b/docs.helm.sh/themes/helmdocs/layouts/index.html
@@ -72,7 +72,7 @@
                       <a href="https://daemonza.github.io/2017/02/20/using-helm-to-deploy-to-kubernetes/" target="_blank">
                         <h3>Deploying to Kubernetes &nbsp; <small><i class="fa fa-external-link"></i></small></h3>
 
-                        <p>Helm can deploy apps to Kubernetes, with release and rollback versioning - <small>(via deamonza)</small></p>
+                        <p>Helm can deploy apps to Kubernetes, with release and rollback versioning - <small>(via daemonza)</small></p>
                       </a>
                     </div>
                   </div>


### PR DESCRIPTION
Typo fix for the name of the site we're pointing to - daemonza, not deamonza.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>