### PR TITLE
Fixing broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ date: "yyyy-mm-dd"
 ---
 ```
 3) Add the content below the `---` as Markdown. The title does not need to be included in this section
-4) Any images should be placed in the `/assets/images/blog/` directory. Images should be losslessly compressed to reduce their size. Tools, such as [ImageOptim](https://imageoptim.com/), can be used.
+4) Any images should be placed in the `/src/img/blog/` directory. Images should be losslessly compressed to reduce their size. Tools, such as [ImageOptim](https://imageoptim.com/), can be used.
 5) To summarize content on the blog index page, insert a `<!--more-->` break in your markdown. This will truncate the content with a _Read More_ link. 
 
 ---

--- a/content/blog/2018-12-11-helm-hub.md
+++ b/content/blog/2018-12-11-helm-hub.md
@@ -12,7 +12,7 @@ Helm was designed with many distributed repositories in mind. Like Homebrew Taps
 
 With this in mind, we are delighted to announce the launch of the [Helm Hub](https://hub.helm.sh). This hub provides a means for you to find charts hosted in many distributed repositories hosted by numerous people and organizations. <!--more-->
 
-![Helm Hub](https://helm.sh/assets/images/blog/helm-hub.png)
+![Helm Hub](https://helm.sh/src/img/blog/helm-hub.png)
 
 Helm repositories can be hosted in many ways including as GitHub or Gitlab pages, in object storage, using [Chartmuseum](https://github.com/helm/chartmuseum), and via a service provider.
 


### PR DESCRIPTION
Blog images appear to be published in a different place than previously. This reflects that reality; however, it's possible that wasn't intentional. In that case, it should be revisited, but meanwhile this could be a temporary fix that restores the missing image on https://helm.sh/blog/intro-helm-hub/.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>