### PR TITLE
Make vanity url usable by chartmuseum

### DIFF
--- a/content/code/chartmuseum.md
+++ b/content/code/chartmuseum.md
@@ -1,0 +1,5 @@
+---
+name: "chartmuseum"
+repoURL: "https://github.com/helm/chartmuseum"
+branch: "master"
+---


### PR DESCRIPTION
Attempting to prevent this error:
```
$ go get -u helm.sh/chartmuseum
go: creating new go.mod: module github.com/helm/helm-www
go get helm.sh/chartmuseum: unrecognized import path "helm.sh/chartmuseum" (parse https://helm.sh/chartmuseum?go-get=1: no go-import meta tags ())
```

Is there anything else needed for this?