### PR TITLE
Fix "helms" showing in in the title and header of the docs

### DIFF
--- a/docs.helm.sh/config.toml
+++ b/docs.helm.sh/config.toml
@@ -6,17 +6,16 @@ theme = "helmdocs"
 contentDir = "source/docs"
 publishdir = "app"
 
-[params]
-    title = "Helm Docs"
-    author = "Ronan Flynn-Curran"
-    description = "Documentation for Helm - The Kubernetes Package Manager."
-
 canonifyURLs = "false"
 relativeURLs = "true"
 pluralizeListTitles = "false"
 plainIdAnchors = "true"
 defaultContentLanguage = "en"
 
+[params]
+  title = "Helm Docs"
+  author = "Ronan Flynn-Curran"
+  description = "Documentation for Helm - The Kubernetes Package Manager."
 
 [[menu.main]]
   name = "Using Helm"


### PR DESCRIPTION
The hugo configuration settings were _under_ the params section which in TOML means that they are part of params, so hugo was completely ignoring them all.

I have moved them up a bit in the file so that they are parsed as root level values in the file. Now the pluralizeListTitles setting (along with a few others) will be applied by Hugo properly.