### PR TITLE
[v3] add a sticky banner for helm 2 and helm info

### DIFF
--- a/themes/helm/layouts/blog/list.html
+++ b/themes/helm/layouts/blog/list.html
@@ -13,6 +13,8 @@
     </h1>
     
     <nav class="top-bar">
+      {{ partial "banner.html" . }}
+        
       <ul class="inline right text-right">
         {{ partial "nav.html" . }}
       </ul>

--- a/themes/helm/layouts/blog/single.html
+++ b/themes/helm/layouts/blog/single.html
@@ -13,6 +13,8 @@
     </h1>
     
     <nav class="top-bar">
+      {{ partial "banner.html" . }}
+        
       <ul class="inline right text-right">
         {{ partial "nav.html" . }}
       </ul>

--- a/themes/helm/layouts/docs/list.html
+++ b/themes/helm/layouts/docs/list.html
@@ -6,6 +6,8 @@
     <div class="main home" id="scrollpane">
 
       <nav class="top-bar">
+        {{ partial "banner.html" . }}
+          
         <ul class="inline right text-right">
           {{ partial "nav.html" . }}
         </ul>

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -28,6 +28,8 @@
     <div class="inner-wrap">
 
       <nav class="home-nav">
+        {{ partial "banner.html" . }}
+          
         <h1>
           <a href="{{ .Site.BaseURL }}" title="Helm.sh">
             {{ partial "logo.html" . }}

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -1,0 +1,16 @@
+<div id="banner">
+  <div class="cc-container">
+
+    <!-- viewing helm 2 version of site (desktop) -->
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm 3 is coming soon (alpha-1 is <a href="https://v3.helm.sh"><strong>here</strong>). &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+
+    <!-- viewing helm 2 version of site (mobile) -->
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3 is coming soon - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+
+    <!-- viewing helm 3 version of site (desktop) -->
+    <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Alpha 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->
+
+    <!-- viewing helm 3 version of site (mobile) -->
+    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing info for Helm 3 <strong>alpha-1</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p> -->
+  </div>
+</div>

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,10 +2,10 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm 3 is coming soon (alpha-1 is <a href="https://v3.helm.sh"><strong>here</strong>). &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-alpha.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3 is coming soon - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-alpha.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
 
     <!-- viewing helm 3 version of site (desktop) -->
     <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Alpha 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->

--- a/themes/helm/layouts/partials/topbar.html
+++ b/themes/helm/layouts/partials/topbar.html
@@ -1,5 +1,6 @@
-{{ partial "cookies.html" . }}
 <nav class="top-bar">
+  {{ partial "banner.html" . }}
+  
   <ul class="inline right text-right">
     {{ partial "nav.html" . }}
   </ul>

--- a/themes/helm/static/src/sass/docs-home.scss
+++ b/themes/helm/static/src/sass/docs-home.scss
@@ -100,6 +100,23 @@
     }
   }
 
+  // offset for banner
+  .home nav.home-nav  {
+    // top: 30px;
+
+    #banner {
+      margin-top: 0 !important;
+    }
+
+    h1 {
+      top: 38px;
+    }
+
+    ul {
+      top: 4rem;
+    }
+  }
+
   .home-featured {
     background-color: $blue1;
     padding-top: 20px;

--- a/themes/helm/static/src/sass/docs-responsive.scss
+++ b/themes/helm/static/src/sass/docs-responsive.scss
@@ -16,6 +16,28 @@
 
   .top-bar {
     left: 0;
+    overflow: visible;
+  }
+
+  .left-off-canvas-toggle {
+    top: 30px;
+  }
+
+   .blog-layout .main.blog nav.top-bar #banner,
+  .sidebar+.main nav.top-bar #banner {
+    margin-left: 0;
+    min-width: 100%;
+  }
+
+   .blog-layout h1.blog-logo {
+    a:first-of-type {
+      left: 25px;
+    }
+
+     a:last-of-type {
+      right: auto;
+      left: 125px;
+    }
   }
 
   .st-default-autocomplete {
@@ -40,7 +62,7 @@
         max-width: 44px;
         left: 50%;
         margin-left: -22px;
-        top: 0.5rem;
+        top: 2.5rem;
 
         svg {
           min-height: 44px;
@@ -50,7 +72,7 @@
       ul {
         width: 96%;
         padding: 0;
-        top: 6rem;
+        top: 8.5rem;
         text-align: center;
         
         li {

--- a/themes/helm/static/src/sass/docs-sidebar.scss
+++ b/themes/helm/static/src/sass/docs-sidebar.scss
@@ -4,7 +4,7 @@
   box-sizing: border-box;
   min-height: 100%;
   left: 0;
-  top: 0;
+  top: 30px;
   bottom: 0;
   background: desaturate(lighten($blue1, 35%), 20%);
   z-index: 700;

--- a/themes/helm/static/src/sass/docs-topbar.scss
+++ b/themes/helm/static/src/sass/docs-topbar.scss
@@ -8,13 +8,13 @@
   position: fixed;
   left: 300px;
   right: 0;
-  top: 0;
+  top: 30px;
   z-index: 1000;
 
   ul {
     min-width: 33.333%;
     margin-right: 0;
-    margin-top: 0.75em;
+    margin-top: -0.5em;
     padding-right: 3.5%;
 
     li {
@@ -89,5 +89,39 @@
   img {
     padding: 1.425em 0.925em;
     color: $grey4;
+  }
+}
+
+// offset banner center when there is a left nav space
+.blog-layout .main.blog,
+.sidebar + .main {
+  nav.top-bar #banner {
+    margin-left: -300px;
+  }
+
+  h1.blog-logo {
+    top: 30px;
+  }
+}
+
+
+#banner {
+  background: $blue4;
+  color: white;
+  position: static;
+  width: 100vw;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin-top: -30px;
+  text-align: center;
+  z-index: 1150;
+
+  p {
+    color: white;
+  }
+
+  a {
+    color: white;
   }
 }

--- a/themes/helm/static/src/sass/helm-home.scss
+++ b/themes/helm/static/src/sass/helm-home.scss
@@ -96,6 +96,23 @@ nav.home-nav {
   }
 }
 
+// offset for banner
+.home nav.home-nav  {
+  // top: 30px;
+
+  #banner {
+    margin-top: 0 !important;
+  }
+
+  h1 {
+    top: 38px;
+  }
+
+  ul {
+    top: 4rem;
+  }
+}
+
 #helm.home {
   background: $blue;
 


### PR DESCRIPTION
Rolled back #220 until we're read to flip the switch. This is a duplicate of that PR.

This adds a sticky banner to the site which states:

* highlights the coming of Helm 3
* states what version of Helm you are currently viewing info on
* links to the other version

---

"You are viewing Helm 2 (latest stable).   Helm 3.0.0-alpha.1 is here.   Visit the v3 docs or read the blog for details."

---

V3 links go to [v3.helm.sh](https://v3.helm.sh/), which has a different message and in turn links back to V2 (aka http://helm.sh)