### PR TITLE
fix homepage positioning for mobile layouts

### DIFF
--- a/themes/helm/static/src/sass/docs-home.scss
+++ b/themes/helm/static/src/sass/docs-home.scss
@@ -120,6 +120,7 @@
       min-height: 125px;
       color: $grey4;
       margin-bottom: 1.25rem;
+      padding-top: 0 !important;
 
       h3 {
         padding: 0.75rem 0 0.5rem;

--- a/themes/helm/static/src/sass/docs-responsive.scss
+++ b/themes/helm/static/src/sass/docs-responsive.scss
@@ -80,6 +80,7 @@
 
         h1 {
           font-size: 1.825rem;
+          margin-top: 0;
         }
 
         h2 {


### PR DESCRIPTION
Currently there's a glitch on helm.sh when you view the site on a mobile device. The vast open seas are a little _too_ vast.

<img width="421" alt="Screen Shot 2019-05-08 at 3 10 05 PM" src="https://user-images.githubusercontent.com/686194/57411806-823aa480-71a3-11e9-8c38-d969a9c14096.png">


This PR corrects the positioning of elements:

<img width="418" alt="Screen Shot 2019-05-08 at 3 09 46 PM" src="https://user-images.githubusercontent.com/686194/57411797-7d75f080-71a3-11e9-97f2-cca9f55beb2e.png">

---

Thanks @karenhchu for flagging the bug.