### PR TITLE
Helm 2: reference Helm 3 rather than the "latest" release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ defaultContentLanguage = "en"
 
 [[params.versions]]
 version = "v3.0.0"
-patch = "beta.2"
+patch = "unreleased"
 url = "https://v3.helm.sh/docs"
 
 [[params.versions]]

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,10 +2,10 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3.0.0-beta.2 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
+    <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm <a href="https://v3.helm.sh"><strong>3 is here</strong>. &nbsp; Visit the <a href="https://v3.helm.sh"><strong>Helm 3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p>
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3.0.0-beta.2 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm 2 (latest). &nbsp; Helm 3 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p>
 
     <!-- viewing helm 3 version of site (desktop) -->
     <!-- <p class="center text-center show-for-medium-up">You are previewing info for Helm 3 (Beta 2). Check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p> -->


### PR DESCRIPTION
This way we stop needing to update the banner each time a new Helm release is out.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>