### PR TITLE
docs(bug): correct the v2 current version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,12 +32,12 @@ defaultContentLanguage = "en"
 version = "v3.0.0"
 patch = "beta.2"
 url = "https://v3.helm.sh/docs"
-primary = true
 
 [[params.versions]]
 version = "v2.14.3"
 patch = "stable"
 url = "https://helm.sh/docs"
+primary = true
 
 [[params.versions]]
 version = "v2.14.0"

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -31,7 +31,7 @@
   ul {
     min-width: 33.333%;
     margin: 0;
-    margin-top: -2.75rem;
+    margin-top: -3.35rem;
     padding: 3.5%;
 
     li {

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -9,7 +9,7 @@
 <li class="versioner">
   {{ with $primary }}
   <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger">
-    {{ .version }}{{ with .patch }} {{ . }}{{ end }} <i class="fa fa-caret-down"></i>
+    {{ .version }}{{ with .stable }} {{ . }}{{ end }} <i class="fa fa-caret-down"></i>
   </a>
   {{ end }}
 


### PR DESCRIPTION
The `$primary` version needs fixing asap - live site shows up as v3 instead of v2! 

I should have spotted this in #269, sorry.