### PR TITLE
feat(go-imports): configure vanity go import path

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,9 @@ defaultContentLanguage = "en"
     author = "Ronan Flynn-Curran"
     description = "Helm - The Kubernetes Package Manager."
 
+[Permalinks]
+  code = "/:filename/"
+
 [[menu.main]]
   name = "Using Helm"
   url = "/docs/using_helm/"

--- a/content/code/helm.md
+++ b/content/code/helm.md
@@ -1,0 +1,4 @@
+---
+title: "helm"
+vanity: "https://github.com/helm/helm"
+---

--- a/themes/helm/layouts/code/single.html
+++ b/themes/helm/layouts/code/single.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta name="go-import" content="https://helm.sh{{substr .RelPermalink 0 -1}} git {{.Params.vanity}}">
+  <meta name="go-source" content="https://helm.sh{{substr .RelPermalink 0 -1}} {{.Params.vanity}} {{.Params.vanity}}/tree/master{/dir} {{.Params.vanity}}/blob/master{/dir}/{file}#L{line}">
+
+  <meta http-equiv="refresh" content="0; url={{.Params.vanity}}">
+</head>
+
+<body>
+  Nothing to see here; <a href="{{ .Params.vanity }}">move along</a>.
+</body>
+
+</html>


### PR DESCRIPTION
Enable `go get helm.sh/helm/...`