### PR TITLE
[#139] change overflow value to resolve firefox keyboard scroll issue

### DIFF
--- a/themes/helm/static/src/sass/docs-layout.scss
+++ b/themes/helm/static/src/sass/docs-layout.scss
@@ -27,7 +27,7 @@ body {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   min-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   padding-left: 300px;
   width: 100%;


### PR DESCRIPTION
This PR addresses the weird Firefox scrolling issue in #139.

The suggestion by @wisniewskit is applied here and solves the strange frame focus issue I was stumped by. 

---

Closes #139.