### PR TITLE
[#240] make search tool clickable again

### DIFF
--- a/themes/helm/static/src/sass/docs-sidebar.scss
+++ b/themes/helm/static/src/sass/docs-sidebar.scss
@@ -215,8 +215,9 @@
   }
   .search-container{
     z-index: 1020;
-    position: "relative";
+    position: relative;
     padding-top: 1rem;
+    
     & > .algolia-autocomplete{
       display: block !important;
       margin: auto;


### PR DESCRIPTION
Part of the fix for #240, this corrects a layout bug that rendered the search box on the docs impossible to click into.

---

This fixes search for the v2 docs - I will follow up with a separate fix for the v3 docs.