### PR TITLE
Updating zoom link for weekly call

### DIFF
--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -163,7 +163,7 @@
 
                     <section>
                       <h4>Developer Standups</h4>
-                      <p>Each week, the Helm teams meet on <a href="https://zoom.us/j/4526666954">Zoom</a>.</p>
+                      <p>Each week, the Helm teams meet on <a href="https://zoom.us/j/696660622">Zoom</a>.</p>
                       <div class="right">
                         <a href="https://github.com/helm/community/blob/master/communication.md">
                           <i class="fa fa-calendar"></i>


### PR DESCRIPTION
Looks like the link for the weekly developer call on the website was an old link. i suspect people were finding the right link from https://github.com/helm/helm/blob/master/README.md#community-discussion-contribution-and-support but if they looked on https://helm.sh it was wrong.