### PR TITLE
fix(go-import): fix go path on meta tags

### DIFF
--- a/themes/helm/layouts/code/single.html
+++ b/themes/helm/layouts/code/single.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-  <meta name="go-import" content="https://helm.sh/{{.Params.Name}} git {{.Params.RepoURL}}">
-  <meta name="go-source" content="https://helm.sh/{{.Params.Name}} git {{.Params.RepoURL}} {{.Params.RepoURL}}/tree/{{.Params.Branch}}{/dir} {{.Params.RepoURL}}/blob/{{.Params.Branch}}{/dir}/{file}#L{line}">
+  <meta name="go-import" content="helm.sh/{{.Params.Name}} git {{.Params.RepoURL}}">
+  <meta name="go-source" content="helm.sh/{{.Params.Name}} git {{.Params.RepoURL}} {{.Params.RepoURL}}/tree/{{.Params.Branch}}{/dir} {{.Params.RepoURL}}/blob/{{.Params.Branch}}{/dir}/{file}#L{line}">
   <meta http-equiv="refresh" content="0; url={{.Params.RepoURL}}">
 </head>
 


### PR DESCRIPTION
Hello, as discussed on #helm-dev slack, this pull request fixes meta tags for go tools.

More info on go-import meta tag: https://golang.org/cmd/go/#hdr-Remote_import_paths
And go-source meta tag: https://github.com/golang/gddo/wiki/Source-Code-Links