### PR TITLE
Improve documentation consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ created via pull requests. The following steps are used to add them.
 
 3. Add the content below the `---` as Markdown. The title does not need to be included in this section
 4. Any images should be placed in the `/img/blog/` directory. Images should be losslessly compressed to reduce their size. Tools, such as [ImageOptim](https://imageoptim.com/), can be used.
-5. To summarize content on the blog index page, insert a `<!--more-->` break in your markdown. This will truncate the content with a _Read More_ link. 
+5. To summarize content on the blog index page, insert a `<!--more-->` break in your markdown. This will truncate the content with a _Read More_ link.
 
 ---
 
 ## How to Edit The Helm Docs
 
-Edits to the docs themselves should be carried out via pull requests on the [helm/helm](https://github.com/helm/helm/tree/master/docs) main repo.  
+Edits to the docs themselves should be carried out via pull requests on the [helm/helm](https://github.com/helm/helm/tree/master/docs) main repo.
 This site will then extract those files during the build process, and publish them to [docs.helm.sh](https://docs.helm.sh).
 
 ---
@@ -46,7 +46,7 @@ The site is built on top of [Hugo](https://gohugo.io/) with a custom theme, and 
 Hugo can be installed via `brew update && brew install hugo`
 Then install the packages needed for Gulp to run:
 
-```
+```console
 npm install -g gulp
 npm install
 ```
@@ -77,12 +77,12 @@ Markdown:
 
 ```
 /content/blog/                  < posts go here
-/content/docs/                  < docs are imported to here   
+/content/docs/                  < docs are imported to here
 ```
 
 The documentation content is pulled in from their home in the [helm/helm](https://github.com/helm/helm/tree/master/docs) repo, as part of the Gulp build process.
 
-Gulp clones the files to the `/source` directory, makes some edits (to hugo-ify markdown and fix some url issues), exporting the compiled docs to `/content/docs`. 
+Gulp clones the files to the `/source` directory, makes some edits (to hugo-ify markdown and fix some url issues), exporting the compiled docs to `/content/docs`.
 
 Hugo then targets the `/content/docs` directory to generate the website, applying the theme (html layouts and css/js assets) in `/themes/hugo`.
 

--- a/content/docs/community/developers.md
+++ b/content/docs/community/developers.md
@@ -26,7 +26,7 @@ NOTE: This will fail if not running from the path `$GOPATH/src/helm.sh/helm`. Th
 directory `helm.sh` should not be a symlink or `build` will not find the relevant
 packages.
 
-If required, this will first install dependencies, rebuild the `vendor/` tree, and 
+If required, this will first install dependencies, rebuild the `vendor/` tree, and
 validate configuration. It will then compile `helm` and place it in `bin/helm`.
 
 To run all the tests (without running the tests for `vendor/`), run
@@ -44,7 +44,7 @@ generate the documentation using `make docs`.
 To expose the Helm man pages to your `man` client, you can put the files in your
 `$MANPATH`:
 
-```
+```console
 $ export MANPATH=$GOPATH/src/helm.sh/helm/docs/man:$MANPATH
 $ man helm
 ```

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -60,7 +60,7 @@ Let's go through a few common examples what this change impacts.
 Your team just deployed their application to production on Kubernetes using Helm. The chart contains a Deployment object
 where the number of replicas is set to three:
 
-```
+```console
 $ helm install myapp ./myapp
 ```
 
@@ -68,14 +68,14 @@ A new developer joins the team. On their first day while observing the productio
 coffee-spilling-on-the-keyboard accident happens and they `kubectl scale` the production deployment from three replicas down
 to zero.
 
-```
+```console
 $ kubectl scale --replicas=0 deployment/myapp
 ```
 
 Another developer on your team notices that the production site is down and decides to rollback the release to its
 previous state:
 
-```
+```console
 $ helm rollback myapp
 ```
 
@@ -94,7 +94,7 @@ generates a patch to change the state back to three.
 Many service meshes and other controller-based applications inject data into Kubernetes objects. This can be something
 like a sidecar, labels, or other information. Previously if you had the given manifest rendered from a Chart:
 
-```
+```yaml
 containers:
 - name: server
   image: nginx:2.0.0
@@ -102,7 +102,7 @@ containers:
 
 And the live state was modified by another application to
 
-```
+```yaml
 containers:
 - name: server
   image: nginx:2.0.0
@@ -112,7 +112,7 @@ containers:
 
 Now, you want to upgrade the `nginx` image tag to `2.1.0`. So, you upgrade to a chart with the given manifest:
 
-```
+```yaml
 containers:
 - name: server
   image: nginx:2.1.0
@@ -125,7 +125,7 @@ cluster's live state is not considered during the patch generation.
 
 The cluster's live state is modified to look like the following:
 
-```
+```yaml
 containers:
 - name: server
   image: nginx:2.1.0
@@ -139,7 +139,7 @@ container.
 
 The cluster's live state is modified to look like the following:
 
-```
+```yaml
 containers:
 - name: server
   image: nginx:2.1.0
@@ -195,7 +195,7 @@ meaning that charts that relied on the `helm dependency` subcommands will need s
 
 In Helm 2, this is how a requirements.yaml looked:
 
-```
+```yaml
 dependencies:
 - name: mariadb
   version: 5.x.x
@@ -207,7 +207,7 @@ dependencies:
 
 In Helm 3, the dependency is expressed the same way, but now from your Chart.yaml:
 
-```
+```yaml
 dependencies:
 - name: mariadb
   version: 5.x.x
@@ -269,7 +269,7 @@ many charts, avoiding redundancy and keeping charts [DRY](https://en.wikipedia.o
 Library charts are declared in the dependencies directive in Chart.yaml, and are installed and managed like any other
 chart.
 
-```
+```yaml
 dependencies:
   - name: mylib
     version: 1.x.x

--- a/content/docs/howto/charts_tips_and_tricks.md
+++ b/content/docs/howto/charts_tips_and_tricks.md
@@ -24,7 +24,7 @@ For example, this template snippet includes a template called `mytpl`, then
 lowercases the result, then wraps that in double quotes.
 
 ```yaml
-value: {{include "mytpl" . | lower | quote}}
+value: {{ include "mytpl" . | lower | quote }}
 ```
 
 The `required` function allows you to declare a particular
@@ -35,7 +35,7 @@ The following example of the `required` function declares an entry for .Values.w
 is required, and will print an error message when that entry is missing:
 
 ```yaml
-value: {{required "A valid .Values.who entry required!" .Values.who }}
+value: {{ required "A valid .Values.who entry required!" .Values.who }}
 ```
 
 ## Quote Strings, Don't Quote Integers
@@ -43,24 +43,24 @@ value: {{required "A valid .Values.who entry required!" .Values.who }}
 When you are working with string data, you are always safer quoting the
 strings than leaving them as bare words:
 
-```
-name: {{.Values.MyName | quote }}
+```yaml
+name: {{ .Values.MyName | quote }}
 ```
 
 But when working with integers _do not quote the values._ That can, in
 many cases, cause parsing errors inside of Kubernetes.
 
-```
+```yaml
 port: {{ .Values.Port }}
 ```
 
 This remark does not apply to env variables values which are expected to be string, even if they represent integers:
 
-```
+```yaml
 env:
-  -name: HOST
+  - name: HOST
     value: "http://host"
-  -name: PORT
+  - name: PORT
     value: "1234"
 ```
 
@@ -112,12 +112,12 @@ to render and exit when .Values.foo is undefined.
 Image pull secrets are essentially a combination of _registry_, _username_, and _password_.  You may need them in an application you are deploying, but to create them requires running _base64_ a couple of times.  We can write a helper template to compose the Docker configuration file for use as the Secret's payload.  Here is an example:
 
 First, assume that the credentials are defined in the `values.yaml` file like so:
-```
+```yaml
 imageCredentials:
   registry: quay.io
   username: someone
   password: sillyness
-```  
+```
 
 We then define our helper template as follows:
 ```
@@ -127,7 +127,7 @@ We then define our helper template as follows:
 ```
 
 Finally, we use the helper template in a larger template to create the Secret manifest:
-```
+```yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -147,7 +147,7 @@ didn't change the application keeps running with the old configuration resulting
 in an inconsistent deployment.
 
 The `sha256sum` function can be used to ensure a deployment's annotation section
-is updated if another file changes: 
+is updated if another file changes:
 
 ```yaml
 kind: Deployment
@@ -178,7 +178,7 @@ strategy logic to avoid taking downtime.
 
 NOTE: In the past we recommended using the `--recreate-pods` flag as another
 option. This flag has been marked as deprecated in Helm 3 in favor of the more
-declarative method above. 
+declarative method above.
 
 ## Tell Helm Not To Uninstall a Resource
 

--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -24,7 +24,7 @@ From there, you should be able to run the client: `helm help`.
 Members of the Kubernetes community have contributed a Helm formula build to
 Homebrew. This formula is generally up to date.
 
-```
+```console
 brew install kubernetes-helm
 ```
 
@@ -36,7 +36,7 @@ project.)
 Members of the Kubernetes community have contributed a [Helm package](https://chocolatey.org/packages/kubernetes-helm) build to
 [Chocolatey](https://chocolatey.org/). This package is generally up to date.
 
-```
+```console
 choco install kubernetes-helm
 ```
 
@@ -48,7 +48,7 @@ of Helm and [install it locally](https://raw.githubusercontent.com/helm/helm/mas
 You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
 
-```
+```console
 $ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
 $ chmod 700 get_helm.sh
 $ ./get_helm.sh
@@ -93,7 +93,7 @@ place it in `bin/helm`.
 
 ## Conclusion
 
-In most cases, installation is as simple as getting a pre-built `helm` 
+In most cases, installation is as simple as getting a pre-built `helm`
 binary. This document covers additional cases for those who want to do
 more sophisticated things with Helm.
 

--- a/content/docs/intro/rbac.md
+++ b/content/docs/intro/rbac.md
@@ -54,13 +54,13 @@ Additionally, you may also create a RoleBinding with `cluster-admin` access. Gra
 
 For this example, we will create a user with the `edit` Role. First, create the namespace:
 
-```
+```console
 $ kubectl create namespace foo
 ```
 
 Now, create a RoleBinding in that namespace, granting the user the `edit` role.
 
-```
+```console
 $ kubectl create rolebinding sam-edit
     --clusterrole edit \​
     --user sam \​
@@ -75,7 +75,7 @@ To do that, grant the user either `admin` or `cluster-admin` access.
 
 Granting a user `cluster-admin` access grants them access to absolutely every resource available in Kubernetes, including node access with `kubectl drain` and other administrative tasks. It is highly recommended to consider providing the user `admin` access instead, or to create a custom ClusterRole tailored to their needs.
 
-```
+```console
 $ kubectl create clusterrolebinding sam-view
     --clusterrole view \​
     --user sam
@@ -93,7 +93,7 @@ In order for a user to run `helm list`, they need to be able to read these secre
 
 Create the file `cluster-role-secret-reader.yaml` and write the following content into the file:
 
-```
+```yaml
 apiVersion: rbac.authorization.k8s.io/v1​
 kind: ClusterRole​
 metadata:​
@@ -106,13 +106,13 @@ rules:​
 
 Then, create the ClusterRole using
 
-```
+```console
 $ kubectl create -f clusterrole-secret-reader.yaml​
 ```
 
 Once that's done, we can grant a user read access to most resources, and then grant them read access to secrets:
 
-```
+```console
 $ kubectl create namespace foo
 
 $ kubectl create rolebinding sam-view
@@ -132,7 +132,7 @@ In certain scenarios, it may be beneficial to grant a user cluster-scope access.
 
 To do that, grant the user both `view` and `secret-reader` access as described above, but with a ClusterRoleBinding.
 
-```
+```console
 $ kubectl create clusterrolebinding sam-view
     --clusterrole view \​
     --user sam

--- a/content/docs/intro/using_helm.md
+++ b/content/docs/intro/using_helm.md
@@ -47,7 +47,7 @@ carefully curated and maintained charts. This chart repository is named
 
 You can see which charts are available by running `helm search`:
 
-```
+```console
 $ helm search
 NAME                 	VERSION 	DESCRIPTION
 stable/drupal   	0.3.2   	One of the most versatile open source content m...
@@ -60,7 +60,7 @@ stable/mysql    	0.1.0   	Chart for MySQL
 With no filter, `helm search` shows you all of the available charts. You
 can narrow down your results by searching with a filter:
 
-```
+```console
 $ helm search mysql
 NAME               	VERSION	DESCRIPTION
 stable/mysql  	0.1.0  	Chart for MySQL
@@ -73,7 +73,7 @@ Why is
 `mariadb` in the list? Because its package description relates it to
 MySQL. We can use `helm inspect chart` to see this:
 
-```
+```console
 $ helm inspect stable/mariadb
 Fetched stable/mariadb to mariadb-0.5.1.tgz
 description: Chart for MariaDB
@@ -94,7 +94,7 @@ package you want to install, you can use `helm install` to install it.
 To install a new package, use the `helm install` command. At its
 simplest, it takes only one argument: The name of the chart.
 
-```
+```console
 $ helm install --generate-name stable/mariadb
 Fetched stable/mariadb-0.3.0 to /Users/mattbutcher/Code/Go/src/helm.sh/helm/mariadb-0.3.0.tgz
 happy-panda
@@ -142,7 +142,7 @@ may take a long time to install into the cluster.
 To keep track of a release's state, or to re-read configuration
 information, you can use `helm status`:
 
-```
+```console
 $ helm status happy-panda
 Last Deployed: Wed Sep 28 12:32:28 2016
 Namespace: default
@@ -395,14 +395,14 @@ is not a full list of cli flags. To see a description of all flags, just run
 When it is time to uninstall or uninstall a release from the cluster, use
 the `helm uninstall` command:
 
-```
+```console
 $ helm uninstall happy-panda
 ```
 
 This will remove the release from the cluster. You can see all of your
 currently deployed releases with the `helm list` command:
 
-```
+```console
 $ helm list
 NAME           	VERSION	UPDATED                        	STATUS         	CHART
 inky-cat       	1      	Wed Sep 28 12:59:46 2016       	DEPLOYED       	alpine-0.1.0

--- a/content/docs/topics/chart_best_practices/dependencies.md
+++ b/content/docs/topics/chart_best_practices/dependencies.md
@@ -42,7 +42,7 @@ When multiple subcharts (dependencies) together provide an optional or swappable
 For example, if both `nginx` and `memcached` together provided performance optimizations for the main app in the chart, and were required to both be present when that feature is enabled, then they might both have a
 tags section like this:
 
-```
+```yaml
 tags:
   - webaccelerator
 ```

--- a/content/docs/topics/chart_best_practices/pods.md
+++ b/content/docs/topics/chart_best_practices/pods.md
@@ -21,13 +21,13 @@ A container image should use a fixed tag or the SHA of the image. It should not 
 
 Images _may_ be defined in the `values.yaml` file to make it easy to swap out images.
 
-```
+```yaml
 image: {{ .Values.redisImage | quote }}
 ```
 
 An image and a tag _may_ be defined in `values.yaml` as two separate fields:
 
-```
+```yaml
 image: "{{ .Values.redisImage }}:{{ .Values.redisTag }}"
 ```
 

--- a/content/docs/topics/chart_best_practices/templates.md
+++ b/content/docs/topics/chart_best_practices/templates.md
@@ -57,14 +57,14 @@ Correct:
 
 Incorrect:
 ```
-{{.foo}}
-{{print "foo"}}
-{{-print "bar"-}}
+{{ .foo }}
+{{ print "foo" }}
+{{- print "bar" -}}
 ```
 
 Templates should chomp whitespace where possible:
 
-```
+```yaml
 foo:
   {{- range .Values.items }}
   {{ . }}
@@ -76,7 +76,7 @@ Blocks (such as control structures) may be indented to indicate flow of the temp
 ```
 {{ if $foo -}}
   {{- with .Bar }}Hello{{ end -}}
-{{- end -}} 
+{{- end -}}
 ```
 
 However, since YAML is a whitespace-oriented language, it is often not possible for code indentation to follow that convention.
@@ -183,7 +183,7 @@ readable than other YAML representations.
 For example, this YAML is closer to the normal YAML method of expressing lists:
 
 ```yaml
-arguments: 
+arguments:
   - "--dirname"
   - "/foo"
 ```

--- a/content/docs/topics/chart_repository.md
+++ b/content/docs/topics/chart_repository.md
@@ -73,7 +73,7 @@ directory that contains packaged charts.
 
 This is an example of an index file:
 
-```
+```yaml
 apiVersion: v1
 entries:
   alpine:

--- a/content/docs/topics/chart_template_guide/accessing_files.md
+++ b/content/docs/topics/chart_template_guide/accessing_files.md
@@ -63,7 +63,7 @@ data:
   {{- end }}
 ```
 
-This config map uses several of the techniques discussed in previous sections. For example, we create a `$files` variable to hold a reference to the `.Files` object. We also use the `tuple` function to create a list of files that we loop through. Then we print each file name (`{{.}}: |-`) followed by the contents of the file `{{ $files.Get . }}`.
+This config map uses several of the techniques discussed in previous sections. For example, we create a `$files` variable to hold a reference to the `.Files` object. We also use the `tuple` function to create a list of files that we loop through. Then we print each file name (`{{ . }}: |-`) followed by the contents of the file `{{ $files.Get . }}`.
 
 Running this template will produce a single ConfigMap with the contents of all three files:
 
@@ -111,7 +111,7 @@ the returned object.
 For example, imagine the directory structure:
 
 ```
-foo/: 
+foo/:
   foo.txt foo.yaml
 
 bar/:

--- a/content/docs/topics/chart_template_guide/builtin_objects.md
+++ b/content/docs/topics/chart_template_guide/builtin_objects.md
@@ -7,7 +7,7 @@ Objects are passed into a template from the template engine. And your code can p
 
 Objects can be simple, and have just one value. Or they can contain other objects or functions. For example. the `Release` object contains several objects (like `Release.Name`) and the `Files` object has a few functions.
 
-In the previous section, we use `{{.Release.Name}}` to insert the name of a release into a template. `Release` is one of the top-level objects that you can access in your templates.
+In the previous section, we use `{{ .Release.Name }}` to insert the name of a release into a template. `Release` is one of the top-level objects that you can access in your templates.
 
 - `Release`: This object describes the release itself. It has several objects inside of it:
   - `Release.Name`: The release name
@@ -15,7 +15,7 @@ In the previous section, we use `{{.Release.Name}}` to insert the name of a rele
   - `Release.IsUpgrade`: This is set to `true` if the current operation is an upgrade or rollback.
   - `Release.IsInstall`: This is set to `true` if the current operation is an install.
 - `Values`: Values passed into the template from the `values.yaml` file and from user-supplied files. By default, `Values` is empty.
-- `Chart`: The contents of the `Chart.yaml` file. Any data in `Chart.yaml` will be accessible here. For example `{{.Chart.Name}}-{{.Chart.Version}}` will print out the `mychart-0.1.0`.
+- `Chart`: The contents of the `Chart.yaml` file. Any data in `Chart.yaml` will be accessible here. For example `{{ .Chart.Name }}-{{ .Chart.Version }}` will print out the `mychart-0.1.0`.
   - The available fields are listed in the [Charts Guide](https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file)
 - `Files`: This provides access to all non-special files in a chart. While you cannot use it to access templates, you can use it to access other files in the chart. See the section _Accessing Files_ for more.
   - `Files.Get` is a function for getting a file by name (`.Files.Get config.ini`)

--- a/content/docs/topics/chart_template_guide/control_structures.md
+++ b/content/docs/topics/chart_template_guide/control_structures.md
@@ -78,7 +78,7 @@ data:
 
 While we're looking at conditionals, we should take a quick look at the way whitespace is controlled in templates. Let's take the previous example and format it to be a little easier to read:
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -87,9 +87,9 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{if eq .Values.favorite.drink "coffee"}}
+  {{ if eq .Values.favorite.drink "coffee" }}
     mug: true
-  {{end}}
+  {{ end }}
 ```
 
 Initially, this looks good. But if we run it through the template engine, we'll get an unfortunate result:
@@ -101,7 +101,7 @@ CHART PATH: /Users/mattbutcher/Code/Go/src/helm.sh/helm/_scratch/mychart
 Error: YAML parse error on mychart/templates/configmap.yaml: error converting YAML to JSON: yaml: line 9: did not find expected key
 ```
 
-What happened? We generated incorrect YAML because of the whitespacing above. 
+What happened? We generated incorrect YAML because of the whitespacing above.
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -118,7 +118,7 @@ data:
 
 `mug` is incorrectly indented. Let's simply out-dent that one line, and re-run:
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -127,9 +127,9 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{if eq .Values.favorite.drink "coffee"}}
+  {{ if eq .Values.favorite.drink "coffee" }}
   mug: true
-  {{end}}
+  {{ end }}
 ```
 
 When we sent that, we'll get YAML that is valid, but still looks a little funny:
@@ -155,7 +155,7 @@ YAML ascribes meaning to whitespace, so managing the whitespace becomes pretty i
 
 First, the curly brace syntax of template declarations can be modified with special characters to tell the template engine to chomp whitespace. `{{- ` (with the dash and space added) indicates that whitespace should be chomped left, while ` -}}` means whitespace to the right should be consumed. _Be careful! Newlines are whitespace!_
 
-> Make sure there is a space between the `-` and the rest of your directive. `{{- 3 }}` means "trim left whitespace and print 3" while `{{-3}}` means "print -3".
+> Make sure there is a space between the `-` and the rest of your directive. `{{- 3 }}` means "trim left whitespace and print 3" while `{{-3 }}` means "print -3".
 
 Using this syntax, we can modify our template to get rid of those new lines:
 
@@ -168,9 +168,9 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}
-  {{- if eq .Values.favorite.drink "coffee"}}
+  {{- if eq .Values.favorite.drink "coffee" }}
   mug: true
-  {{- end}}
+  {{- end }}
 ```
 
 Just for the sake of making this point clear, let's adjust the above, and substitute an `*` for each whitespace that will be deleted following this rule. an `*` at the end of the line indicates a newline character that would be removed
@@ -184,9 +184,9 @@ data:
   myvalue: "Hello World"
   drink: {{ .Values.favorite.drink | default "tea" | quote }}
   food: {{ .Values.favorite.food | upper | quote }}*
-**{{- if eq .Values.favorite.drink "coffee"}}
+**{{- if eq .Values.favorite.drink "coffee" }}
   mug: true*
-**{{- end}}
+**{{- end }}
 
 ```
 
@@ -219,7 +219,7 @@ That will produce `food: "PIZZA"mug:true` because it consumed newlines on both s
 
 > For the details on whitespace control in templates, see the [Official Go template documentation](https://godoc.org/text/template)
 
-Finally, sometimes it's easier to tell the template system how to indent for you instead of trying to master the spacing of template directives. For that reason, you may sometimes find it useful to use the `indent` function (`{{indent 2 "mug:true"}}`).
+Finally, sometimes it's easier to tell the template system how to indent for you instead of trying to master the spacing of template directives. For that reason, you may sometimes find it useful to use the `indent` function (`{{ indent 2 "mug:true" }}`).
 
 ## Modifying scope using `with`
 
@@ -262,7 +262,7 @@ But here's a note of caution! Inside of the restricted scope, you will not be ab
   {{- end }}
 ```
 
-It will produce an error because `Release.Name` is not inside of the restricted scope for `.`. However, if we swap the last two lines, all will work as expected because the scope is reset after `{{end}}`.
+It will produce an error because `Release.Name` is not inside of the restricted scope for `.`. However, if we swap the last two lines, all will work as expected because the scope is reset after `{{ end }}`.
 
 ```yaml
   {{- with .Values.favorite }}

--- a/content/docs/topics/chart_template_guide/debugging.md
+++ b/content/docs/topics/chart_template_guide/debugging.md
@@ -15,7 +15,7 @@ When your YAML is failing to parse, but you want to see what is generated, one
 easy way to retrieve the YAML is to comment out the problem section in the template,
 and then re-run `helm install --dry-run --debug`:
 
-```YAML
+```yaml
 apiVersion: v1
 # some: problem section
 # {{ .Values.foo | quote }}
@@ -23,7 +23,7 @@ apiVersion: v1
 
 The above will be rendered and returned with the comments intact:
 
-```YAML
+```yaml
 apiVersion: v1
 # some: problem section
 #  "bar"

--- a/content/docs/topics/chart_template_guide/functions_and_pipelines.md
+++ b/content/docs/topics/chart_template_guide/functions_and_pipelines.md
@@ -7,7 +7,7 @@ So far, we've seen how to place information into a template. But that informatio
 
 Let's start with a best practice: When injecting strings from the `.Values` object into the template, we ought to quote these strings. We can do that by calling the `quote` function in the template directive:
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -107,7 +107,7 @@ drink: {{ .Values.favorite.drink | default "tea" | quote }}
 
 If we run this as normal, we'll get our `coffee`:
 
-```
+```yaml
 # Source: mychart/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/content/docs/topics/chart_template_guide/named_templates.md
+++ b/content/docs/topics/chart_template_guide/named_templates.md
@@ -194,7 +194,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-configmap
   labels:
-    {{ template "mychart.app" .}}
+    {{ template "mychart.app" . }}
 data:
   myvalue: "Hello World"
   {{- range $key, $val := .Values.favorite }}

--- a/content/docs/topics/chart_template_guide/subcharts_and_globals.md
+++ b/content/docs/topics/chart_template_guide/subcharts_and_globals.md
@@ -37,7 +37,7 @@ dessert: cake
 
 Next, we'll create a new ConfigMap template in `mychart/charts/mysubchart/templates/configmap.yaml`:
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -127,7 +127,7 @@ global:
   salad: caesar
 ```
 
-Because of the way globals work, both `mychart/templates/configmap.yaml` and `mysubchart/templates/configmap.yaml` should be able to access that value as `{{ .Values.global.salad}}`.
+Because of the way globals work, both `mychart/templates/configmap.yaml` and `mysubchart/templates/configmap.yaml` should be able to access that value as `{{ .Values.global.salad }}`.
 
 `mychart/templates/configmap.yaml`:
 

--- a/content/docs/topics/chart_template_guide/values_files.md
+++ b/content/docs/topics/chart_template_guide/values_files.md
@@ -32,7 +32,7 @@ data:
   drink: {{ .Values.favoriteDrink }}
 ```
 
-Notice on the last line we access `favoriteDrink` as an attribute of `Values`: `{{ .Values.favoriteDrink}}`.
+Notice on the last line we access `favoriteDrink` as an attribute of `Values`: `{{ .Values.favoriteDrink }}`.
 
 Let's see how this renders.
 
@@ -57,7 +57,7 @@ data:
 
 Because `favoriteDrink` is set in the default `values.yaml` file to `coffee`, that's the value displayed in the template. We can easily override that by adding a `--set` flag in our call to `helm install`:
 
-```
+```console
 helm install --dry-run --debug --set favoriteDrink=slurm ./mychart
 SERVER: "localhost:44134"
 CHART PATH: /Users/mattbutcher/Code/Go/src/helm.sh/helm/_scratch/mychart
@@ -88,7 +88,7 @@ favorite:
 
 Now we would have to modify the template slightly:
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/content/docs/topics/chart_template_guide/variables.md
+++ b/content/docs/topics/chart_template_guide/variables.md
@@ -82,7 +82,7 @@ data:
   myvalue: "Hello World"
   {{- range $key, $val := .Values.favorite }}
   {{ $key }}: {{ $val | quote }}
-  {{- end}}
+  {{- end }}
 ```
 
 Now on the first iteration, `$key` will be `drink` and `$val` will be `coffee`, and on the second, `$key` will be `food` and `$val` will be `pizza`. Running the above will generate this:
@@ -99,7 +99,7 @@ data:
   food: "pizza"
 ```
 
-Variables are normally not "global". They are scoped to the block in which they are declared. Earlier, we assigned `$relname` in the top level of the template. That variable will be in scope for the entire template. But in our last example, `$key` and `$val` will only be in scope inside of the `{{range...}}{{end}}` block.
+Variables are normally not "global". They are scoped to the block in which they are declared. Earlier, we assigned `$relname` in the top level of the template. That variable will be in scope for the entire template. But in our last example, `$key` and `$val` will only be in scope inside of the `{{ range... }}{{ end }}` block.
 
 However, there is one variable that is always global - `$` - this
 variable will always point to the root context.  This can be very
@@ -114,8 +114,8 @@ kind: Secret
 metadata:
   name: {{ .name }}
   labels:
-    # Many helm templates would use `.` below, but that will not work, 
-    # however `$` will work here 
+    # Many helm templates would use `.` below, but that will not work,
+    # however `$` will work here
     app.kubernetes.io/name: {{ template "fullname" $ }}
     # I cannot reference .Chart.Name, but I can do $.Chart.Name
     helm.sh/chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"

--- a/content/docs/topics/chart_template_guide/yaml_techniques.md
+++ b/content/docs/topics/chart_template_guide/yaml_techniques.md
@@ -180,7 +180,7 @@ Now the value of `coffee` will be `Latte\nCappuccino\nEspresso\n\n\n`.
 Indentation inside of a text block is preserved, and results in the preservation
 of line breaks, too:
 
-```
+```yaml
 coffee: |-
   Latte
     12 oz
@@ -339,7 +339,7 @@ reference is expanded and then discarded.
 So if we were to decode and then re-encode the example above, the resulting
 YAML would be:
 
-```YAML
+```yaml
 coffee: yes, please
 favorite: Cappucino
 coffees:

--- a/content/docs/topics/chart_tests.md
+++ b/content/docs/topics/chart_tests.md
@@ -37,7 +37,7 @@ mariadb/
   templates/tests/test-mariadb-connection.yaml
 ```
 In `wordpress/templates/tests/test-mariadb-connection.yaml`:
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:

--- a/content/docs/topics/charts.md
+++ b/content/docs/topics/charts.md
@@ -266,7 +266,7 @@ Tags - The tags field is a YAML list of labels to associate with this chart.
 In the top parent's values, all charts with tags can be enabled or disabled by
 specifying the tag and a boolean value.
 
-````
+```yaml
 # parentchart/Chart.yaml
 dependencies:
       - name: subchart1
@@ -285,8 +285,8 @@ dependencies:
           - back-end
           - subchart2
 
-````
-````
+```
+```yaml
 # parentchart/values.yaml
 
 subchart1:
@@ -294,7 +294,7 @@ subchart1:
 tags:
   front-end: false
   back-end: true
-````
+```
 
 In the above example all charts with the tag `front-end` would be disabled but since the
 `subchart1.enabled` path evaluates to 'true' in the parent's values, the condition will override the
@@ -308,10 +308,10 @@ is no corresponding path and value in the parent's values so that condition has 
 
 The `--set` parameter can be used as usual to alter tag and condition values.
 
-````
+```console
 helm install --set tags.front-end=true --set subchart2.enabled=false
 
-````
+```
 
 ##### Tags and Condition Resolution
 
@@ -442,7 +442,7 @@ For example, if the WordPress chart depends on the Apache chart, the
 Apache chart (of the correct version) is supplied in the WordPress
 chart's `charts/` directory:
 
-```
+```yaml
 wordpress:
   Chart.yaml
   # ...
@@ -550,13 +550,13 @@ spec:
       serviceAccount: deis-database
       containers:
         - name: deis-database
-          image: {{.Values.imageRegistry}}/postgres:{{.Values.dockerTag}}
-          imagePullPolicy: {{.Values.pullPolicy}}
+          image: {{ .Values.imageRegistry }}/postgres:{{ .Values.dockerTag }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
             - containerPort: 5432
           env:
             - name: DATABASE_STORAGE
-              value: {{default "minio" .Values.storage}}
+              value: {{ default "minio" .Values.storage }}
 ```
 
 The above example, based loosely on [https://github.com/deis/charts](https://github.com/deis/charts), is a template for a Kubernetes replication controller.
@@ -596,12 +596,12 @@ sensitive_.
 - `Files`: A map-like object containing all non-special files in the chart. This
   will not give you access to templates, but will give you access to additional
   files that are present (unless they are excluded using `.helmignore`). Files can be
-  accessed using `{{index .Files "file.name"}}` or using the `{{.Files.Get name}}` or
-  `{{.Files.GetString name}}` functions. You can also access the contents of the file
-  as `[]byte` using `{{.Files.GetBytes}}`
+  accessed using `{{ index .Files "file.name" }}` or using the `{{ .Files.Get name }}` or
+  `{{ .Files.GetString name }}` functions. You can also access the contents of the file
+  as `[]byte` using `{{ .Files.GetBytes }}`
 - `Capabilities`: A map-like object that contains information about the versions
-  of Kubernetes (`{{.Capabilities.KubeVersion}}` and the supported Kubernetes
- API versions (`{{.Capabilities.APIVersions.Has "batch/v1"`)
+  of Kubernetes (`{{ .Capabilities.KubeVersion }}` and the supported Kubernetes
+ API versions (`{{ .Capabilities.APIVersions.Has "batch/v1" }}`)
 
 **NOTE:** Any unknown Chart.yaml fields will be dropped. They will not
 be accessible inside of the `Chart` object. Thus, Chart.yaml cannot be
@@ -681,13 +681,13 @@ spec:
       serviceAccount: deis-database
       containers:
         - name: deis-database
-          image: {{.Values.imageRegistry}}/postgres:{{.Values.dockerTag}}
-          imagePullPolicy: {{.Values.pullPolicy}}
+          image: {{ .Values.imageRegistry }}/postgres:{{ .Values.dockerTag }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
             - containerPort: 5432
           env:
             - name: DATABASE_STORAGE
-              value: {{default "minio" .Values.storage}}
+              value: {{ default "minio" .Values.storage }}
 
 ```
 
@@ -746,7 +746,7 @@ apache:
 The above adds a `global` section with the value `app: MyWordPress`.
 This value is available to _all_ charts as `.Values.global.app`.
 
-For example, the `mysql` templates may access `app` as `{{.Values.global.app}}`, and
+For example, the `mysql` templates may access `app` as `{{ .Values.global.app }}`, and
 so can the `apache` chart. Effectively, the values file above is
 regenerated like this:
 
@@ -852,9 +852,9 @@ name: frontend
 protocol: https
 ```
 
-````
+```console
 helm install --set port=443
-````
+```
 
 Furthermore, the final `.Values` object is checked against *all* subchart
 schemas. This means that restrictions on a subchart can't be circumvented by a

--- a/content/docs/topics/charts_hooks.md
+++ b/content/docs/topics/charts_hooks.md
@@ -115,12 +115,12 @@ declares a job to be run on `post-install`:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{.Release.Name}}"
+  name: "{{ .Release.Name }}"
   labels:
-    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
-    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -130,30 +130,30 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{.Release.Name}}"
+      name: "{{ .Release.Name }}"
       labels:
-        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
-        app.kubernetes.io/instance: {{.Release.Name | quote }}
-        helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       restartPolicy: Never
       containers:
       - name: post-install-job
         image: "alpine:3.3"
-        command: ["/bin/sleep","{{default "10" .Values.sleepyTime}}"]
+        command: ["/bin/sleep","{{ default "10" .Values.sleepyTime }}"]
 
 ```
 
 What makes this template a hook is the annotation:
 
-```
+```yaml
   annotations:
     "helm.sh/hook": post-install
 ```
 
 One resource can implement multiple hooks:
 
-```
+```yaml
   annotations:
     "helm.sh/hook": post-install,post-upgrade
 ```
@@ -175,11 +175,11 @@ deterministic executing order. Weights are defined using the following annotatio
 
 Hook weights can be positive or negative numbers but must be represented as
 strings. When Helm starts the execution cycle of hooks of a particular Kind it
-will sort those hooks in ascending order. 
+will sort those hooks in ascending order.
 
 It is also possible to define policies that determine when to delete corresponding hook resources. Hook deletion policies are defined using the following annotation:
 
-```
+```yaml
   annotations:
     "helm.sh/hook-delete-policy": hook-succeeded
 ```

--- a/content/docs/topics/plugins.md
+++ b/content/docs/topics/plugins.md
@@ -63,7 +63,7 @@ script, `keybase.sh` (optional).
 The core of a plugin is a simple YAML file named `plugin.yaml`.
 Here is a plugin YAML for a plugin that adds support for Keybase operations:
 
-```
+```yaml
 name: "last"
 version: "0.1.0"
 usage: "get the last release name"
@@ -140,7 +140,7 @@ can have a special capability to download Charts from arbitrary sources.
 
 Plugins shall declare this special capability in the `plugin.yaml` file (top level):
 
-```
+```yaml
 downloaders:
 - command: "bin/mydownloader"
   protocols:

--- a/content/docs/topics/provenance.md
+++ b/content/docs/topics/provenance.md
@@ -33,7 +33,7 @@ that passphrase for any commands that support the `--sign` option.
 
 Creating a new chart is the same as before:
 
-```
+```console
 $ helm create mychart
 Creating mychart
 ```
@@ -41,7 +41,7 @@ Creating mychart
 Once ready to package, add the `--sign` flag to `helm package`. Also, specify
 the name under which the signing key is known and the keyring containing the corresponding private key:
 
-```
+```console
 $ helm package --sign --key 'helm signing key' --keyring path/to/keyring.secret mychart
 ```
 
@@ -50,7 +50,7 @@ use `gpg --list-secret-keys` to list the keys you have.
 
 **Warning:**  the GnuPG v2 store your secret keyring using a new format 'kbx' on the default location  '~/.gnupg/pubring.kbx'. Please use the following command to convert your keyring to the legacy gpg format:
 
-```
+```console
 $ gpg --export-secret-keys >~/.gnupg/secring.gpg
 ```
 
@@ -59,20 +59,20 @@ Both files should eventually be uploaded to your desired chart repository.
 
 You can verify a chart using `helm verify`:
 
-```
+```console
 $ helm verify mychart-0.1.0.tgz
 ```
 
 A failed verification looks like this:
 
-```
+```console
 $ helm verify topchart-0.1.0.tgz
 Error: sha256 sum does not match for topchart-0.1.0.tgz: "sha256:1939fbf7c1023d2f6b865d137bbb600e0c42061c3235528b1e8c82f4450c12a7" != "sha256:5a391a90de56778dd3274e47d789a2c84e0e106e1a37ef8cfa51fd60ac9e623a"
 ```
 
 To verify during an install, use the `--verify` flag.
 
-```
+```console
 $ helm install --verify mychart-0.1.0.tgz
 ```
 
@@ -97,7 +97,7 @@ Prerequisites:
 
 The first step is to import your keybase keys into your local GnuPG keyring:
 
-```
+```console
 $ keybase pgp export -s | gpg --import
 ```
 
@@ -106,7 +106,7 @@ locally into your `~/.gnupg/secring.gpg` file.
 
 You can double check by running `gpg --list-secret-keys`.
 
-```
+```console
 $ gpg --list-secret-keys                                                                                                       1 ↵
 /Users/mattbutcher/.gnupg/secring.gpg
 -------------------------------------
@@ -126,7 +126,7 @@ That is the full name of your key.
 Next, you can package and sign a chart with `helm package`. Make sure you use at
 least part of that name string in `--key`.
 
-```
+```console
 $ helm package --sign --key technosophos --keyring ~/.gnupg/secring.gpg mychart
 ```
 
@@ -139,7 +139,7 @@ You can also use a similar technique to verify a chart signed by someone else's
 Keybase key. Say you want to verify a package signed by `keybase.io/technosophos`.
 To do this, use the `keybase` tool:
 
-```
+```console
 $ keybase follow technosophos
 $ keybase pgp pull
 ```
@@ -151,7 +151,7 @@ your GnuPG keyring (`~/.gnupg/pubring.gpg`).
 At this point, you can now use `helm verify` or any of the commands with a `--verify`
 flag:
 
-```
+```console
 $ helm verify somechart-1.2.3.tgz
 ```
 

--- a/content/docs/topics/registries.md
+++ b/content/docs/topics/registries.md
@@ -14,14 +14,14 @@ Currently OCI support is considered *experimental*.
 In order to use the commands described below,
 please set `HELM_EXPERIMENTAL_OCI` in the enironment:
 
-```
+```console
 export HELM_EXPERIMENTAL_OCI=1
 ```
 
 ## Running a registry
 
 Starting a registry for test purposes is trivial. As long as you have Docker installed, run the following command:
-```
+```console
 docker run -dp 5000:5000 --restart=always --name registry registry
 ```
 
@@ -38,12 +38,12 @@ For more configuration options, please see [the docs](https://docs.docker.com/re
 If you wish to enable auth on the registry, you can do the following-
 
 First, create file `auth.htpasswd` with username and password combo:
-```
+```console
 htpasswd -cB -b auth.htpasswd myuser mypass
 ```
 
 Then, start the server, mounting that file and setting the `REGISTRY_AUTH` env var:
-```
+```console
 docker run -dp 5000:5000 --restart=always --name registry \
   -v $(pwd)/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
   -e REGISTRY_AUTH="{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}" \
@@ -60,7 +60,7 @@ Commands are available under both `helm registry` and `helm chart` that allow yo
 
 login to a registry (with manual password entry)
 
-```
+```console
 $ helm registry login -u myuser localhost:5000
 Password:
 Login succeeded
@@ -70,7 +70,7 @@ Login succeeded
 
 logout from a registry
 
-```
+```console
 $ helm registry logout localhost:5000
 Logout succeeded
 ```
@@ -81,7 +81,7 @@ Logout succeeded
 
 save a chart directory to local cache
 
-```
+```console
 $ helm chart save mychart/ localhost:5000/myrepo/mychart:2.7.0
 ref:     localhost:5000/myrepo/mychart:2.7.0
 digest:  1b251d38cfe948dfc0a5745b7af5ca574ecb61e52aed10b19039db39af6e1617
@@ -95,7 +95,7 @@ version: 0.1.0
 
 list all saved charts
 
-```
+```console
 $ helm chart list
 REF                                                     NAME                    VERSION DIGEST  SIZE            CREATED
 localhost:5000/myrepo/mychart:2.7.0                     mychart                 2.7.0   84059d7 454 B           27 seconds
@@ -110,7 +110,7 @@ localhost:5000/stable/anchore-engine:0.10.0             anchore-engine          
 
 export a chart to directory
 
-```
+```console
 $ helm chart export localhost:5000/myrepo/mychart:2.7.0
 ref:     localhost:5000/myrepo/mychart:2.7.0
 digest:  1b251d38cfe948dfc0a5745b7af5ca574ecb61e52aed10b19039db39af6e1617
@@ -124,7 +124,7 @@ Exported chart to mychart/
 
 push a chart to remote
 
-```
+```console
 $ helm chart push localhost:5000/myrepo/mychart:2.7.0
 The push refers to repository [localhost:5000/myrepo/mychart]
 ref:     localhost:5000/myrepo/mychart:2.7.0
@@ -139,7 +139,7 @@ version: 0.1.0
 
 remove a chart from cache
 
-```
+```console
 $ helm chart remove localhost:5000/myrepo/mychart:2.7.0
 2.7.0: removed
 ```
@@ -148,7 +148,7 @@ $ helm chart remove localhost:5000/myrepo/mychart:2.7.0
 
 pull a chart from remote
 
-```
+```console
 $ helm chart pull localhost:5000/myrepo/mychart:2.7.0
 2.7.0: Pulling from localhost:5000/myrepo/mychart
 ref:     localhost:5000/myrepo/mychart:2.7.0
@@ -165,7 +165,7 @@ Charts stored using the commands above will be cached on the filesystem.
 
 The [OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/master/image-layout.md)
 is adhered to strictly for filesystem layout, for example:
-```
+```console
 $ tree ~/Library/Caches/helm/
 /Users/myuser/Library/Caches/helm/
 └── registry
@@ -182,7 +182,7 @@ $ tree ~/Library/Caches/helm/
 ```
 
 Example index.json, which contains refs to all Helm chart manifests:
-```
+```console
 $ cat ~/Library/Caches/helm/registry/cache/index.json  | jq
 {
   "schemaVersion": 2,
@@ -200,7 +200,7 @@ $ cat ~/Library/Caches/helm/registry/cache/index.json  | jq
 ```
 
 Example Helm chart manifest (note the `mediaType` fields):
-```
+```console
 $ cat ~/Library/Caches/helm/registry/cache/blobs/sha256/31fb454efb3c69fafe53672598006790122269a1b3b458607dbe106aba7059ef | jq
 {
   "schemaVersion": 2,


### PR DESCRIPTION
* Improve syntax highlighting
* Use space after/before `{{`/`}}` to be consistent
  with the scaffolding chart and with what we require in the
  charts repo
