### PR TITLE
Fix broken link in Quicklinks

### DIFF
--- a/themes/helm/layouts/docs/list.html
+++ b/themes/helm/layouts/docs/list.html
@@ -88,7 +88,7 @@ Helm | Docs
 
                 <div class="small-12 large-4 columns">
                   <div class="panel">
-                    <a href="https://hackernoon.com/the-missing-ci-cd-kubernetes-component-helm-package-manager-1fe002aac680#.691sk2zhu" target="_blank">
+                    <a href="https://medium.com/@gajus/the-missing-ci-cd-kubernetes-component-helm-package-manager-1fe002aac680" target="_blank">
                       <h3>CI/CD for Kubernetes &nbsp; <small><i class="fa fa-external-link"></i></small></h3>
 
                       <p>Instructions on using Helm as the missing CI/CD Kubernetes component - <small>(via hackernoon)</small></p>


### PR DESCRIPTION
Looks like this change didn't get migrated over.

https://github.com/helm/helm/pull/6067