### PR TITLE
fix submenu links for new structure

### DIFF
--- a/themes/helm/layouts/partials/offcanvas.html
+++ b/themes/helm/layouts/partials/offcanvas.html
@@ -3,7 +3,7 @@
 
     <ul class="off-canvas-list current sidebar-main">
       <li>
-        <a class="sidebar-nav-item" href="{{ .Site.BaseURL | safeHTMLAttr }}">
+        <a class="sidebar-nav-item" href="{{ .Site.BaseURL | safeHTMLAttr }}docs">
           <span class="ripple">Docs Home <span></span></span>
         </a>
       </li>
@@ -16,7 +16,7 @@
         <ul class="current">
           {{ range .Children.ByWeight }}
           <li class="toctree-l2 {{if $.IsMenuCurrent "main" . }} active {{end}}">
-            <a href="../../{{ .Parent | safeHTMLAttr }}/#{{ .URL | safeHTMLAttr }}" title="Switch to {{ .Name }}">
+            <a href="../../docs/{{ .Parent | safeHTMLAttr }}/#{{ .URL | safeHTMLAttr }}" title="Switch to {{ .Name }}">
               {{ .Name }}
             </a>
           </li>


### PR DESCRIPTION
On desktop, the side navigation work with the new structure (from the site changes #162), but on mobile the menu is in the old format and the sub category links need updating.

This adds `docs` to the path of those links to fix the menu on mobile.

Signed-off-by: flynnduism <flynnduism@gmail.com>