### PR TITLE
Change banner to mention beta.1

### DIFF
--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,10 +2,10 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-alpha.2 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-beta.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-alpha.2 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-beta.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
 
     <!-- viewing helm 3 version of site (desktop) -->
     <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Alpha 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,10 +2,10 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-alpha.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-alpha.2 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-alpha.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-alpha.2 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
 
     <!-- viewing helm 3 version of site (desktop) -->
     <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Alpha 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->


### PR DESCRIPTION
Currently, the banner atop the website mentions alpha 1, but we're on alpha 2 now.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>