### PR TITLE
add an OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+maintainers:
+  - flynnduism
+  - mattfarina
+  - bridgetkromhout
+  - bacongobbler
+  - vdice
+  - karenhchu 


### PR DESCRIPTION
This adds a list of repo maintainers, based off of the existing [web team](https://github.com/orgs/helm/teams/web/members) and core [Helm Org](https://github.com/orgs/helm/teams/helm-org-maintainers/members) personnel.

Addresses #227