### PR TITLE
Set versions via site configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,21 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     "app"
   ]
 
+[[params.versions]]
+version = "v3.0.0"
+patch = "beta.1"
+url = "https://v3.helm.sh/docs"
+primary = true
+
+[[params.versions]]
+version = "v2.14.3"
+patch = "stable"
+url = "https://helm.sh/docs"
+
+[[params.versions]]
+version = "v2.14.0"
+url = "https://v2-14-0.helm.sh/docs"
+
 [Permalinks]
   code = "/:filename/"
 

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -1,3 +1,5 @@
+{{ $versions := site.Params.versions }}
+{{ $primary  := index (where $versions ".primary" true) 0 }}
 <li><a href="https://github.com/helm/helm" title="Get Helm">Get Helm</a></li>
 <li><a href="/blog" title="Helm Blog">Blog</a></li>
 <li><a href="/docs" title="Helm Documentation">Docs</a></li>
@@ -5,10 +7,19 @@
 <li><a href="https://twitter.com/helmpack" target="_blank" class="hide-for-small-only" title="Helm on Twitter"><img src="/img/twitter.svg" alt="Helm on twitter" /></a></li>
 <li><a href="https://github.com/helm/helm" target="_blank" class="hide-for-small-only" title="Helm on Github"><img src="/img/github.svg" alt="Github" /></a></li>
 <li class="versioner">
-  <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">v3.0.0 beta.1 <i class="fa fa-caret-down"></i></a>
+  {{ with $primary }}
+  <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">
+    {{ .version }}{{ with .patch }} {{ . }}{{ end }} <i class="fa fa-caret-down"></i>
+  </a>
+  {{ end }}
+
   <ul id="drop1" class="f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1">
-    <li><a href="https://v3.helm.sh/docs">v3.0.0 <em>beta 1</em></a></li>
-    <li><a href="https://helm.sh/docs">v2.14.3 <em>stable</em></a></li>
-    <li><a href="https://v2-14-0.helm.sh/docs" class="active">v2.14.0</a></li>
+    {{ range $versions }}
+    <li>
+      <a href="{{ .url }}">
+        {{ .version }}{{ with .patch }} <em>{{ . }}</em>{{ end }}
+      </a>
+    </li>
+    {{ end }}
   </ul>
 </li>


### PR DESCRIPTION
This PR enables updating the config selector via the site config rather than hard-coding those values in the `nav` partial