### PR TITLE
Fixing blog URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ created via pull requests. The following steps are used to add them.
 ---
 layout: post
 title: "A Fancy Title"
-permalink: "/blog/2018/fancy-title/"
+slug: "fancy-title"
 authorname: "Captain Awesome"
 authorlink: "https://example.com"
 date: "yyyy-mm-dd"

--- a/content/blog/2018-06-01-cncf.md
+++ b/content/blog/2018-06-01-cncf.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Helm Enters the CNCF"
-permalink: "/helm-enters-the-cncf/"
+slug: "helm-enters-the-cncf"
+aliases: "/blog/2018-06-01-cncf/"
 authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"

--- a/content/blog/2018-07-23-bring-helm-home.md
+++ b/content/blog/2018-07-23-bring-helm-home.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Bringing Helm Home"
-permalink: "/blog/bringing-helm-home/"
+slug: "bringing-helm-home"
+aliases: "/blog/2018-07-23-bring-helm-home/"
 authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"

--- a/content/blog/2018-07-24-helm-emeritus-rimus.md
+++ b/content/blog/2018-07-24-helm-emeritus-rimus.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Helm Emeritus Maintainer Rimas Mocevicius"
-permalink: "/helm-emeritus-maintainer-rimas-mocevicius/"
+slug: "helm-emeritus-maintainer-rimas-mocevicius"
+aliases: "/blog/2018-07-24-helm-emeritus-rimus/"
 authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"

--- a/content/blog/2018-08-27-helm-switch-dco.md
+++ b/content/blog/2018-08-27-helm-switch-dco.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Helm Moves To DCO"
-permalink: "/blog/helm-dco/"
+slug: "helm-dco"
+aliases: "/blog/2018-08-27-helm-switch-dco/"
 authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 date: "2018-08-27"

--- a/content/blog/2018-09-07-new-gov-and-elections.md
+++ b/content/blog/2018-09-07-new-gov-and-elections.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "New Governance And Elections"
-permalink: "/blog/new-gov-and-elections/"
+slug: "new-gov-and-elections"
+aliases: "/blog/2018-09-07-new-gov-and-elections/"
 authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 date: "2018-09-07"

--- a/content/blog/2018-09-25-chart-testing-intro.md
+++ b/content/blog/2018-09-25-chart-testing-intro.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Using the Community Chart Testing Tools Yourself"
-permalink: "/blog/chart-testing-intro/"
+slug: "chart-testing-intro"
+aliases: "/blog/2018-09-25-chart-testing-intro/"
 authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 date: "2018-09-25"

--- a/content/blog/2018-10-04-helm-org-maintainers.md
+++ b/content/blog/2018-10-04-helm-org-maintainers.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Introducing the Helm Org Maintainers"
-permalink: "/blog/intro-helm-org-maintainers/"
+slug: "intro-helm-org-maintainers"
+aliases: "/blog/2018-10-04-helm-org-maintainers/"
 authorname: "Matt Farina & Matt Butcher"
 authorlink: "https://helm.sh"
 date: "2018-10-04"

--- a/content/blog/2018-12-11-helm-hub.md
+++ b/content/blog/2018-12-11-helm-hub.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Introducing the Helm Hub"
-permalink: "/blog/intro-helm-hub/"
+slug: "intro-helm-hub"
+aliases: "/blog/2018-12-11-helm-hub/"
 authorname: "Matt Farina"
 authorlink: "https://mattfarina.com"
 date: "2018-12-11"

--- a/content/blog/2019-01-14-chartmuseum-security-notice.md
+++ b/content/blog/2019-01-14-chartmuseum-security-notice.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "ChartMuseum Vulnerability: Authorization Bypass [CVE-2019-1000009]"
-permalink: "/blog/chartmuseum-security-notice-2019/"
+slug: "chartmuseum-security-notice-2019"
+aliases: "/blog/2019-01-14-chartmuseum-security-notice/"
 authorname: "Matt Farina & Josh Dolitsky"
 authorlink: "https://helm.sh"
 date: "2019-01-14"

--- a/content/blog/2019-01-14-helm-security-notice.md
+++ b/content/blog/2019-01-14-helm-security-notice.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Helm Vulnerability: Client Unpacking Chart that Contains Malicious Content [CVE-2019-1000008]"
-permalink: "/blog/helm-security-notice-2019/"
+slug: "helm-security-notice-2019"
+aliases: "/blog/2019-01-14-helm-security-notice/"
 authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"


### PR DESCRIPTION
I noticed that a subtle difference between Jekyll and Hugo is showing up in how we're handling the URLs for the Helm blog. This means that all previous-to-the-Hugo-migration links to specific blog posts are currently broken.

This problem can be observed if you hover over the blog post URLs the wayback machine shows used to exist: https://web.archive.org/web/20190203185202/https://helm.sh//blog/

It also shows up on the live site right now because the "new helm governance" link is broken on https://helm.sh/blog/2018-10-04-helm-org-maintainers/

Background on why this happened: Jekyll has a concept of permalink in the frontmatter for individual blog posts (https://jekyllrb.com/docs/permalinks/). Hugo handles URL parsing in different ways, leading to that permalink line in each blog post being ignored (https://gohugo.io/content-management/urls/).

This PR resolves the issue in the following ways:

1) Restore the desired URLs for the existing blog posts. This will fix anywhere that is linking to the previous URLs, in that the links will work again.

2) Also keep the less-desired URLs working. This will ensure that we don't lose out on traffic from anywhere that linked to the blog recently, whether it be a search engine or intentional link by a human.

3) Corrects the example in the README.

For future blog posts, we can just go ahead and set a `slug` at publication time. We will not need to use `aliases` going forward because the filename doesn't default to being part of the URL if a `slug` is set.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>