### PR TITLE
fix: remove references to helm init

### DIFF
--- a/content/docs/community/release_checklist.md
+++ b/content/docs/community/release_checklist.md
@@ -274,8 +274,6 @@ Download Helm X.Y. The common platform binaries are here:
 - [Linux s390x](https://get.helm.sh/helm-vX.Y.Z-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-vX.Y.Z-linux-s390x.tar.gz.sha256) / CHECKSUM_VAL)
 - [Windows amd64](https://get.helm.sh/helm-vX.Y.Z-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-vX.Y.Z-windows-amd64.zip.sha256) / CHECKSUM_VAL)
 
-Once you have the client installed, upgrade Tiller with `helm init --upgrade`.
-
 The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get) on any system with `bash`.
 
 ## What's Next

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -357,14 +357,14 @@ We provide it because it is useful, but we suggest that users carefully read the
 script first. What we'd really like, though, are better packaged releases of
 Helm.
 
-### How do I put the Helm client files somewhere other than ~/.helm?
+### How do I put the Helm client files somewhere other than their defaults?
 
-Set the `$HELM_HOME` environment variable, and then run `helm init`:
+Helm uses the XDG structure for storing files. There are environment
+variables you can use to override these locations:
 
-```console
-export HELM_HOME=/some/path
-helm init --client-only
-```
+- `$XDG_CACHE_HOME`: set an alternative location for storing cached files.
+- `$XDG_CONFIG_HOME`: set an alternative location for storing Helm configuration.
+- `$XDG_DATA_HOME`: set an alternative location for storing Helm data.
 
 Note that if you have existing repositories, you will need to re-add them
 with `helm repo add...`.

--- a/content/docs/glossary.md
+++ b/content/docs/glossary.md
@@ -55,13 +55,10 @@ While _Helm_ is the name of the project, the command line client is also
 named `helm`. By convention, when speaking of the project, _Helm_ is
 capitalized. When speaking of the client, _helm_ is in lowercase.
 
-## Helm Home (HELM_HOME)
+## Helm Configuration Files (XDG)
 
-The Helm client stores information in a local directory referred to as
-_helm home_. By default, this is in the `$HOME/.helm` directory.
-
-This directory contains configuration and cache data, and is created by
-`helm init`.
+Helm stores its configuration files in XDG directories. These
+directories are created the first time `helm` is run.
 
 ## Kube Config (KUBECONFIG)
 

--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -93,9 +93,9 @@ place it in `bin/helm`.
 
 ## Conclusion
 
-In most cases, installation is as simple as getting a pre-built `helm` binary
-and running `helm init`. This document covers additional cases for those
-who want to do more sophisticated things with Helm.
+In most cases, installation is as simple as getting a pre-built `helm` 
+binary. This document covers additional cases for those who want to do
+more sophisticated things with Helm.
 
 Once you have the Helm Client successfully installed, you can
 move on to using Helm to manage charts.

--- a/content/docs/topics/plugins.md
+++ b/content/docs/topics/plugins.md
@@ -42,19 +42,6 @@ $ helm plugin install https://github.com/technosophos/helm-template
 
 If you have a plugin tar distribution, simply untar the plugin into the `$(helm home)/plugins` directory. You can also install tarball plugins directly from url by issuing `helm plugin install http://domain/path/to/plugin.tar.gz`
 
-Alternatively, a set of plugins can be installed during the `helm init` process by using the `--plugins <file.yaml>` flag, where `file.yaml` looks like this:
-
-```
-plugins:
-- name: helm-template
-  url: https://github.com/technosophos/helm-template
-- name: helm-diff
-  url: https://github.com/databus23/helm-diff
-  version: 2.11.0+3
-```
-
-The `name` field only exists to allow you to easily identify plugins, and does not serve a functional purpose. If a plugin specified in the file is already installed, it maintains its current version.
-
 ## Building Plugins
 
 In many ways, a plugin is similar to a chart. Each plugin has a top-level


### PR DESCRIPTION
Removes all non-autogenerated references to `helm init`.

It appears that the automatically generated HTML and Man pages need updating.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>