### PR TITLE
[#181] update the url replace task for helm command docs (helm > helm)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -267,7 +267,7 @@ gulp.task('clone', function(cb) {
   gulp.task('redirect-subfolder', function() {
     return gulp.src('source/docs/helm/*.md')
       // update internal urls within the helm_commands
-      .pipe(replace('](helm', '](../../helm/#helm'))
+      .pipe(replace('](helm', '](../../docs/helm/#helm'))
       .pipe(replace('.md)', ')'))
       .pipe(gulp.dest('source/docs/helm/'))
   });


### PR DESCRIPTION
Updates the find and replace task that makes internal links work with the Hugo site structure.

Fixes #181.

Signed-off-by: flynnduism <flynnduism@gmail.com>