### PR TITLE
Improve contrast accessibility of contribute button

### DIFF
--- a/themes/helm/assets/sass/docs-sidebar.scss
+++ b/themes/helm/assets/sass/docs-sidebar.scss
@@ -203,12 +203,12 @@
       display: block;
       padding-top: .5rem;
       padding-bottom: .575rem;
-      background-color: $light2;
-      color: $blue3;
+      background-color: $blue3;
+      color: $light2;
 
       i {
         margin: -0.05em 0.5em 0 -0.667em;
-        color: $blue3;
+        color: $light2;
         font-size: $scalex3;
       }
     }


### PR DESCRIPTION
One more tweak: the button's contrast ratio was failing accessibility checks, so I reversed the color scheme with color variables to make it more legible.

<img width="259" alt="image" src="https://user-images.githubusercontent.com/928675/64701580-a3234700-d46e-11e9-9d4a-7465ff9e79ab.png">

Hopefully this drives some increased engagement, too? The original button kinda blended in and didn't look too inviting (almost disabled).

Signed-off-by: Ben Radcliffe <bsradcliffe@gmail.com>