### PR TITLE
Add vanity url for helm v3 with Go modules

### DIFF
--- a/content/code/helm-v3.md
+++ b/content/code/helm-v3.md
@@ -1,0 +1,6 @@
+---
+url: "helm/v3"
+name: "helm/v3"
+repoURL: "https://github.com/helm/helm"
+branch: "dev-v3"
+---


### PR DESCRIPTION
With Go modules and packages with a major version greater than 1
the major version needs to be in the path. In Helm's case this
is a sort of virtual path and not on disk. The vanity redirect
needs to reflect this new version.

Fixes #300