### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+
+[*.{html,js,json,md,sass,scss,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I find [EditorConfig](https://editorconfig.org/) files to be quite useful for enforcing stylistic standards within docs/website projects. This is one that I've used in a wide variety of projects and, I think, embodies best practices.