### PR TITLE
fix: Update docs to include generate-name argument

### DIFF
--- a/content/docs/intro/quickstart.md
+++ b/content/docs/intro/quickstart.md
@@ -70,7 +70,7 @@ of the official `stable` charts.
 
 ```console
 $ helm repo update              # Make sure we get the latest list of charts
-$ helm install stable/mysql
+$ helm install stable/mysql --generate-name
 Released smiling-penguin
 ```
 


### PR DESCRIPTION
install: requires release name or --generate-name argument
`helm install [NAME] [CHART] [flags]`