### PR TITLE
fix sticky banner for v2 <-> v3 site links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ defaultContentLanguage = "en"
 
 [[params.versions]]
 version = "v3.0.0"
-patch = "beta.1"
+patch = "beta.2"
 url = "https://v3.helm.sh/docs"
 primary = true
 

--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,21 @@ defaultContentLanguage = "en"
     "app"
   ]
 
+[[params.versions]]
+version = "v3.0.0"
+patch = "beta.1"
+url = "https://v3.helm.sh/docs"
+primary = true
+
+[[params.versions]]
+version = "v2.14.3"
+patch = "stable"
+url = "https://helm.sh/docs"
+
+[[params.versions]]
+version = "v2.14.0"
+url = "https://v2-14-0.helm.sh/docs"
+
 [Permalinks]
   code = "/:filename/"
 

--- a/themes/helm/assets/sass/docs-home.scss
+++ b/themes/helm/assets/sass/docs-home.scss
@@ -107,6 +107,10 @@
       margin-top: 0 !important;
     }
 
+    h1 {
+      margin-top: 38px;
+    }
+
     ul {
       top: 4rem;
     }

--- a/themes/helm/assets/sass/docs-responsive.scss
+++ b/themes/helm/assets/sass/docs-responsive.scss
@@ -19,6 +19,10 @@
     overflow: visible;
   }
 
+  .left-off-canvas-toggle {
+    top: 30px;
+  }
+
    .blog-layout .main.blog nav.top-bar #banner,
   .sidebar+.main nav.top-bar #banner {
     margin-left: 0;
@@ -49,9 +53,9 @@
       min-width: 100%;
     }
 
-    // .fa {
-    //   display: none;
-    // }
+    .fa {
+      display: none;
+    }
 
     nav.home-nav {
       h1 {
@@ -69,7 +73,7 @@
         width: 96%;
         padding: 0;
         top: 8.5rem;
-        text-align: center;
+        text-align: center !important;
         
         li {
           margin-left: auto;
@@ -81,6 +85,10 @@
             padding: 0 1rem;
             font-size: 1rem;
             line-height: 1.5;
+          }
+
+          &.versioner {
+            display: none !important;
           }
         }
       }
@@ -187,7 +195,7 @@
         }
 
         &.versioner {
-          display: none;
+          display: none !important;
         }
 
         a.active + ul {
@@ -227,6 +235,9 @@
       }
     }
 
+    li.versioner {
+      display: none !important;
+    }
   }
 
   .contrib-text .lead {

--- a/themes/helm/assets/sass/docs-sidebar.scss
+++ b/themes/helm/assets/sass/docs-sidebar.scss
@@ -4,7 +4,7 @@
   box-sizing: border-box;
   min-height: 100%;
   left: 0;
-  top: 0;
+  top: 30px;
   bottom: 0;
   background: desaturate(lighten($blue1, 35%), 20%);
   z-index: 700;

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -1,3 +1,20 @@
+.top-bar,
+.home-nav {
+  .versioner {
+    padding: 0 !important;
+    margin: 0 0 -1px !important;
+    display: none;
+    
+    a.versioner-trigger {
+      padding-left: 1.667rem;
+      padding-right: 2rem;
+      background-color: lighten($blue1, 45%);
+      min-width: 10rem;
+      display: inline-block;
+    }
+  }
+}
+
 .top-bar {
   perspective: 800px;
   min-height: 5.125em;
@@ -8,20 +25,21 @@
   position: fixed;
   left: 300px;
   right: 0;
-  top: 0;
+  top: 30px;
   z-index: 1000;
 
   ul {
     min-width: 33.333%;
     margin: 0;
-    padding: 0;
+    margin-top: -3.5rem;
+    padding: 3.5%;
 
     li {
       display: inline-block;
       margin: 0 0.5rem;
 
       a {
-        padding: 1.25em 1rem;
+        padding: 1rem;
         color: $blue4;
         font-size: 1.125rem;
         @include klinicBold;
@@ -47,20 +65,6 @@
         }
       }
 
-      &.versioner {
-        padding: 0 !important;
-        margin: 0 0 -1px !important;
-        display: none;
-        
-        a.versioner-trigger {
-          padding-left: 1.667rem;
-          padding-right: 2rem;
-          background-color: lighten($blue1, 45%);
-          min-width: 10rem;
-          display: inline-block;
-        }
-      }
-
       &:nth-child(4) {
         padding-right: 1.667rem;
       }
@@ -72,7 +76,7 @@
         text-align: center;
         
         a {
-          min-height: 5rem;
+          min-height: 4.5rem;
         }
       }
     }
@@ -129,7 +133,7 @@
     &.f-open-dropdown {
       left: auto !important;
       right: 0 !important;
-      top: 80px !important;
+      top: 135px !important;
     }
     
     li {
@@ -230,4 +234,29 @@
   nav.top-bar #banner {
     margin-left: -300px;
   }
+
+  h1.blog-logo {
+    top: 30px;
+  }
+}
+
+#banner {	
+  background: $blue4;	
+  color: white;	
+  position: static;	
+  width: 100vw;	
+  top: 0;	
+  left: 0;	
+  right: 0;	
+  margin-top: -30px;	
+  text-align: center;	
+  z-index: 1150;	
+
+  p {	
+    color: white;	
+  }	
+
+  a {	
+    color: white;	
+  }	
 }

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -31,7 +31,7 @@
   ul {
     min-width: 33.333%;
     margin: 0;
-    margin-top: -3.5rem;
+    margin-top: -2.75rem;
     padding: 3.5%;
 
     li {

--- a/themes/helm/assets/sass/helm-blog.scss
+++ b/themes/helm/assets/sass/helm-blog.scss
@@ -76,7 +76,7 @@
   }
 
   .main {
-    padding-top: 0;
+    padding-top: 2rem;
 
     &.blog {
 

--- a/themes/helm/assets/sass/helm-home.scss
+++ b/themes/helm/assets/sass/helm-home.scss
@@ -40,6 +40,79 @@ body.home {
   }
 }
 
+nav.home-nav {
+  position: absolute;
+  min-height: 300px;
+  left: 0;
+  right: 0;
+  top: 0;
+  z-index: 2000;
+
+  h1 {
+    position: absolute;
+    left: 5%;
+    top: 0.5rem;
+    max-width: 112px;
+
+    img,
+    svg {
+      min-height: 96px;
+    }
+  }
+
+  ul {
+    position: absolute;
+    top: 3.25rem;
+    right: 2%;
+
+    li {
+      list-style: none;
+      display: inline-block;
+
+      a {
+        display: inline-block;
+        margin: 0 1.333rem;
+        font-size: 1.25rem;
+        line-height: 2;
+        position: relative;
+        letter-spacing: 0.0125em;
+        color: $darkblue;
+        @include klinicBold;
+        @include ripple;
+
+        img {
+          max-height: 2rem;
+          color: $dark2;
+          line-height: 2.5;
+          padding-top: 0.5rem;
+          margin: -0.5rem -1rem 0 1rem;
+
+          &:hover {
+            opacity: 0.7;
+          }
+        }
+      }
+    }
+  }
+}
+
+// offset for banner
+.home nav.home-nav {
+  // top: 30px;
+
+  #banner {
+    margin-top: 0 !important;
+  }
+
+  h1 {
+    top: 38px;
+  }
+
+  ul {
+    top: 4rem;
+  }
+}
+
 
 #helm.home {
   background: $blue;

--- a/themes/helm/layouts/blog/list.html
+++ b/themes/helm/layouts/blog/list.html
@@ -16,6 +16,8 @@ Helm | Blog
     </h1>
     
     <nav class="top-bar">
+      {{ partial "banner.html" . }}
+      
       <ul class="inline right text-right">
         {{ partial "nav.html" . }}
       </ul>

--- a/themes/helm/layouts/blog/single.html
+++ b/themes/helm/layouts/blog/single.html
@@ -12,6 +12,8 @@
     </h1>
     
     <nav class="top-bar">
+      {{ partial "banner.html" . }}
+      
       <ul class="inline right text-right">
         {{ partial "nav.html" . }}
       </ul>

--- a/themes/helm/layouts/docs/list.html
+++ b/themes/helm/layouts/docs/list.html
@@ -9,6 +9,8 @@ Helm | Docs
   <div class="main home" id="scrollpane">
 
     <nav class="top-bar">
+      {{ partial "banner.html" . }}
+      
       <ul class="inline right text-right">
         {{ partial "nav.html" . }}
       </ul>

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -3,7 +3,9 @@ Helm Docs | Helm
 {{ end }}
 
 {{ define "main" }}
-<nav class="top-bar home-nav">
+<nav class="home-nav">
+  {{ partial "banner.html" . }}
+  
   <h1>
     <a href="{{ site.BaseURL }}" title="Helm.sh">
       {{ partial "logo.html" . }}

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,15 +2,15 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-beta.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-beta.2 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-beta.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-beta.2 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
 
     <!-- viewing helm 3 version of site (desktop) -->
-    <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Beta 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->
+    <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Beta 2). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->
 
     <!-- viewing helm 3 version of site (mobile) -->
-    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing info for Helm 3 <strong>beta-1</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p> -->
+    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing info for Helm 3 <strong>beta-2</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p> -->
   </div>
 </div>

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,15 +2,15 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-alpha.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-beta.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-alpha.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-beta.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
 
     <!-- viewing helm 3 version of site (desktop) -->
-    <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Alpha 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->
+    <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Beta 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->
 
     <!-- viewing helm 3 version of site (mobile) -->
-    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing info for Helm 3 <strong>alpha-1</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p> -->
+    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing info for Helm 3 <strong>beta-1</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p> -->
   </div>
 </div>

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -1,0 +1,16 @@
+<div id="banner">
+  <div class="cc-container">
+
+    <!-- viewing helm 2 version of site (desktop) -->
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-alpha.1 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+
+    <!-- viewing helm 2 version of site (mobile) -->
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-alpha.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+
+    <!-- viewing helm 3 version of site (desktop) -->
+    <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Alpha 1). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->
+
+    <!-- viewing helm 3 version of site (mobile) -->
+    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing info for Helm 3 <strong>alpha-1</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p> -->
+  </div>
+</div>

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -5,10 +5,10 @@
 <li class="social"><a href="https://twitter.com/helmpack" target="_blank" class="hide-for-small-only" title="Helm on Twitter"><img src="/img/twitter.svg" alt="Helm on twitter" /></a></li>
 <li class="social"><a href="https://github.com/helm/helm" target="_blank" class="hide-for-small-only" title="Helm on Github"><img src="/img/github.svg" alt="Github" /></a></li>
 <li class="versioner">
-  <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">v2.14.2 <i class="fa fa-caret-down"></i></a>
+  <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">v2.14.3 <i class="fa fa-caret-down"></i></a>
   <ul id="drop1" class="f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1">
-    <li><a href="https://v3.helm.sh/docs">v3.0.0 <em>alpha 1</em></a></li>
-    <li><a href="https://helm.sh/docs" class="active">v2.14.2 <em>stable</em></a></li>
+    <li><a href="https://v3.helm.sh/docs">v3.0.0 <em>beta 1</em></a></li>
+    <li><a href="https://helm.sh/docs" class="active">v2.14.3 <em>stable</em></a></li>
     <li><a href="https://v2-14-0.helm.sh/docs">v2.14.0</a></li>
   </ul>
 </li>

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -1,3 +1,5 @@
+{{ $versions := site.Params.versions }}
+{{ $primary  := index (where $versions ".primary" true) 0 }}
 <li><a href="https://github.com/helm/helm" title="Get Helm">Get Helm</a></li>
 <li><a href="/blog" title="Helm Blog">Blog</a></li>
 <li><a href="/docs" title="Helm Documentation">Docs</a></li>
@@ -5,10 +7,19 @@
 <li class="social"><a href="https://twitter.com/helmpack" target="_blank" class="hide-for-small-only" title="Helm on Twitter"><img src="/img/twitter.svg" alt="Helm on twitter" /></a></li>
 <li class="social"><a href="https://github.com/helm/helm" target="_blank" class="hide-for-small-only" title="Helm on Github"><img src="/img/github.svg" alt="Github" /></a></li>
 <li class="versioner">
-  <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">v2.14.3 <i class="fa fa-caret-down"></i></a>
+  {{ with $primary }}
+  <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">
+    {{ .version }}{{ with .patch }} {{ . }}{{ end }} <i class="fa fa-caret-down"></i>
+  </a>
+  {{ end }}
+
   <ul id="drop1" class="f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1">
-    <li><a href="https://v3.helm.sh/docs">v3.0.0 <em>beta 1</em></a></li>
-    <li><a href="https://helm.sh/docs" class="active">v2.14.3 <em>stable</em></a></li>
-    <li><a href="https://v2-14-0.helm.sh/docs">v2.14.0</a></li>
+    {{ range $versions }}
+    <li>
+      <a href="{{ .url }}">
+        {{ .version }}{{ with .patch }} <em>{{ . }}</em>{{ end }}
+      </a>
+    </li>
+    {{ end }}
   </ul>
 </li>

--- a/themes/helm/layouts/partials/topbar.html
+++ b/themes/helm/layouts/partials/topbar.html
@@ -1,4 +1,6 @@
-<nav class="top-bar">  
+<nav class="top-bar">
+  {{ partial "banner.html" . }}
+  
   <ul class="inline right text-right">
     {{ partial "nav.html" . }}
   </ul>


### PR DESCRIPTION
* denotes latest releases as `2.14.3` and `3.0.0.beta.1`, this replaces PR #256 which got stuck with a conflict
* restores the sticky v2/v3 banner to the homepage *

The sticky banner was taken off the homepage when the version dropdown menu was added to the [site](https://github.com/helm/helm-www/commit/a392fbc9496223b2cc39c1423c575d179a72d8b3). Adding it back here because I think both are useful to highlight where things are. 