### PR TITLE
fix: updated references about HELM_HOME to use XDG_*

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -307,7 +307,7 @@ In Helm 3, Helm now respects the following environment variables as per the XDG 
 Helm plugins are still passed `$HELM_HOME` as an alias to `$XDG_DATA_HOME` for backwards compatibility with plugins
 looking to use `$HELM_HOME` as a scratchpad environment.
 
-Several new environment variables are also passed in to the plugin's environment to accomodate this change:
+Several new environment variables are also passed in to the plugin's environment to accommodate this change:
 
 - `$HELM_PATH_CACHE` for the cache path
 - `$HELM_PATH_CONFIG` for the config path
@@ -322,7 +322,7 @@ In order to better align the verbiage from other package managers, `helm delete`
 can be used.
 
 In Helm 2, in order to purge the release ledger, the `--purge` flag had to be provided. This
-functionality is now enabled by default. To retain the previous behaviour, use
+functionality is now enabled by default. To retain the previous behavior, use
 `helm uninstall --keep-history`.
 
 Additionally, several other commands were re-named to accommodate the same conventions:
@@ -374,9 +374,19 @@ with `helm repo add...`.
 
 ### I want to delete my local Helm. Where are all its files?
 
-Along with the `helm` binary, Helm stores some files in `$HELM_HOME`, which is
-located by default in `~/.helm`.
+Along with the `helm` binary, Helm stores some files in the following locations:
 
+- $XDG_CACHE_HOME
+- $XDG_CONFIG_HOME
+- $XDG_DATA_HOME
+
+The following table gives the default folder for each of these, by OS:
+
+| Operating System | Cache Path                | Configuration Path             | Data Path               |
+| ---------------- | ------------------------- | ------------------------------ | ----------------------- |
+| Linux            | $HOME/.cache/helm         | $HOME/.config/helm             | $HOME/.local/share/helm |
+| macOS            | $HOME/Library/Caches/helm | $HOME/Library/Preferences/helm | $HOME/Library/helm      |
+| Windows          | %TEMP%\helm               | %APPDATA%\helm                 | %APPDATA%\helm          |
 
 ## Troubleshooting
 

--- a/content/docs/topics/chart_repository.md
+++ b/content/docs/topics/chart_repository.md
@@ -295,5 +295,5 @@ chart information.
 
 *Under the hood, the `helm repo add` and `helm repo update` commands are
 fetching the index.yaml file and storing them in the
-`$HELM_HOME/repository/cache/` directory. This is where the `helm search`
+`$XDG_CACHE_HOME/helm/repository/cache/` directory. This is where the `helm search`
 function finds information about charts.*

--- a/content/docs/topics/charts.md
+++ b/content/docs/topics/charts.md
@@ -994,7 +994,7 @@ barrier for setting up a repository.
 The `helm create` command takes an optional `--starter` option that lets you
 specify a "starter chart".
 
-Starters are just regular charts, but are located in `$HELM_HOME/starters`.
+Starters are just regular charts, but are located in `$XDG_DATA_HOME/helm/starters`.
 As a chart developer, you may author charts that are specifically designed
 to be used as starters. Such charts should be designed with the following
 considerations in mind:
@@ -1005,6 +1005,6 @@ considerations in mind:
 - All occurrences of `<CHARTNAME>` will be replaced with the specified chart
   name so that starter charts can be used as templates.
 
-Currently the only way to add a chart to `$HELM_HOME/starters` is to manually
+Currently the only way to add a chart to `$XDG_DATA_HOME/helm/starters` is to manually
 copy it there. In your chart's documentation, you may want to explain that
 process.

--- a/content/docs/topics/plugins.md
+++ b/content/docs/topics/plugins.md
@@ -157,7 +157,7 @@ available Charts.
 
 The defined command will be invoked with the following scheme:
 `command certFile keyFile caFile full-URL`. The SSL credentials are coming from the
-repo definition, stored in `$HELM_HOME/repository/repositories.yaml`. Downloader
+repo definition, stored in `$XDG_DATA_HOME/helm/repositories.yaml`. Downloader
 plugin is expected to dump the raw content to stdout and report errors on stderr.
 
 The downloader command also supports sub-commands or arguments, allowing you to specify
@@ -180,7 +180,7 @@ The following variables are guaranteed to be set:
   `helm myplug` will have the short name `myplug`.
 - `HELM_PLUGIN_DIR`: The directory that contains the plugin.
 - `HELM_BIN`: The path to the `helm` command (as executed by the user).
-- `HELM_HOME`: The path to the Helm home.
+- `HELM_HOME`: The path to `$XDG_DATA_HOME/helm`.
 - `HELM_PATH_*`: Paths to important Helm files and directories are stored in
   environment variables prefixed by `HELM_PATH`.
 


### PR DESCRIPTION
Updated references to `HELM_HOME` to talk about XDG directories.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>