### PR TITLE
[230] ensure gulp does not wipe away content/docs/

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,9 +94,7 @@ gulp.task('images', function () {
 gulp.task('clean', function () {
   return del([
     destination + '/src/**/*',
-    'source/',
-    'content/docs/*',
-    '!content/docs/README.md'
+    'source/'
   ], {force: true});
 });
 


### PR DESCRIPTION
I noticed running gulp will erase the content/docs/ directory during the `clean` task. This is a legacy of the previous cloning of the docs from helm/helm, and should be removed now as part of #230.

This is a short term fix until #237 (Hugo Pipes) is implemented and Gulp is removed.