### PR TITLE
Helm 3: reference Helm 3 rather than specific version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,7 +31,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [[params.versions]]
 version = "v3.0.0"
-patch = "beta.1"
+patch = "unreleased"
 url = "https://v3.helm.sh/docs"
 primary = true
 

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -2,15 +2,15 @@
   <div class="cc-container">
 
     <!-- viewing helm 2 version of site (desktop) -->
-    <!-- <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm 3 is coming soon (3.0.0-beta.1 is <a href="https://v3.helm.sh"><strong>here</strong>). &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p> -->
+    <!-- <p class="center text-center show-for-medium-up">You are viewing Helm 2 (latest stable). &nbsp; Helm 3 is coming soon (3 is <a href="https://v3.helm.sh"><strong>here</strong>). &nbsp; Visit the <a href="https://v3.helm.sh"><strong>v3 docs</strong></a> or read the <a href="https://helm.sh/blog"><strong>blog</strong></a> for details.</p> -->
 
     <!-- viewing helm 2 version of site (mobile) -->
-    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">You are viewing Helm 2 (latest). &nbsp; Helm 3.0.0-beta.1 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p> -->
+    <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">You are viewing Helm 2 (latest). &nbsp; Helm 3 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p> -->
 
     <!-- viewing helm 3 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing info for Helm 3.0.0-beta.1 - check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p>
+    <p class="center text-center show-for-medium-up">You are viewing info for Helm 3 - check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p>
 
     <!-- viewing helm 3 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm <strong>3.0.0-beta.1</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p>
+    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm <strong>3</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p>
   </div>
 </div>


### PR DESCRIPTION
This way we don't have to update the banner each time a new version of Helm is released.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>