### PR TITLE
Resolve hugo build error

### DIFF
--- a/docs.helm.sh/config.toml
+++ b/docs.helm.sh/config.toml
@@ -7,7 +7,6 @@ contentDir = "source/docs"
 publishdir = "app"
 
 canonifyURLs = "false"
-relativeURLs = "true"
 pluralizeListTitles = "false"
 plainIdAnchors = "true"
 defaultContentLanguage = "en"


### PR DESCRIPTION
This is a follow up to #176 - the `relativeURLs` option in the site config was throwing errors when hugo was building the site. Removing it will fix the builds. 