### PR TITLE
Fixing broken links on blog

### DIFF
--- a/content/blog/2018-06-01-cncf.md
+++ b/content/blog/2018-06-01-cncf.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Helm Enters the CNCF"
 slug: "helm-enters-the-cncf"
-aliases: "/blog/2018-06-01-cncf/"
+aliases: ["/blog/2018-06-01-cncf/", "/helm-enters-the-cncf/"]
 authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"

--- a/content/blog/2018-07-24-helm-emeritus-rimus.md
+++ b/content/blog/2018-07-24-helm-emeritus-rimus.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Helm Emeritus Maintainer Rimas Mocevicius"
 slug: "helm-emeritus-maintainer-rimas-mocevicius"
-aliases: "/blog/2018-07-24-helm-emeritus-rimus/"
+aliases: ["/blog/2018-07-24-helm-emeritus-rimus/", "/helm-emeritus-maintainer-rimas-mocevicius/"]
 authorname: "Matt Butcher"
 author: "@technosophos"
 authorlink: "https://twitter.com/technosophos"


### PR DESCRIPTION
I noticed that https://twitter.com/HelmPack/status/1002577607135617024 has a link to https://helm.sh/helm-enters-the-cncf/index.html which 404s because we aren't rewriting URLs like that. 

I think this issue is being caused by that difference in Jekyll permalinks vs Hugo slugs (like in https://github.com/helm/helm-www/pull/183) - when I did those rewrites, I handled them all with the `/blog/` in the URL. But we need to cover the (as far as I can tell) two cases without that.
