### PR TITLE
#233 (docs): Improve layout for code line length

### DIFF
--- a/themes/helm/static/src/sass/docs-content.scss
+++ b/themes/helm/static/src/sass/docs-content.scss
@@ -73,9 +73,11 @@
     background-color: #e4f3f9;
     color: black;
     border: none;
-    padding: 0.75em 1em;
+    padding: 0.75em 2rem 0.75rem 1rem;
     margin: 0.25em 0 2.5em;
     font-size: 1rem;
+    min-width: 65vw;
+    overflow: scroll;
 
     code {
       padding: 0;
@@ -84,9 +86,6 @@
     }
 
     &:hover {
-      min-width: 65vw;
-      overflow: scroll;
-      padding-right: 2rem;
       background-color: lighten(#e4f3f9, 2.5%);
 
       code {

--- a/themes/helm/static/src/sass/docs-content.scss
+++ b/themes/helm/static/src/sass/docs-content.scss
@@ -80,7 +80,17 @@
     code {
       padding: 0;
       background-color: #e4f3f9;
-      font-size: 1rem;
+      font-size: 1rem; 
+    }
+
+    &:hover {
+      min-width: 67vw;
+      overflow: scroll;
+      background-color: lighten(#e4f3f9, 2.5%);
+
+      code {
+        background-color: lighten(#e4f3f9, 2.5%);
+      }
     }
   }
 

--- a/themes/helm/static/src/sass/docs-content.scss
+++ b/themes/helm/static/src/sass/docs-content.scss
@@ -84,8 +84,9 @@
     }
 
     &:hover {
-      min-width: 67vw;
+      min-width: 65vw;
       overflow: scroll;
+      padding-right: 2rem;
       background-color: lighten(#e4f3f9, 2.5%);
 
       code {


### PR DESCRIPTION
Fix for #233. 

Having horizontal scrolling within code snippets is standard web practice, but I do see how lots of sideways scrolling is annoying when the code runs far longer than the reading pane.

The website layout limits line length intentionally, which imposes whitespace on large screens. This approach is to [aid readability of page copy](https://uxplanet.org/10-tips-on-typography-in-web-design-13a378f4aa0d#f63f), but does not suit the code sections. 

**Before:**

![Screen Shot 2019-07-17 at 2 40 53 PM](https://user-images.githubusercontent.com/686194/61413646-e8792d00-a8a0-11e9-977e-24e2283612c1.png)


The proposed solution here widens the code boxes to the right towards the edge of the viewport, to give long lines of code more space. This will maintain a pleasant line-length for the normal text, but expand for the code.

**After:**

![Screen Shot 2019-07-17 at 2 31 42 PM](https://user-images.githubusercontent.com/686194/61413140-a4395d00-a89f-11e9-97ac-aa93c7ecb1b9.png)
