### PR TITLE
[#230] fix the grid layout for v3 docs

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,9 +1,9 @@
 {{ partial "header.html" . }}
 
-<div class="container container-full docs-home">
+<div class="container container-full">
   {{ partial "sidebar.html" . }}
 
-  <div class="main home" id="scrollpane">
+  <div class="main home page" id="scrollpane">
 
     <nav class="top-bar">
 
@@ -21,7 +21,6 @@
           <div class="container">
             {{ .Content }}
           </div>
-          <div id="boat"></div>
         </section>
 
         <div class="row home-featured">

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 
-<div class="container container-full blog-layout">
+<div class="container container-full">
     {{ partial "sidebar.html" . }}
 
   <div class="main docs docs-single page" id="scrollpane">
@@ -24,14 +24,9 @@
     <div class="row">
       <div class="small-1 columns">&nbsp;</div>
       <div class="small-10 columns content-wrap">
-        <article id="content">
-          <h1>{{ .Title }}</h1>
-          
-          {{ .Content }}
-
-          <p class="author"><a href="{{ .Params.authorlink }}" target="_blank">{{ .Params.authorname }}<br> <small>{{ .Params.author }}</a></small></p>
-
-       </article>
+        <h1>{{ .Title }}</h1>
+        
+        {{ .Content }}
       </div>
       <div class="small-1 columns">&nbsp;</div>
     </div>


### PR DESCRIPTION
This PR is the first in a series of layout fixes to restore the Hugo templates for the docs. During the build pipeline changes in #230, there were also html and css changes to the theme files that bumped a few things around.

Live site:

![Screen Shot 2019-07-24 at 12 29 50 PM](https://user-images.githubusercontent.com/686194/61822690-0863a000-ae0f-11e9-9d4f-98397974f877.png)

After this patch:

![Screen Shot 2019-07-24 at 12 29 59 PM](https://user-images.githubusercontent.com/686194/61822698-0c8fbd80-ae0f-11e9-9a02-4d67eaac3592.png)

---

## To Do:

I will follow up with a separate PR to tidy up the _category_ landing pages (like [this one](https://v3.helm.sh/docs/topics/chart_template_guide/)).

---

Signed-off-by: flynnduism <flynnduism@gmail.com>