### PR TITLE
Formats all docs to use same wrapping

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,9 +5,16 @@ description: "Everything you need to know about how the documentation is organiz
 
 # How the documentation is organized
 
-Helm has a lot of documentation. A high-level overview of how it’s organized will help you know where to look for certain things:
+Helm has a lot of documentation. A high-level overview of how it’s organized
+will help you know where to look for certain things:
 
-- [Tutorials](intro) take you by the hand through a series of steps to create your first Helm chart. Start here if you’re new to Helm.
-- [Topic guides](topics) discuss key topics and concepts at a fairly high level and provide useful background information and explanation.
-- [Community Guides](community) discuss topics centered around Helm’s community. Start here if you want to learn more about the development process of Helm itself and how you can contribute.
-- [How-to guides](howto) are recipes. They guide you through the steps involved in addressing key problems and use-cases. They are more advanced than tutorials and assume some knowledge of how Helm works.
+- [Tutorials](intro) take you by the hand through a series of steps to create
+  your first Helm chart. Start here if you’re new to Helm.
+- [Topic guides](topics) discuss key topics and concepts at a fairly high level
+  and provide useful background information and explanation.
+- [Community Guides](community) discuss topics centered around Helm’s community.
+  Start here if you want to learn more about the development process of Helm
+  itself and how you can contribute.
+- [How-to guides](howto) are recipes. They guide you through the steps involved
+  in addressing key problems and use-cases. They are more advanced than
+  tutorials and assume some knowledge of how Helm works.

--- a/content/docs/community/_index.md
+++ b/content/docs/community/_index.md
@@ -5,4 +5,5 @@ weight: 6
 
 # Community Guides
 
-Learn here about the development process for the Helm project itself and how you can contribute.
+Learn here about the development process for the Helm project itself and how you
+can contribute.

--- a/content/docs/community/developers.md
+++ b/content/docs/community/developers.md
@@ -4,8 +4,7 @@ description: "Instructions for setting up your environment for developing Helm."
 weight: 1
 ---
 
-This guide explains how to set up your environment for developing on
-Helm.
+This guide explains how to set up your environment for developing on Helm.
 
 ## Prerequisites
 
@@ -22,15 +21,15 @@ We use Make to build our programs. The simplest way to get started is:
 $ make
 ```
 
-NOTE: This will fail if not running from the path `$GOPATH/src/helm.sh/helm`. The
-directory `helm.sh` should not be a symlink or `build` will not find the relevant
-packages.
+NOTE: This will fail if not running from the path `$GOPATH/src/helm.sh/helm`.
+The directory `helm.sh` should not be a symlink or `build` will not find the
+relevant packages.
 
-If required, this will first install dependencies, rebuild the `vendor/` tree, and
-validate configuration. It will then compile `helm` and place it in `bin/helm`.
+If required, this will first install dependencies, rebuild the `vendor/` tree,
+and validate configuration. It will then compile `helm` and place it in
+`bin/helm`.
 
-To run all the tests (without running the tests for `vendor/`), run
-`make test`.
+To run all the tests (without running the tests for `vendor/`), run `make test`.
 
 To run Helm locally, you can run `bin/helm`.
 
@@ -54,22 +53,22 @@ $ man helm
 
 To build Docker images, use `make docker-build`.
 
-Pre-build images are already available in the official Kubernetes Helm
-GCR registry.
+Pre-build images are already available in the official Kubernetes Helm GCR
+registry.
 
 ## Running a Local Cluster
 
-For development, we highly recommend using the
-[Kubernetes Minikube](https://github.com/kubernetes/minikube)
-developer-oriented distribution.
+For development, we highly recommend using the [Kubernetes
+Minikube](https://github.com/kubernetes/minikube) developer-oriented
+distribution.
 
 ## Contribution Guidelines
 
-We welcome contributions. This project has set up some guidelines in
-order to ensure that (a) code quality remains high, (b) the project
-remains consistent, and (c) contributions follow the open source legal
-requirements. Our intent is not to burden contributors, but to build
-elegant and high-quality open source code so that our users will benefit.
+We welcome contributions. This project has set up some guidelines in order to
+ensure that (a) code quality remains high, (b) the project remains consistent,
+and (c) contributions follow the open source legal requirements. Our intent is
+not to burden contributors, but to build elegant and high-quality open source
+code so that our users will benefit.
 
 Make sure you have read and understood the main CONTRIBUTING guide:
 
@@ -79,35 +78,35 @@ https://github.com/helm/helm/blob/master/CONTRIBUTING.md
 
 The code for the Helm project is organized as follows:
 
-- The individual programs are located in `cmd/`. Code inside of `cmd/`
-  is not designed for library re-use.
+- The individual programs are located in `cmd/`. Code inside of `cmd/` is not
+  designed for library re-use.
 - Shared libraries are stored in `pkg/`.
 - The `scripts/` directory contains a number of utility scripts. Most of these
   are used by the CI/CD pipeline.
 - The `docs/` folder is used for documentation and examples.
 
-Go dependencies are managed with
-[Dep](https://github.com/golang/dep) and stored in the
-`vendor/` directory.
+Go dependencies are managed with [Dep](https://github.com/golang/dep) and stored
+in the `vendor/` directory.
 
 ### Git Conventions
 
-We use Git for our version control system. The `master` branch is the
-home of the current development candidate. Releases are tagged.
+We use Git for our version control system. The `master` branch is the home of
+the current development candidate. Releases are tagged.
 
-We accept changes to the code via GitHub Pull Requests (PRs). One
-workflow for doing this is as follows:
+We accept changes to the code via GitHub Pull Requests (PRs). One workflow for
+doing this is as follows:
 
-1. Go to your `$GOPATH/src` directory, then `mkdir helm.sh; cd helm.sh` and `git clone` the
-   `github.com/helm/helm` repository.
+1. Go to your `$GOPATH/src` directory, then `mkdir helm.sh; cd helm.sh` and `git
+   clone` the `github.com/helm/helm` repository.
 2. Fork that repository into your GitHub account
 3. Add your repository as a remote for `$GOPATH/src/helm.sh/helm`
-4. Create a new working branch (`git checkout -b feat/my-feature`) and
-   do your work on that branch.
-5. When you are ready for us to review, push your branch to GitHub, and
-   then open a new pull request with us.
+4. Create a new working branch (`git checkout -b feat/my-feature`) and do your
+   work on that branch.
+5. When you are ready for us to review, push your branch to GitHub, and then
+   open a new pull request with us.
 
-For Git commit messages, we follow the [Semantic Commit Messages](http://karma-runner.github.io/0.13/dev/git-commit-msg.html):
+For Git commit messages, we follow the [Semantic Commit
+Messages](http://karma-runner.github.io/0.13/dev/git-commit-msg.html):
 
 ```
 fix(helm): add --foo flag to 'helm install'
@@ -129,24 +128,28 @@ Common commit types:
 Common scopes:
 
 - helm: The Helm CLI
-- pkg/lint: The lint package. Follow a similar convention for any
-  package
+- pkg/lint: The lint package. Follow a similar convention for any package
 - `*`: two or more scopes
 
 Read more:
-- The [Deis Guidelines](https://github.com/deis/workflow/blob/master/src/contributing/submitting-a-pull-request.md)
+- The [Deis
+  Guidelines](https://github.com/deis/workflow/blob/master/src/contributing/submitting-a-pull-request.md)
   were the inspiration for this section.
-- Karma Runner [defines](http://karma-runner.github.io/0.13/dev/git-commit-msg.html) the semantic commit message idea.
+- Karma Runner
+  [defines](http://karma-runner.github.io/0.13/dev/git-commit-msg.html) the
+  semantic commit message idea.
 
 ### Go Conventions
 
-We follow the Go coding style standards very closely. Typically, running
-`go fmt` will make your code beautiful for you.
+We follow the Go coding style standards very closely. Typically, running `go
+fmt` will make your code beautiful for you.
 
 We also typically follow the conventions recommended by `go lint` and
 `gometalinter`. Run `make test-style` to test the style conformance.
 
 Read more:
 
-- Effective Go [introduces formatting](https://golang.org/doc/effective_go.html#formatting).
-- The Go Wiki has a great article on [formatting](https://github.com/golang/go/wiki/CodeReviewComments).
+- Effective Go [introduces
+  formatting](https://golang.org/doc/effective_go.html#formatting).
+- The Go Wiki has a great article on
+  [formatting](https://github.com/golang/go/wiki/CodeReviewComments).

--- a/content/docs/community/history.md
+++ b/content/docs/community/history.md
@@ -5,27 +5,29 @@ description: "Provides a high-level overview of the project's history."
 
 Kubernetes Helm is the merged result of [Helm
 Classic](https://github.com/helm/helm) and the Kubernetes port of GCS Deployment
-Manager. The project was jointly started by Google and Deis, though it
-is now part of the CNCF. Many companies now contribute regularly to Helm.
+Manager. The project was jointly started by Google and Deis, though it is now
+part of the CNCF. Many companies now contribute regularly to Helm.
 
 Differences from Helm Classic:
 
-- Helm now has both a client (`helm`) and a library. In version 2 it had a server (`tiller`) but the capability is now contained within the library. 
+- Helm now has both a client (`helm`) and a library. In version 2 it had a
+  server (`tiller`) but the capability is now contained within the library. 
 - Helm's chart format has changed for the better:
   - Dependencies are immutable and stored inside of a chart's `charts/`
     directory.
-  - Charts are strongly versioned using [SemVer 2](http://semver.org/spec/v2.0.0.html)
+  - Charts are strongly versioned using [SemVer
+    2](http://semver.org/spec/v2.0.0.html)
   - Charts can be loaded from directories or from chart archive files
-  - Helm supports Go templates without requiring you to run `generate`
-    or `template` commands.
-  - Helm makes it easy to configure your releases -- and share the
-    configuration with the rest of your team.
-- Helm chart repositories now use plain HTTP(S) instead of Git/GitHub.
-  There is no longer any GitHub dependency.
+  - Helm supports Go templates without requiring you to run `generate` or
+    `template` commands.
+  - Helm makes it easy to configure your releases -- and share the configuration
+    with the rest of your team.
+- Helm chart repositories now use plain HTTP(S) instead of Git/GitHub. There is
+  no longer any GitHub dependency.
   - A chart server is a simple HTTP server
   - Charts are referenced by version
-  - The `helm serve` command will run a local chart server, though you
-    can easily use object storage (S3, GCS) or a regular web server.
+  - The `helm serve` command will run a local chart server, though you can
+    easily use object storage (S3, GCS) or a regular web server.
   - And you can still load charts from a local directory.
-- The Helm workspace is gone. You can now work anywhere on your
-  filesystem that you want to work.
+- The Helm workspace is gone. You can now work anywhere on your filesystem that
+  you want to work.

--- a/content/docs/community/related.md
+++ b/content/docs/community/related.md
@@ -4,72 +4,130 @@ description: "third-party tools, plugins and documentation provided by the commu
 weight: 3
 ---
 
-The Helm community has produced many extra tools, plugins, and documentation about
-Helm. We love to hear about these projects. If you have anything you'd like to
-add to this list, please open an [issue](https://github.com/helm/helm/issues)
-or [pull request](https://github.com/helm/helm/pulls).
+The Helm community has produced many extra tools, plugins, and documentation
+about Helm. We love to hear about these projects. If you have anything you'd
+like to add to this list, please open an
+[issue](https://github.com/helm/helm/issues) or [pull
+request](https://github.com/helm/helm/pulls).
 
 ## Article, Blogs, How-Tos, and Extra Documentation
 
-- [Using Helm to Deploy to Kubernetes](https://daemonza.github.io/2017/02/20/using-helm-to-deploy-to-kubernetes/)
-- [Honestbee's Helm Chart Conventions](https://gist.github.com/so0k/f927a4b60003cedd101a0911757c605a)
-- [Deploying Kubernetes Applications with Helm](http://cloudacademy.com/blog/deploying-kubernetes-applications-with-helm/)
-- [Releasing backward-incompatible changes: Kubernetes, Jenkins, Prometheus Operator, Helm and Traefik](https://medium.com/@enxebre/releasing-backward-incompatible-changes-kubernetes-jenkins-plugin-prometheus-operator-helm-self-6263ca61a1b1#.e0c7elxhq)
-- [CI/CD with Kubernetes, Helm & Wercker ](http://www.slideshare.net/Diacode/cicd-with-kubernetes-helm-wercker-madscalability)
-- [The missing CI/CD Kubernetes component: Helm package manager](https://hackernoon.com/the-missing-ci-cd-kubernetes-component-helm-package-manager-1fe002aac680#.691sk2zhu)
-- [The Workflow "Umbrella" Helm Chart](https://deis.com/blog/2017/workflow-chart-assembly)
-- [GitLab, Consumer Driven Contracts, Helm and Kubernetes](https://medium.com/@enxebre/gitlab-consumer-driven-contracts-helm-and-kubernetes-b7235a60a1cb#.xwp1y4tgi)
-- [Writing a Helm Chart](https://www.influxdata.com/packaged-kubernetes-deployments-writing-helm-chart/)
-- [Creating a Helm Plugin in 3 Steps](http://technosophos.com/2017/03/21/creating-a-helm-plugin.html)
+- [Using Helm to Deploy to
+  Kubernetes](https://daemonza.github.io/2017/02/20/using-helm-to-deploy-to-kubernetes/)
+- [Honestbee's Helm Chart
+  Conventions](https://gist.github.com/so0k/f927a4b60003cedd101a0911757c605a)
+- [Deploying Kubernetes Applications with
+  Helm](http://cloudacademy.com/blog/deploying-kubernetes-applications-with-helm/)
+- [Releasing backward-incompatible changes: Kubernetes, Jenkins, Prometheus
+  Operator, Helm and
+  Traefik](https://medium.com/@enxebre/releasing-backward-incompatible-changes-kubernetes-jenkins-plugin-prometheus-operator-helm-self-6263ca61a1b1#.e0c7elxhq)
+- [CI/CD with Kubernetes, Helm & Wercker
+  ](http://www.slideshare.net/Diacode/cicd-with-kubernetes-helm-wercker-madscalability)
+- [The missing CI/CD Kubernetes component: Helm package
+  manager](https://hackernoon.com/the-missing-ci-cd-kubernetes-component-helm-package-manager-1fe002aac680#.691sk2zhu)
+- [The Workflow "Umbrella" Helm
+  Chart](https://deis.com/blog/2017/workflow-chart-assembly)
+- [GitLab, Consumer Driven Contracts, Helm and
+  Kubernetes](https://medium.com/@enxebre/gitlab-consumer-driven-contracts-helm-and-kubernetes-b7235a60a1cb#.xwp1y4tgi)
+- [Writing a Helm
+  Chart](https://www.influxdata.com/packaged-kubernetes-deployments-writing-helm-chart/)
+- [Creating a Helm Plugin in 3
+  Steps](http://technosophos.com/2017/03/21/creating-a-helm-plugin.html)
 
 ## Video, Audio, and Podcast
 
-- [CI/CD with Jenkins, Kubernetes, and Helm](https://www.youtube.com/watch?v=NVoln4HdZOY): AKA "The Infamous Croc Hunter Video".
-- [KubeCon2016: Delivering Kubernetes-Native Applications by Michelle Noorali](https://www.youtube.com/watch?v=zBc1goRfk3k&index=49&list=PLj6h78yzYM2PqgIGU1Qmi8nY7dqn9PCr4)
-- [Helm with Michelle Noorali and Matthew Butcher](https://gcppodcast.com/post/episode-50-helm-with-michelle-noorali-and-matthew-butcher/): The official Google CloudPlatform Podcast interviews Michelle and Matt about Helm.
+- [CI/CD with Jenkins, Kubernetes, and
+  Helm](https://www.youtube.com/watch?v=NVoln4HdZOY): AKA "The Infamous Croc
+  Hunter Video".
+- [KubeCon2016: Delivering Kubernetes-Native Applications by Michelle
+  Noorali](https://www.youtube.com/watch?v=zBc1goRfk3k&index=49&list=PLj6h78yzYM2PqgIGU1Qmi8nY7dqn9PCr4)
+- [Helm with Michelle Noorali and Matthew
+  Butcher](https://gcppodcast.com/post/episode-50-helm-with-michelle-noorali-and-matthew-butcher/):
+  The official Google CloudPlatform Podcast interviews Michelle and Matt about
+  Helm.
 
 ## Helm Plugins
 
-- [Technosophos's Helm Plugins](https://github.com/technosophos/helm-plugins) - Plugins for GitHub, Keybase, and GPG
-- [helm-template](https://github.com/technosophos/helm-template) - Debug/render templates client-side
-- [Helm Value Store](https://github.com/skuid/helm-value-store) - Plugin for working with Helm deployment values
-- [Helm Diff](https://github.com/databus23/helm-diff) - Preview `helm upgrade` as a coloured diff
-- [helm-env](https://github.com/adamreese/helm-env) - Plugin to show current environment
-- [helm-last](https://github.com/adamreese/helm-last) - Plugin to show the latest release
-- [helm-nuke](https://github.com/adamreese/helm-nuke) - Plugin to destroy all releases
-- [App Registry](https://github.com/app-registry/helm-plugin) - Plugin to manage charts via the [App Registry specification](https://github.com/app-registry/spec)
-- [helm-secrets](https://github.com/futuresimple/helm-secrets) - Plugin to manage and store secrets safely
-- [helm-edit](https://github.com/mstrzele/helm-edit) - Plugin for editing release's values
-- [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories on Google Cloud Storage
-- [helm-github](https://github.com/sagansystems/helm-github) - Plugin to install Helm Charts from Github repositories
-- [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - Plugin to monitor a release and rollback based on Prometheus/ElasticSearch query
-- [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm Charts from hiera using k8comp
-- [helm-hashtag](https://github.com/balboah/helm-hashtag) - Plugin for tracking docker tag hash digests as values
-- [helm-unittest](https://github.com/lrills/helm-unittest) - Plugin for unit testing chart locally with YAML
+- [Technosophos's Helm Plugins](https://github.com/technosophos/helm-plugins) -
+  Plugins for GitHub, Keybase, and GPG
+- [helm-template](https://github.com/technosophos/helm-template) - Debug/render
+  templates client-side
+- [Helm Value Store](https://github.com/skuid/helm-value-store) - Plugin for
+  working with Helm deployment values
+- [Helm Diff](https://github.com/databus23/helm-diff) - Preview `helm upgrade`
+  as a coloured diff
+- [helm-env](https://github.com/adamreese/helm-env) - Plugin to show current
+  environment
+- [helm-last](https://github.com/adamreese/helm-last) - Plugin to show the
+  latest release
+- [helm-nuke](https://github.com/adamreese/helm-nuke) - Plugin to destroy all
+  releases
+- [App Registry](https://github.com/app-registry/helm-plugin) - Plugin to manage
+  charts via the [App Registry
+  specification](https://github.com/app-registry/spec)
+- [helm-secrets](https://github.com/futuresimple/helm-secrets) - Plugin to
+  manage and store secrets safely
+- [helm-edit](https://github.com/mstrzele/helm-edit) - Plugin for editing
+  release's values
+- [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories
+  on Google Cloud Storage
+- [helm-github](https://github.com/sagansystems/helm-github) - Plugin to install
+  Helm Charts from Github repositories
+- [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - Plugin to
+  monitor a release and rollback based on Prometheus/ElasticSearch query
+- [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm
+  Charts from hiera using k8comp
+- [helm-hashtag](https://github.com/balboah/helm-hashtag) - Plugin for tracking
+  docker tag hash digests as values
+- [helm-unittest](https://github.com/lrills/helm-unittest) - Plugin for unit
+  testing chart locally with YAML
 
-We also encourage GitHub authors to use the [helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories)
+We also encourage GitHub authors to use the
+[helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories)
 tag on their plugin repositories.
 
 ## Additional Tools
 
 Tools layered on top of Helm.
 
-- [Quay App Registry](https://coreos.com/blog/quay-application-registry-for-kubernetes.html) - Open Kubernetes application registry, including a Helm access client
-- [Chartify](https://github.com/appscode/chartify) - Generate Helm charts from existing Kubernetes resources.
-- [VIM-Kubernetes](https://github.com/andrewstuart/vim-kubernetes) - VIM plugin for Kubernetes and Helm
-- [Landscaper](https://github.com/Eneco/landscaper/) - "Landscaper takes a set of Helm Chart references with values (a desired state), and realizes this in a Kubernetes cluster."
-- [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative spec for deploying helm charts
-- [Autohelm](https://github.com/reactiveops/autohelm) - Autohelm is _another_ simple declarative spec for deploying helm charts. Written in python and supports git urls as a source for helm charts.
-- [Helmsman](https://github.com/Praqma/helmsman) - Helmsman is a helm-charts-as-code tool which enables installing/upgrading/protecting/moving/deleting releases from version controlled desired state files (described in a simple TOML format).  
-- [Schelm](https://github.com/databus23/schelm) - Render a Helm manifest to a directory
-- [Drone.io Helm Plugin](http://plugins.drone.io/ipedrazas/drone-helm/) - Run Helm inside of the Drone CI/CD system
-- [Cog](https://github.com/ohaiwalt/cog-helm) - Helm chart to deploy Cog on Kubernetes
-- [Monocular](https://github.com/helm/monocular) - Web UI for Helm Chart repositories
-- [Helm Chart Publisher](https://github.com/luizbafilho/helm-chart-publisher) - HTTP API for publishing Helm Charts in an easy way
-- [Armada](https://github.com/att-comdev/armada) - Manage prefixed releases throughout various Kubernetes namespaces, and removes completed jobs for complex deployments. Used by the [Openstack-Helm](https://github.com/openstack/openstack-helm) team.
-- [ChartMuseum](https://github.com/chartmuseum/chartmuseum) - Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
-- [Codefresh](https://codefresh.io) - Kubernetes native CI/CD and management platform with UI dashboards for managing Helm charts and releases
-- [Captain](https://github.com/alauda/captain) - A Helm3 Controller using HelmRequest and Release CRD
+- [Quay App
+  Registry](https://coreos.com/blog/quay-application-registry-for-kubernetes.html) - Open Kubernetes application registry, including a Helm access client
+- [Chartify](https://github.com/appscode/chartify) - Generate Helm charts from
+  existing Kubernetes resources.
+- [VIM-Kubernetes](https://github.com/andrewstuart/vim-kubernetes) - VIM plugin
+  for Kubernetes and Helm
+- [Landscaper](https://github.com/Eneco/landscaper/) - "Landscaper takes a set
+  of Helm Chart references with values (a desired state), and realizes this in a
+  Kubernetes cluster."
+- [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative
+  spec for deploying helm charts
+- [Autohelm](https://github.com/reactiveops/autohelm) - Autohelm is _another_
+  simple declarative spec for deploying helm charts. Written in python and
+  supports git urls as a source for helm charts.
+- [Helmsman](https://github.com/Praqma/helmsman) - Helmsman is a
+  helm-charts-as-code tool which enables
+  installing/upgrading/protecting/moving/deleting releases from version
+  controlled desired state files (described in a simple TOML format).  
+- [Schelm](https://github.com/databus23/schelm) - Render a Helm manifest to a
+  directory
+- [Drone.io Helm Plugin](http://plugins.drone.io/ipedrazas/drone-helm/) - Run
+  Helm inside of the Drone CI/CD system
+- [Cog](https://github.com/ohaiwalt/cog-helm) - Helm chart to deploy Cog on
+  Kubernetes
+- [Monocular](https://github.com/helm/monocular) - Web UI for Helm Chart
+  repositories
+- [Helm Chart Publisher](https://github.com/luizbafilho/helm-chart-publisher) -
+  HTTP API for publishing Helm Charts in an easy way
+- [Armada](https://github.com/att-comdev/armada) - Manage prefixed releases
+  throughout various Kubernetes namespaces, and removes completed jobs for
+  complex deployments. Used by the
+  [Openstack-Helm](https://github.com/openstack/openstack-helm) team.
+- [ChartMuseum](https://github.com/chartmuseum/chartmuseum) - Helm Chart
+  Repository with support for Amazon S3 and Google Cloud Storage
+- [Codefresh](https://codefresh.io) - Kubernetes native CI/CD and management
+  platform with UI dashboards for managing Helm charts and releases
+- [Captain](https://github.com/alauda/captain) - A Helm3 Controller using
+  HelmRequest and Release CRD
 
 ## Helm Included
 
@@ -79,10 +137,15 @@ Platforms, distributions, and services that include Helm support.
 - [Cabin](http://www.skippbox.com/cabin/) - Mobile App for Managing Kubernetes
 - [Qstack](https://qstack.com)
 - [Fabric8](https://fabric8.io) - Integrated development platform for Kubernetes
-- [Jenkins X](http://jenkins-x.io/) - open source automated CI/CD for Kubernetes which uses Helm for [promoting](http://jenkins-x.io/about/features/#promotion) applications through [environments via GitOps](http://jenkins-x.io/about/features/#environments)
+- [Jenkins X](http://jenkins-x.io/) - open source automated CI/CD for Kubernetes
+  which uses Helm for [promoting](http://jenkins-x.io/about/features/#promotion)
+  applications through [environments via
+  GitOps](http://jenkins-x.io/about/features/#environments)
 
 ## Misc
 
 Grab bag of useful things for Chart authors and Helm users
 
-- [Await](https://github.com/saltside/await) - Docker image to "await" different conditions--especially useful for init containers. [More Info](http://blog.slashdeploy.com/2017/02/16/introducing-await/)
+- [Await](https://github.com/saltside/await) - Docker image to "await" different
+  conditions--especially useful for init containers. [More
+  Info](http://blog.slashdeploy.com/2017/02/16/introducing-await/)

--- a/content/docs/community/release_checklist.md
+++ b/content/docs/community/release_checklist.md
@@ -4,7 +4,8 @@ description: "Checklist for maintainers when releasing the next version of Helm.
 weight: 2
 ---
 
-**IMPORTANT**: If your experience deviates from this document, please document the changes to keep it up-to-date.
+**IMPORTANT**: If your experience deviates from this document, please document
+the changes to keep it up-to-date.
 
 ## A Maintainer's Guide to Releasing Helm
 
@@ -14,17 +15,28 @@ So you're in charge of a new release for helm? Cool. Here's what to do...
 
 Just kidding! :trollface:
 
-All releases will be of the form vX.Y.Z where X is the major version number, Y is the minor version number and Z is the patch release number. This project strictly follows [semantic versioning](http://semver.org/) so following this step is critical.
+All releases will be of the form vX.Y.Z where X is the major version number, Y
+is the minor version number and Z is the patch release number. This project
+strictly follows [semantic versioning](http://semver.org/) so following this
+step is critical.
 
-It is important to note that this document assumes that the git remote in your repository that corresponds to "https://github.com/helm/helm" is named "upstream". If yours is not (for example, if you've chosen to name it "origin" or something similar instead), be sure to adjust the listed snippets for your local environment accordingly. If you are not sure what your upstream remote is named, use a command like `git remote -v` to find out.
+It is important to note that this document assumes that the git remote in your
+repository that corresponds to "https://github.com/helm/helm" is named
+"upstream". If yours is not (for example, if you've chosen to name it "origin"
+or something similar instead), be sure to adjust the listed snippets for your
+local environment accordingly. If you are not sure what your upstream remote is
+named, use a command like `git remote -v` to find out.
 
-If you don't have an upstream remote, you can add one easily using something like:
+If you don't have an upstream remote, you can add one easily using something
+like:
 
 ```shell
 git remote add upstream git@github.com:helm/helm.git
 ```
 
-In this doc, we are going to reference a few environment variables as well, which you may want to set for convenience. For major/minor releases, use the following:
+In this doc, we are going to reference a few environment variables as well,
+which you may want to set for convenience. For major/minor releases, use the
+following:
 
 ```shell
 export RELEASE_NAME=vX.Y.0
@@ -41,23 +53,34 @@ export RELEASE_BRANCH_NAME="release-X.Y"
 export RELEASE_CANDIDATE_NAME="$RELEASE_NAME-rc1"
 ```
 
-We are also going to be adding security and verification of the release process by hashing the binaries and providing signature files. We perform this using [GitHub and GPG](https://help.github.com/en/articles/about-commit-signature-verification). If you do not have GPG already setup you can follow these steps:
+We are also going to be adding security and verification of the release process
+by hashing the binaries and providing signature files. We perform this using
+[GitHub and
+GPG](https://help.github.com/en/articles/about-commit-signature-verification).
+If you do not have GPG already setup you can follow these steps:
 
 1. [Install GPG](https://gnupg.org/index.html)
-2. [Generate GPG key](https://help.github.com/en/articles/generating-a-new-gpg-key)
-3. [Add key to GitHub account](https://help.github.com/en/articles/adding-a-new-gpg-key-to-your-github-account)
-4. [Set signing key in Git](https://help.github.com/en/articles/telling-git-about-your-signing-key)
+2. [Generate GPG
+   key](https://help.github.com/en/articles/generating-a-new-gpg-key)
+3. [Add key to GitHub
+   account](https://help.github.com/en/articles/adding-a-new-gpg-key-to-your-github-account)
+4. [Set signing key in
+   Git](https://help.github.com/en/articles/telling-git-about-your-signing-key)
 
 Once you have a signing key you need to add it to the KEYS file at the root of
 the repository. The instructions for adding it to the KEYS file are in the file.
-If you have not done so already, you need to add your public key to the keyserver
-network. If you use GnuPG you can follow the [instructions provided by Debian](https://debian-administration.org/article/451/Submitting_your_GPG_key_to_a_keyserver).
+If you have not done so already, you need to add your public key to the
+keyserver network. If you use GnuPG you can follow the [instructions provided by
+Debian](https://debian-administration.org/article/451/Submitting_your_GPG_key_to_a_keyserver).
 
 ## 1. Create the Release Branch
 
 ### Major/Minor Releases
 
-Major releases are for new feature additions and behavioral changes *that break backwards compatibility*. Minor releases are for new feature additions that do not break backwards compatibility. To create a major or minor release, start by creating a `release-vX.Y.0` branch from master.
+Major releases are for new feature additions and behavioral changes *that break
+backwards compatibility*. Minor releases are for new feature additions that do
+not break backwards compatibility. To create a major or minor release, start by
+creating a `release-vX.Y.0` branch from master.
 
 ```shell
 git fetch upstream
@@ -65,11 +88,13 @@ git checkout upstream/master
 git checkout -b $RELEASE_BRANCH_NAME
 ```
 
-This new branch is going to be the base for the release, which we are going to iterate upon later.
+This new branch is going to be the base for the release, which we are going to
+iterate upon later.
 
 ### Patch releases
 
-Patch releases are a few critical cherry-picked fixes to existing releases. Start by creating a `release-vX.Y.Z` branch from the latest patch release.
+Patch releases are a few critical cherry-picked fixes to existing releases.
+Start by creating a `release-vX.Y.Z` branch from the latest patch release.
 
 ```shell
 git fetch upstream --tags
@@ -77,7 +102,8 @@ git checkout $PREVIOUS_PATCH_RELEASE
 git checkout -b $RELEASE_BRANCH_NAME
 ```
 
-From here, we can cherry-pick the commits we want to bring into the patch release:
+From here, we can cherry-pick the commits we want to bring into the patch
+release:
 
 ```shell
 # get the commits ids we want to cherry-pick
@@ -87,11 +113,13 @@ git cherry-pick -x <commit-id>
 git cherry-pick -x <commit-id>
 ```
 
-This new branch is going to be the base for the release, which we are going to iterate upon later.
+This new branch is going to be the base for the release, which we are going to
+iterate upon later.
 
 ## 2. Change the Version Number in Git
 
-When doing a minor release, make sure to update pkg/version/version.go with the new release version.
+When doing a minor release, make sure to update pkg/version/version.go with the
+new release version.
 
 ```shell
 $ git diff pkg/version/version.go
@@ -110,15 +138,17 @@ index 2109a0a..6f5a1a4 100644
         BuildMetadata = "unreleased"
 ```
 
-For patch releases, the old version number will be the latest patch release, so just bump the patch number, incrementing Z by one.
+For patch releases, the old version number will be the latest patch release, so
+just bump the patch number, incrementing Z by one.
 
 ```shell
 git add .
 git commit -m "bump version to $RELEASE_CANDIDATE_NAME"
 ```
 
-This will update it for the $RELEASE_BRANCH_NAME only. You will also need to pull
-this change into the master branch for when the next release is being created.
+This will update it for the $RELEASE_BRANCH_NAME only. You will also need to
+pull this change into the master branch for when the next release is being
+created.
 
 ```shell
 # get the last commit id i.e. commit to bump the version
@@ -137,28 +167,35 @@ git push origin bump-version-<release-version>
 
 ## 3. Commit and Push the Release Branch
 
-In order for others to start testing, we can now push the release branch upstream and start the test process.
+In order for others to start testing, we can now push the release branch
+upstream and start the test process.
 
 ```shell
 git push upstream $RELEASE_BRANCH_NAME
 ```
 
-Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) and make sure the release passed CI before proceeding.
+Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) and
+make sure the release passed CI before proceeding.
 
-If anyone is available, let others peer-review the branch before continuing to ensure that all the proper changes have been made and all of the commits for the release are there.
+If anyone is available, let others peer-review the branch before continuing to
+ensure that all the proper changes have been made and all of the commits for the
+release are there.
 
 ## 4. Create a Release Candidate
 
-Now that the release branch is out and ready, it is time to start creating and iterating on release candidates.
+Now that the release branch is out and ready, it is time to start creating and
+iterating on release candidates.
 
 ```shell
 git tag --sign --annotate "${RELEASE_CANDIDATE_NAME}" --message "Helm release ${RELEASE_CANDIDATE_NAME}"
 git push upstream $RELEASE_CANDIDATE_NAME
 ```
 
-CircleCI will automatically create a tagged release image and client binary to test with.
+CircleCI will automatically create a tagged release image and client binary to
+test with.
 
-For testers, the process to start testing after CircleCI finishes building the artifacts involves the following steps to grab the client:
+For testers, the process to start testing after CircleCI finishes building the
+artifacts involves the following steps to grab the client:
 
 linux/amd64, using /bin/bash:
 
@@ -178,21 +215,35 @@ windows/amd64, using PowerShell:
 PS C:\> Invoke-WebRequest -Uri "https://get.helm.sh/helm-$RELEASE_CANDIDATE_NAME-windows-amd64.tar.gz" -OutFile "helm-$ReleaseCandidateName-windows-amd64.tar.gz"
 ```
 
-Then, unpack and move the binary to somewhere on your $PATH, or move it somewhere and add it to your $PATH (e.g. /usr/local/bin/helm for linux/macOS, C:\Program Files\helm\helm.exe for Windows).
+Then, unpack and move the binary to somewhere on your $PATH, or move it
+somewhere and add it to your $PATH (e.g. /usr/local/bin/helm for linux/macOS,
+C:\Program Files\helm\helm.exe for Windows).
 
 ## 5. Iterate on Successive Release Candidates
 
-Spend several days explicitly investing time and resources to try and break helm in every possible way, documenting any findings pertinent to the release. This time should be spent testing and finding ways in which the release might have caused various features or upgrade environments to have issues, not coding. During this time, the release is in code freeze, and any additional code changes will be pushed out to the next release.
+Spend several days explicitly investing time and resources to try and break helm
+in every possible way, documenting any findings pertinent to the release. This
+time should be spent testing and finding ways in which the release might have
+caused various features or upgrade environments to have issues, not coding.
+During this time, the release is in code freeze, and any additional code changes
+will be pushed out to the next release.
 
-During this phase, the $RELEASE_BRANCH_NAME branch will keep evolving as you will produce new release candidates. The frequency of new candidates is up to the release manager: use your best judgement taking into account the severity of reported issues, testers' availability, and the release deadline date. Generally speaking, it is better to let a release roll over the deadline than to ship a broken release.
+During this phase, the $RELEASE_BRANCH_NAME branch will keep evolving as you
+will produce new release candidates. The frequency of new candidates is up to
+the release manager: use your best judgement taking into account the severity of
+reported issues, testers' availability, and the release deadline date. Generally
+speaking, it is better to let a release roll over the deadline than to ship a
+broken release.
 
-Each time you'll want to produce a new release candidate, you will start by adding commits to the branch by cherry-picking from master:
+Each time you'll want to produce a new release candidate, you will start by
+adding commits to the branch by cherry-picking from master:
 
 ```shell
 git cherry-pick -x <commit_id>
 ```
 
-You will also want to update the release version number and the CHANGELOG as we did in steps 2 and 3 as separate commits.
+You will also want to update the release version number and the CHANGELOG as we
+did in steps 2 and 3 as separate commits.
 
 After that, tag it and notify users of the new release candidate:
 
@@ -202,11 +253,14 @@ git tag --sign --annotate "${RELEASE_CANDIDATE_NAME}" --message "Helm release ${
 git push upstream $RELEASE_CANDIDATE_NAME
 ```
 
-From here on just repeat this process, continuously testing until you're happy with the release candidate.
+From here on just repeat this process, continuously testing until you're happy
+with the release candidate.
 
 ## 6. Finalize the Release
 
-When you're finally happy with the quality of a release candidate, you can move on and create the real thing. Double-check one last time to make sure everything is in order, then finally push the release tag.
+When you're finally happy with the quality of a release candidate, you can move
+on and create the real thing. Double-check one last time to make sure everything
+is in order, then finally push the release tag.
 
 ```shell
 git checkout $RELEASE_BRANCH_NAME
@@ -214,11 +268,14 @@ git tag --sign --annotate "${RELEASE_NAME}" --message "Helm release ${RELEASE_NA
 git push upstream $RELEASE_NAME
 ```
 
-Verify that the release succeeded in CI. If not, you will need to fix the release and push the release again.
+Verify that the release succeeded in CI. If not, you will need to fix the
+release and push the release again.
 
 ## 7. PGP Sign the downloads
 
-While hashes provide a signature that the content of the downloads is what it was generated, signed packages provide traceability of where the package came from.
+While hashes provide a signature that the content of the downloads is what it
+was generated, signed packages provide traceability of where the package came
+from.
 
 To do this, run the following `make` commands:
 
@@ -229,15 +286,20 @@ make fetch-dist
 make sign
 ```
 
-This will generate ascii armored signature files for each of the files pushed by CI.
+This will generate ascii armored signature files for each of the files pushed by
+CI.
 
 All of the signature files need to be uploaded to the release on GitHub.
 
 ## 8. Write the Release Notes
 
-We will auto-generate a changelog based on the commits that occurred during a release cycle, but it is usually more beneficial to the end-user if the release notes are hand-written by a human being/marketing team/dog.
+We will auto-generate a changelog based on the commits that occurred during a
+release cycle, but it is usually more beneficial to the end-user if the release
+notes are hand-written by a human being/marketing team/dog.
 
-If you're releasing a major/minor release, listing notable user-facing features is usually sufficient. For patch releases, do the same, but make note of the symptoms and who is affected.
+If you're releasing a major/minor release, listing notable user-facing features
+is usually sufficient. For patch releases, do the same, but make note of the
+symptoms and who is affected.
 
 An example release note for a minor release would look like this:
 
@@ -298,29 +360,40 @@ The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will g
 - docs(release_checklist): fix changelog generation command (#4694) 8442851a5c566a01d9b4c69b368d64daa04f6a7f (Matthew Fisher)
 ```
 
-The changelog at the bottom of the release notes can be generated with this command:
+The changelog at the bottom of the release notes can be generated with this
+command:
 
 ```shell
 PREVIOUS_RELEASE=vX.Y.Z
 git log --no-merges --pretty=format:'- %s %H (%aN)' $RELEASE_NAME $PREVIOUS_RELEASE
 ```
 
-After generating the changelog, you will need to categorize the changes as shown in the example above.
+After generating the changelog, you will need to categorize the changes as shown
+in the example above.
 
-Once finished, go into GitHub and edit the release notes for the tagged release with the notes written here.
+Once finished, go into GitHub and edit the release notes for the tagged release
+with the notes written here.
 
-Remember to attach the ascii armored signatures generated in the previous step to the release notes.
+Remember to attach the ascii armored signatures generated in the previous step
+to the release notes.
 
-It is now worth getting other people to take a look at the release notes before the release is published. Send
-a request out to [#helm-dev](https://kubernetes.slack.com/messages/C51E88VDG) for review. It is always
-beneficial as it can be easy to miss something.
+It is now worth getting other people to take a look at the release notes before
+the release is published. Send a request out to
+[#helm-dev](https://kubernetes.slack.com/messages/C51E88VDG) for review. It is
+always beneficial as it can be easy to miss something.
 
 When you are ready to go, hit `publish`.
 
 ## 9. Evangelize
 
-Congratulations! You're done. Go grab yourself a $DRINK_OF_CHOICE. You've earned it.
+Congratulations! You're done. Go grab yourself a $DRINK_OF_CHOICE. You've earned
+it.
 
-After enjoying a nice $DRINK_OF_CHOICE, go forth and announce the glad tidings of the new release in Slack and on Twitter. You should also notify any key partners in the helm community such as the homebrew formula maintainers, the owners of incubator projects (e.g. ChartMuseum) and any other interested parties.
+After enjoying a nice $DRINK_OF_CHOICE, go forth and announce the glad tidings
+of the new release in Slack and on Twitter. You should also notify any key
+partners in the helm community such as the homebrew formula maintainers, the
+owners of incubator projects (e.g. ChartMuseum) and any other interested
+parties.
 
-Optionally, write a blog post about the new release and showcase some of the new features on there!
+Optionally, write a blog post about the new release and showcase some of the new
+features on there!

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -7,8 +7,8 @@ weight: 1
 This page provides help with the most common questions about Helm.
 
 **We'd love your help** making this document better. To add, correct, or remove
-information, [file an issue](https://github.com/helm/helm-www/issues) or
-send us a pull request.
+information, [file an issue](https://github.com/helm/helm-www/issues) or send us
+a pull request.
 
 ## Changes since Helm 2
 
@@ -16,40 +16,52 @@ Here's an exhaustive list of all the major changes introduced in Helm 3.
 
 ### Removal of Tiller
 
-During the Helm 2 development cycle, we introduced Tiller. Tiller played an important role for teams working on a shared
-cluster - it made it possible for multiple different operators to interact with the same set of releases.
+During the Helm 2 development cycle, we introduced Tiller. Tiller played an
+important role for teams working on a shared cluster - it made it possible for
+multiple different operators to interact with the same set of releases.
 
-With role-based access controls (RBAC) enabled by default in Kubernetes 1.6, locking down Tiller for use in a production
-scenario became more difficult to manage. Due to the vast number of possible security policies, our stance was to
-provide a permissive default configuration. This allowed first-time users to start experimenting with Helm and
-Kubernetes without having to dive headfirst into the security controls. Unfortunately, this permissive configuration
-could grant a user a broad range of permissions they weren’t intended to have. DevOps and SREs had to learn additional
-operational steps when installing Tiller into a multi-tenant cluster.
+With role-based access controls (RBAC) enabled by default in Kubernetes 1.6,
+locking down Tiller for use in a production scenario became more difficult to
+manage. Due to the vast number of possible security policies, our stance was to
+provide a permissive default configuration. This allowed first-time users to
+start experimenting with Helm and Kubernetes without having to dive headfirst
+into the security controls. Unfortunately, this permissive configuration could
+grant a user a broad range of permissions they weren’t intended to have. DevOps
+and SREs had to learn additional operational steps when installing Tiller into a
+multi-tenant cluster.
 
-After hearing how community members were using Helm in certain scenarios, we found that Tiller’s release management
-system did not need to rely upon an in-cluster operator to maintain state or act as a central hub for Helm release
-information. Instead, we could simply fetch information from the Kubernetes API server, render the Charts client-side,
-and store a record of the installation in Kubernetes.
+After hearing how community members were using Helm in certain scenarios, we
+found that Tiller’s release management system did not need to rely upon an
+in-cluster operator to maintain state or act as a central hub for Helm release
+information. Instead, we could simply fetch information from the Kubernetes API
+server, render the Charts client-side, and store a record of the installation in
+Kubernetes.
 
-Tiller’s primary goal could be accomplished without Tiller, so one of the first decisions we made regarding Helm 3 was
-to completely remove Tiller.
+Tiller’s primary goal could be accomplished without Tiller, so one of the first
+decisions we made regarding Helm 3 was to completely remove Tiller.
 
-With Tiller gone, the security model for Helm is radically simplified. Helm 3 now supports all the modern security,
-identity, and authorization features of modern Kubernetes. Helm’s permissions are evaluated using your [kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
-Cluster administrators can restrict user permissions at whatever granularity they see fit. Releases are still recorded
-in-cluster, and the rest of Helm’s functionality remains.
+With Tiller gone, the security model for Helm is radically simplified. Helm 3
+now supports all the modern security, identity, and authorization features of
+modern Kubernetes. Helm’s permissions are evaluated using your [kubeconfig
+file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
+Cluster administrators can restrict user permissions at whatever granularity
+they see fit. Releases are still recorded in-cluster, and the rest of Helm’s
+functionality remains.
 
 ### Improved Upgrade Strategy: 3-way Strategic Merge Patches
 
-Helm 2 used a two-way strategic merge patch. During an upgrade, it compared the most recent chart's manifest
-against the proposed chart's manifest (the one supplied during `helm upgrade`). It compared the differences between
-these two charts to determine what changes needed to be applied to the resources in Kubernetes. If changes were
-applied to the cluster out-of-band (such as during a `kubectl edit`), those changes were not considered. This resulted in
-resources being unable to roll back to its previous state: because Helm only considered the last applied chart's
-manifest as its current state, if there were no changes in the chart's state, the live state was left unchanged.
+Helm 2 used a two-way strategic merge patch. During an upgrade, it compared the
+most recent chart's manifest against the proposed chart's manifest (the one
+supplied during `helm upgrade`). It compared the differences between these two
+charts to determine what changes needed to be applied to the resources in
+Kubernetes. If changes were applied to the cluster out-of-band (such as during a
+`kubectl edit`), those changes were not considered. This resulted in resources
+being unable to roll back to its previous state: because Helm only considered
+the last applied chart's manifest as its current state, if there were no changes
+in the chart's state, the live state was left unchanged.
 
-In Helm 3, we now use a three-way strategic merge patch. Helm considers the old manifest, its live state, and the
-new manifest when generating a patch.
+In Helm 3, we now use a three-way strategic merge patch. Helm considers the old
+manifest, its live state, and the new manifest when generating a patch.
 
 #### Examples
 
@@ -57,23 +69,25 @@ Let's go through a few common examples what this change impacts.
 
 ##### Rolling back where live state has changed
 
-Your team just deployed their application to production on Kubernetes using Helm. The chart contains a Deployment object
-where the number of replicas is set to three:
+Your team just deployed their application to production on Kubernetes using
+Helm. The chart contains a Deployment object where the number of replicas is set
+to three:
 
 ```console
 $ helm install myapp ./myapp
 ```
 
-A new developer joins the team. On their first day while observing the production cluster, a horrible
-coffee-spilling-on-the-keyboard accident happens and they `kubectl scale` the production deployment from three replicas down
-to zero.
+A new developer joins the team. On their first day while observing the
+production cluster, a horrible coffee-spilling-on-the-keyboard accident happens
+and they `kubectl scale` the production deployment from three replicas down to
+zero.
 
 ```console
 $ kubectl scale --replicas=0 deployment/myapp
 ```
 
-Another developer on your team notices that the production site is down and decides to rollback the release to its
-previous state:
+Another developer on your team notices that the production site is down and
+decides to rollback the release to its previous state:
 
 ```console
 $ helm rollback myapp
@@ -81,18 +95,22 @@ $ helm rollback myapp
 
 What happens?
 
-In Helm 2, it would generate a patch, comparing the old manifest against the new manifest. Because this is a
-rollback, it's the same manifest. Helm would determine that there is nothing to change because there is no difference
-between the old manifest and the new manifest. The replica count continues to stay at zero. Panic ensues.
+In Helm 2, it would generate a patch, comparing the old manifest against the new
+manifest. Because this is a rollback, it's the same manifest. Helm would
+determine that there is nothing to change because there is no difference between
+the old manifest and the new manifest. The replica count continues to stay at
+zero. Panic ensues.
 
-In Helm 3, the patch is generated using the old manifest, the live state, and the new manifest. Helm recognizes that the
-old state was at three, the live state is at zero and the new manifest wishes to change it back to three, so it
+In Helm 3, the patch is generated using the old manifest, the live state, and
+the new manifest. Helm recognizes that the old state was at three, the live
+state is at zero and the new manifest wishes to change it back to three, so it
 generates a patch to change the state back to three.
 
 ##### Upgrades where live state has changed
 
-Many service meshes and other controller-based applications inject data into Kubernetes objects. This can be something
-like a sidecar, labels, or other information. Previously if you had the given manifest rendered from a Chart:
+Many service meshes and other controller-based applications inject data into
+Kubernetes objects. This can be something like a sidecar, labels, or other
+information. Previously if you had the given manifest rendered from a Chart:
 
 ```yaml
 containers:
@@ -110,7 +128,8 @@ containers:
   image: my-cool-mesh:1.0.0
 ```
 
-Now, you want to upgrade the `nginx` image tag to `2.1.0`. So, you upgrade to a chart with the given manifest:
+Now, you want to upgrade the `nginx` image tag to `2.1.0`. So, you upgrade to a
+chart with the given manifest:
 
 ```yaml
 containers:
@@ -120,8 +139,9 @@ containers:
 
 What happens?
 
-In Helm 2, Helm generates a patch of the `containers` object between the old manifest and the new manifest. The
-cluster's live state is not considered during the patch generation.
+In Helm 2, Helm generates a patch of the `containers` object between the old
+manifest and the new manifest. The cluster's live state is not considered during
+the patch generation.
 
 The cluster's live state is modified to look like the following:
 
@@ -133,9 +153,9 @@ containers:
 
 The sidecar pod is removed from live state. More panic ensues.
 
-In Helm 3, Helm generates a patch of the `containers` object between the old manifest, the live state, and the new
-manifest. It notices that the new manifest changes the image tag to `2.1.0`, but live state contains a sidecar
-container.
+In Helm 3, Helm generates a patch of the `containers` object between the old
+manifest, the live state, and the new manifest. It notices that the new manifest
+changes the image tag to `2.1.0`, but live state contains a sidecar container.
 
 The cluster's live state is modified to look like the following:
 
@@ -149,35 +169,41 @@ containers:
 
 ### Release Names are now scoped to the Namespace
 
-With the removal of Tiller, the information about each release had to go somewhere. In Helm 2, this was stored in the
-same namespace as Tiller. In practice, this meant that once a name was used by a release, no other release could use
-that same name, even if it was deployed in a different namespace.
+With the removal of Tiller, the information about each release had to go
+somewhere. In Helm 2, this was stored in the same namespace as Tiller. In
+practice, this meant that once a name was used by a release, no other release
+could use that same name, even if it was deployed in a different namespace.
 
-In Helm 3, release information about a particular release is now stored in the same namespace as the release itself.
-This means that users can now `helm install wordpress stable/wordpress` in two separate namespaces, and each can be
-referred with `helm list` by changing the current namespace context (e.g. `helm list --namespace foo`).
+In Helm 3, release information about a particular release is now stored in the
+same namespace as the release itself. This means that users can now `helm
+install wordpress stable/wordpress` in two separate namespaces, and each can be
+referred with `helm list` by changing the current namespace context (e.g. `helm
+list --namespace foo`).
 
 ### Secrets as the default storage driver
 
-Helm 2 used ConfigMaps by default to store release information. In Helm 3, Secrets are now used as the default storage
-driver.
+Helm 2 used ConfigMaps by default to store release information. In Helm 3,
+Secrets are now used as the default storage driver.
 
 ### Go import path changes
 
-In Helm 3, Helm switched the Go import path over from `k8s.io/helm` to `helm.sh/helm/v3`. If you intend
-to upgrade to the Helm 3 Go client libraries, make sure to change your import paths.
+In Helm 3, Helm switched the Go import path over from `k8s.io/helm` to
+`helm.sh/helm/v3`. If you intend to upgrade to the Helm 3 Go client libraries,
+make sure to change your import paths.
 
 ### Capabilities
 
-The `.Capabilities` built-in object available during the rendering stage has been simplified.
+The `.Capabilities` built-in object available during the rendering stage has
+been simplified.
 
 [Built-in Objects](/docs/topics/chart_template_guide/builtin_objects/)
 
 ### Validating Chart Values with JSONSchema
 
-A JSON Schema can now be imposed upon chart values. This ensures that values provided by the user follow the schema
-laid out by the chart maintainer, providing better error reporting when the user provides an incorrect set of values for
-a chart.
+A JSON Schema can now be imposed upon chart values. This ensures that values
+provided by the user follow the schema laid out by the chart maintainer,
+providing better error reporting when the user provides an incorrect set of
+values for a chart.
 
 Validation occurs when any of the following commands are invoked:
 
@@ -186,13 +212,15 @@ Validation occurs when any of the following commands are invoked:
 * `helm template`
 * `helm lint`
 
-See the documentation on [Schema files](/docs/topics/charts#schema-files) for more information.
+See the documentation on [Schema files](/docs/topics/charts#schema-files) for
+more information.
 
 ### Consolidation of `requirements.yaml` into `Chart.yaml`
 
-The Chart dependency management system moved from requirements.yaml and requirements.lock to Chart.yaml and Chart.lock. 
-We recommend that new charts meant for Helm 3 use the new format. However, Helm 3 still understands Chart API version 1 (`v1`)
-and will load existing `requirements.yaml` files
+The Chart dependency management system moved from requirements.yaml and
+requirements.lock to Chart.yaml and Chart.lock. We recommend that new charts
+meant for Helm 3 use the new format. However, Helm 3 still understands Chart API
+version 1 (`v1`) and will load existing `requirements.yaml` files
 
 In Helm 2, this is how a `requirements.yaml` looked:
 
@@ -206,7 +234,8 @@ dependencies:
     - database
 ```
 
-In Helm 3, the dependency is expressed the same way, but now from your `Chart.yaml`:
+In Helm 3, the dependency is expressed the same way, but now from your
+`Chart.yaml`:
 
 ```yaml
 dependencies:
@@ -218,57 +247,75 @@ dependencies:
     - database
 ```
 
-Charts are still downloaded and placed in the `charts/` directory, so subcharts vendored into the `charts/` directory will continue to work without modification.
+Charts are still downloaded and placed in the `charts/` directory, so subcharts
+vendored into the `charts/` directory will continue to work without
+modification.
 
 ### Name (or --generate-name) is now required on install
 
-In Helm 2, if no name was provided, an auto-generated name would be given. In production, this proved to be more of a
-nuisance than a helpful feature. In Helm 3, Helm will throw an error if no name is provided with `helm install`.
+In Helm 2, if no name was provided, an auto-generated name would be given. In
+production, this proved to be more of a nuisance than a helpful feature. In Helm
+3, Helm will throw an error if no name is provided with `helm install`.
 
-For those who still wish to have a name auto-generated for you, you can use the `--generate-name` flag to create one for
-you.
+For those who still wish to have a name auto-generated for you, you can use the
+`--generate-name` flag to create one for you.
 
 ### Pushing Charts to OCI Registries
 
-This is an experimental feature introduced in Helm 3. To use, set the environment variable `HELM_EXPERIMENTAL_OCI=1`.
+This is an experimental feature introduced in Helm 3. To use, set the
+environment variable `HELM_EXPERIMENTAL_OCI=1`.
 
-At a high level, a Chart Repository is a location where Charts can be stored and shared. The Helm client packs and ships
-Helm Charts to a Chart Repository. Simply put, a Chart Repository is a basic HTTP server that houses an index.yaml file
-and some packaged charts.
+At a high level, a Chart Repository is a location where Charts can be stored and
+shared. The Helm client packs and ships Helm Charts to a Chart Repository.
+Simply put, a Chart Repository is a basic HTTP server that houses an index.yaml
+file and some packaged charts.
 
-While there are several benefits to the Chart Repository API meeting the most basic storage requirements, a few
-drawbacks have started to show:
+While there are several benefits to the Chart Repository API meeting the most
+basic storage requirements, a few drawbacks have started to show:
 
-- Chart Repositories have a very hard time abstracting most of the security implementations required in a production environment. Having a standard API for authentication and authorization is very important in production scenarios.
-- Helm’s Chart provenance tools used for signing and verifying the integrity and origin of a chart are an optional piece of the Chart publishing process.
-- In multi-tenant scenarios, the same Chart can be uploaded by another tenant, costing twice the storage cost to store the same content. Smarter chart repositories have been designed to handle this, but it’s not a part of the formal specification.
-- Using a single index file for search, metadata information, and fetching Charts has made it difficult or clunky to design around in secure multi-tenant implementations.
+- Chart Repositories have a very hard time abstracting most of the security
+  implementations required in a production environment. Having a standard API
+  for authentication and authorization is very important in production
+  scenarios.
+- Helm’s Chart provenance tools used for signing and verifying the integrity and
+  origin of a chart are an optional piece of the Chart publishing process.
+- In multi-tenant scenarios, the same Chart can be uploaded by another tenant,
+  costing twice the storage cost to store the same content. Smarter chart
+  repositories have been designed to handle this, but it’s not a part of the
+  formal specification.
+- Using a single index file for search, metadata information, and fetching
+  Charts has made it difficult or clunky to design around in secure multi-tenant
+  implementations.
 
-Docker’s Distribution project (also known as Docker Registry v2) is the successor to the Docker Registry project. Many
-major cloud vendors have a product offering of the Distribution project, and with so many vendors offering the same
-product, the Distribution project has benefited from many years of hardening, security best practices, and
-battle-testing.
+Docker’s Distribution project (also known as Docker Registry v2) is the
+successor to the Docker Registry project. Many major cloud vendors have a
+product offering of the Distribution project, and with so many vendors offering
+the same product, the Distribution project has benefited from many years of
+hardening, security best practices, and battle-testing.
 
-Please have a look at `helm help chart` and `helm help registry` for more information on how to package a chart and
-push it to a Docker registry.
+Please have a look at `helm help chart` and `helm help registry` for more
+information on how to package a chart and push it to a Docker registry.
 
 For more info, please see [this page](/docs/topics/registries/).
 
 ### Removal of `helm serve`
 
-`helm serve` ran a local Chart Repository on your machine for development purposes. However, it didn't receive much
-uptake as a development tool and had numerous issues with its design. In the end, we decided to remove it and split it
-out as a plugin.
+`helm serve` ran a local Chart Repository on your machine for development
+purposes. However, it didn't receive much uptake as a development tool and had
+numerous issues with its design. In the end, we decided to remove it and split
+it out as a plugin.
 
 ### Library chart support
 
-Helm 3 supports a class of chart called a “library chart”. This is a chart that is shared by other charts, but does not
-create any release artifacts of its own. A library chart’s templates can only declare `define` elements. Globally scoped
-non-`define` content is simply ignored. This allows users to re-use and share snippets of code that can be re-used across
-many charts, avoiding redundancy and keeping charts [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
+Helm 3 supports a class of chart called a “library chart”. This is a chart that
+is shared by other charts, but does not create any release artifacts of its own.
+A library chart’s templates can only declare `define` elements. Globally scoped
+non-`define` content is simply ignored. This allows users to re-use and share
+snippets of code that can be re-used across many charts, avoiding redundancy and
+keeping charts [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
-Library charts are declared in the dependencies directive in Chart.yaml, and are installed and managed like any other
-chart.
+Library charts are declared in the dependencies directive in Chart.yaml, and are
+installed and managed like any other chart.
 
 ```yaml
 dependencies:
@@ -277,61 +324,73 @@ dependencies:
     repository: quay.io
 ```
 
-We’re very excited to see the use cases this feature opens up for chart developers, as well as any best practices that
-arise from consuming library charts.
+We’re very excited to see the use cases this feature opens up for chart
+developers, as well as any best practices that arise from consuming library
+charts.
 
 ### Chart.yaml apiVersion bump
 
-With the introduction of library chart support and the consolidation of requirements.yaml into Chart.yaml, clients that
-understood Helm 2's package format won't understand these new features. So, we bumped the apiVersion in Chart.yaml
-from `v1` to `v2`.
+With the introduction of library chart support and the consolidation of
+requirements.yaml into Chart.yaml, clients that understood Helm 2's package
+format won't understand these new features. So, we bumped the apiVersion in
+Chart.yaml from `v1` to `v2`.
 
-`helm create` now creates charts using this new format, so the default apiVersion was bumped there as well.
+`helm create` now creates charts using this new format, so the default
+apiVersion was bumped there as well.
 
-Clients wishing to support both versions of Helm charts should inspect the `apiVersion` field in Chart.yaml to
-understand how to parse the package format.
+Clients wishing to support both versions of Helm charts should inspect the
+`apiVersion` field in Chart.yaml to understand how to parse the package format.
 
 ### XDG Base Directory Support
 
-[The XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) is
-a portable standard defining where configuration, data, and cached files should be stored on the filesystem.
+[The XDG Base Directory
+Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+is a portable standard defining where configuration, data, and cached files
+should be stored on the filesystem.
 
-In Helm 2, Helm stored all this information in `~/.helm` (affectionately known as `helm home`), which could be changed
-by setting the `$HELM_HOME` environment variable, or by using the global flag `--home`.
+In Helm 2, Helm stored all this information in `~/.helm` (affectionately known
+as `helm home`), which could be changed by setting the `$HELM_HOME` environment
+variable, or by using the global flag `--home`.
 
-In Helm 3, Helm now respects the following environment variables as per the XDG Base Directory Specification:
+In Helm 3, Helm now respects the following environment variables as per the XDG
+Base Directory Specification:
 
 - `$XDG_CACHE_HOME`
 - `$XDG_CONFIG_HOME`
 - `$XDG_DATA_HOME`
 
-Helm plugins are still passed `$HELM_HOME` as an alias to `$XDG_DATA_HOME` for backwards compatibility with plugins
-looking to use `$HELM_HOME` as a scratchpad environment.
+Helm plugins are still passed `$HELM_HOME` as an alias to `$XDG_DATA_HOME` for
+backwards compatibility with plugins looking to use `$HELM_HOME` as a scratchpad
+environment.
 
-Several new environment variables are also passed in to the plugin's environment to accommodate this change:
+Several new environment variables are also passed in to the plugin's environment
+to accommodate this change:
 
 - `$HELM_PATH_CACHE` for the cache path
 - `$HELM_PATH_CONFIG` for the config path
 - `$HELM_PATH_DATA` for the data path
 
-Helm plugins looking to support Helm 3 should consider using these new environment variables instead.
+Helm plugins looking to support Helm 3 should consider using these new
+environment variables instead.
 
 ### CLI Command Renames
 
-In order to better align the verbiage from other package managers, `helm delete` was re-named to
-`helm uninstall`. `helm delete` is still retained as an alias to `helm uninstall`, so either form
-can be used.
+In order to better align the verbiage from other package managers, `helm delete`
+was re-named to `helm uninstall`. `helm delete` is still retained as an alias to
+`helm uninstall`, so either form can be used.
 
-In Helm 2, in order to purge the release ledger, the `--purge` flag had to be provided. This
-functionality is now enabled by default. To retain the previous behavior, use
-`helm uninstall --keep-history`.
+In Helm 2, in order to purge the release ledger, the `--purge` flag had to be
+provided. This functionality is now enabled by default. To retain the previous
+behavior, use `helm uninstall --keep-history`.
 
-Additionally, several other commands were re-named to accommodate the same conventions:
+Additionally, several other commands were re-named to accommodate the same
+conventions:
 
 - `helm inspect` -> `helm show`
 - `helm fetch` -> `helm pull`
 
-These commands have also retained their older verbs as aliases, so you can continue to use them in either form.
+These commands have also retained their older verbs as aliases, so you can
+continue to use them in either form.
 
 ### Automatically creating namespaces
 
@@ -349,8 +408,8 @@ started.
 
 ### Why do you provide a `curl ...|bash` script?
 
-There is a script in our repository (`scripts/get`) that can be executed as
-a `curl ..|bash` script. The transfers are all protected by HTTPS, and the script
+There is a script in our repository (`scripts/get`) that can be executed as a
+`curl ..|bash` script. The transfers are all protected by HTTPS, and the script
 does some auditing of the packages it fetches. However, the script has all the
 usual dangers of any shell script.
 
@@ -360,15 +419,16 @@ Helm.
 
 ### How do I put the Helm client files somewhere other than their defaults?
 
-Helm uses the XDG structure for storing files. There are environment
-variables you can use to override these locations:
+Helm uses the XDG structure for storing files. There are environment variables
+you can use to override these locations:
 
 - `$XDG_CACHE_HOME`: set an alternative location for storing cached files.
-- `$XDG_CONFIG_HOME`: set an alternative location for storing Helm configuration.
+- `$XDG_CONFIG_HOME`: set an alternative location for storing Helm
+  configuration.
 - `$XDG_DATA_HOME`: set an alternative location for storing Helm data.
 
-Note that if you have existing repositories, you will need to re-add them
-with `helm repo add...`.
+Note that if you have existing repositories, you will need to re-add them with
+`helm repo add...`.
 
 
 ## Uninstalling
@@ -404,9 +464,10 @@ Another variation of the error message is:
 Unable to connect to the server: x509: certificate signed by unknown authority
 ```
 
-The issue is that your local Kubernetes config file must have the correct credentials.
+The issue is that your local Kubernetes config file must have the correct
+credentials.
 
 When you create a cluster on GKE, it will give you credentials, including SSL
-certificates and certificate authorities. These need to be stored in a Kubernetes
-config file (Default: `~/.kube/config` so that `kubectl` and `helm` can access
-them.
+certificates and certificate authorities. These need to be stored in a
+Kubernetes config file (Default: `~/.kube/config` so that `kubectl` and `helm`
+can access them.

--- a/content/docs/glossary.md
+++ b/content/docs/glossary.md
@@ -1,19 +1,19 @@
 ---
-title: "Glossary"
+title: "Glossary" 
 description: "Terms used to describe components of Helm's architecture."
 weight: 2
 ---
 
 ## Chart
 
-A Helm package that contains information sufficient for installing a set
-of Kubernetes resources into a Kubernetes cluster.
+A Helm package that contains information sufficient for installing a set of
+Kubernetes resources into a Kubernetes cluster.
 
 Charts contain a `Chart.yaml` file as well as templates, default values
 (`values.yaml`), and dependencies.
 
-Charts are developed in a well-defined directory structure, and then
-packaged into an archive format called a _chart archive_.
+Charts are developed in a well-defined directory structure, and then packaged
+into an archive format called a _chart archive_.
 
 ## Chart Archive
 
@@ -21,109 +21,107 @@ A _chart archive_ is a tarred and gzipped (and optionally signed) chart.
 
 ## Chart Dependency (Subcharts)
 
-Charts may depend upon other charts. There are two ways a dependency may
-occur:
+Charts may depend upon other charts. There are two ways a dependency may occur:
 
-- Soft dependency: A chart may simply not function without another chart
-  being installed in a cluster. Helm does not provide tooling for this
-  case. In this case, dependencies may be managed separately.
-- Hard dependency: A chart may contain (inside of its `charts/`
-  directory) another chart upon which it depends. In this case,
-  installing the chart will install all of its dependencies. In this
-  case, a chart and its dependencies are managed as a collection.
+- Soft dependency: A chart may simply not function without another chart being
+  installed in a cluster. Helm does not provide tooling for this case. In this
+  case, dependencies may be managed separately.
+- Hard dependency: A chart may contain (inside of its `charts/` directory)
+  another chart upon which it depends. In this case, installing the chart will
+  install all of its dependencies. In this case, a chart and its dependencies
+  are managed as a collection.
 
-When a chart is packaged (via `helm package`) all of its hard dependencies
-are bundled with it.
+When a chart is packaged (via `helm package`) all of its hard dependencies are
+bundled with it.
 
 ## Chart Version
 
-Charts are versioned according to the [SemVer 2
-spec](https://semver.org). A version number is required on every chart.
+Charts are versioned according to the [SemVer 2 spec](https://semver.org). A
+version number is required on every chart.
 
 ## Chart.yaml
 
-Information about a chart is stored in a special file called
-`Chart.yaml`. Every chart must have this file.
+Information about a chart is stored in a special file called `Chart.yaml`. Every
+chart must have this file.
 
 ## Helm (and helm)
 
-Helm is the package manager for Kubernetes. As an operating system
-package manager makes it easy to install tools on an OS, Helm makes it
-easy to install applications and resources into Kubernetes clusters.
+Helm is the package manager for Kubernetes. As an operating system package
+manager makes it easy to install tools on an OS, Helm makes it easy to install
+applications and resources into Kubernetes clusters.
 
-While _Helm_ is the name of the project, the command line client is also
-named `helm`. By convention, when speaking of the project, _Helm_ is
-capitalized. When speaking of the client, _helm_ is in lowercase.
+While _Helm_ is the name of the project, the command line client is also named
+`helm`. By convention, when speaking of the project, _Helm_ is capitalized. When
+speaking of the client, _helm_ is in lowercase.
 
 ## Helm Configuration Files (XDG)
 
-Helm stores its configuration files in XDG directories. These
-directories are created the first time `helm` is run.
+Helm stores its configuration files in XDG directories. These directories are
+created the first time `helm` is run.
 
 ## Kube Config (KUBECONFIG)
 
 The Helm client learns about Kubernetes clusters by using files in the _Kube
-config_ file format. By default, Helm attempts to find this file in the
-place where `kubectl` creates it (`$HOME/.kube/config`).
+config_ file format. By default, Helm attempts to find this file in the place
+where `kubectl` creates it (`$HOME/.kube/config`).
 
 ## Lint (Linting)
 
 To _lint_ a chart is to validate that it follows the conventions and
-requirements of the Helm chart standard. Helm provides tools to do this,
-notably the `helm lint` command.
+requirements of the Helm chart standard. Helm provides tools to do this, notably
+the `helm lint` command.
 
 ## Provenance (Provenance file)
 
-Helm charts may be accompanied by a _provenance file_ which provides
-information about where the chart came from and what it contains.
+Helm charts may be accompanied by a _provenance file_ which provides information
+about where the chart came from and what it contains.
 
 Provenance files are one part of the Helm security story. A provenance contains
-a cryptographic hash of the chart archive file, the Chart.yaml data, and
-a signature block (an OpenPGP "clearsign" block). When coupled with a
-keychain, this provides chart users with the ability to:
+a cryptographic hash of the chart archive file, the Chart.yaml data, and a
+signature block (an OpenPGP "clearsign" block). When coupled with a keychain,
+this provides chart users with the ability to:
 
 - Validate that a chart was signed by a trusted party
 - Validate that the chart file has not been tampered with
 - Validate the contents of a chart metadata (`Chart.yaml`)
 - Quickly match a chart to its provenance data
 
-Provenance files have the `.prov` extension, and can be served from a
-chart repository server or any other HTTP server.
+Provenance files have the `.prov` extension, and can be served from a chart
+repository server or any other HTTP server.
 
 ## Release
 
-When a chart is installed, the Helm library creates a _release_
-to track that installation.
+When a chart is installed, the Helm library creates a _release_ to track that
+installation.
 
-A single chart may be installed many times into the same cluster, and
-create many different releases. For example, one can install three
-PostgreSQL databases by running `helm install` three times with a
-different release name.
+A single chart may be installed many times into the same cluster, and create
+many different releases. For example, one can install three PostgreSQL databases
+by running `helm install` three times with a different release name.
 
 ## Release Number (Release Version)
 
-A single release can be updated multiple times. A sequential counter is
-used to track releases as they change. After a first `helm install`, a
-release will have _release number_ 1. Each time a release is upgraded or
-rolled back, the release number will be incremented.
+A single release can be updated multiple times. A sequential counter is used to
+track releases as they change. After a first `helm install`, a release will have
+_release number_ 1. Each time a release is upgraded or rolled back, the release
+number will be incremented.
 
 ## Rollback
 
-A release can be upgraded to a newer chart or configuration. But since
-release history is stored, a release can also be _rolled back_ to a
-previous release number. This is done with the `helm rollback` command.
+A release can be upgraded to a newer chart or configuration. But since release
+history is stored, a release can also be _rolled back_ to a previous release
+number. This is done with the `helm rollback` command.
 
 Importantly, a rolled back release will receive a new release number.
 
-Operation | Release Number
-----------|---------------
-install   | release 1
-upgrade   | release 2
-upgrade   | release 3
-rollback 1| release 4 (but running the same config as release 1)
+| Operation  | Release Number                                       |
+|------------|------------------------------------------------------|
+| install    | release 1                                            |
+| upgrade    | release 2                                            |
+| upgrade    | release 3                                            |
+| rollback 1 | release 4 (but running the same config as release 1) |
 
-The above table illustrates how release numbers increment across
-install, upgrade, and rollback.
+The above table illustrates how release numbers increment across install,
+upgrade, and rollback.
 
 ## Helm Library (or SDK)
 
@@ -134,31 +132,31 @@ instead of a CLI.
 
 ## Repository (Repo, Chart Repository)
 
-Helm charts may be stored on dedicated HTTP servers called _chart
-repositories_ (_repositories_, or just _repos_).
+Helm charts may be stored on dedicated HTTP servers called _chart repositories_
+(_repositories_, or just _repos_).
 
-A chart repository server is a simple HTTP server that can serve an
-`index.yaml` file that describes a batch of charts, and provides
-information on where each chart can be downloaded from. (Many chart
-repositories serve the charts as well as the `index.yaml` file.)
+A chart repository server is a simple HTTP server that can serve an `index.yaml`
+file that describes a batch of charts, and provides information on where each
+chart can be downloaded from. (Many chart repositories serve the charts as well
+as the `index.yaml` file.)
 
 A Helm client can point to zero or more chart repositories. By default, Helm
+<<<<<<< HEAD
 clients are not configured with any chart repositories. Chart repositories can
 be added at any time using the `helm repo add` command.
+=======
+clients are not configured with any chart repositories.
+>>>>>>> Formats all docs to use same wrapping
 
 ## Values (Values Files, values.yaml)
 
-Values provide a way to override template defaults with your own
-information.
+Values provide a way to override template defaults with your own information.
 
-Helm Charts are "parameterized", which means the chart developer may
-expose configuration that can be overridden at installation time. For
-example, a chart may expose a `username` field that allows setting a
-user name for a service.
+Helm Charts are "parameterized", which means the chart developer may expose
+configuration that can be overridden at installation time. For example, a chart
+may expose a `username` field that allows setting a user name for a service.
 
 These exposed variables are called _values_ in Helm parlance.
 
 Values can be set during `helm install` and `helm upgrade` operations, either by
 passing them in directly, or by using a `values.yaml` file.
-
-

--- a/content/docs/howto/_index.md
+++ b/content/docs/howto/_index.md
@@ -5,4 +5,7 @@ weight: 2
 
 # How-to Guides
 
-Here you’ll find short answers to “How do I….?” types of questions. These how-to guides don’t cover topics in depth – you’ll find that material in the [Topic Guides](../topics). However, these guides will help you quickly accomplish common tasks.
+Here you’ll find short answers to “How do I….?” types of questions. These how-to
+guides don’t cover topics in depth – you’ll find that material in the [Topic
+Guides](../topics). However, these guides will help you quickly accomplish
+common tasks.

--- a/content/docs/howto/chart_repository_sync_example.md
+++ b/content/docs/howto/chart_repository_sync_example.md
@@ -4,15 +4,20 @@ description: "Describes how to synchronize your local and remote chart repositor
 weight: 2
 ---
 
-*Note: This example is specifically for a Google Cloud Storage (GCS) bucket which serves a chart repository.*
+*Note: This example is specifically for a Google Cloud Storage (GCS) bucket
+which serves a chart repository.*
 
 ## Prerequisites
-* Install the [gsutil](https://cloud.google.com/storage/docs/gsutil) tool. *We rely heavily on the gsutil rsync functionality*
+* Install the [gsutil](https://cloud.google.com/storage/docs/gsutil) tool. *We
+  rely heavily on the gsutil rsync functionality*
 * Be sure to have access to the Helm binary
-* _Optional: We recommend you set [object versioning](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#top_of_page) on your GCS bucket in case you accidentally delete something._
+* _Optional: We recommend you set [object
+  versioning](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#top_of_page)
+  on your GCS bucket in case you accidentally delete something._
 
 ## Set up a local chart repository directory
-Create a local directory like we did in [the chart repository guide](chart_repository.md), and place your packaged charts in that directory.
+Create a local directory like we did in [the chart repository
+guide](chart_repository.md), and place your packaged charts in that directory.
 
 For example:
 ```console
@@ -21,15 +26,19 @@ $ mv alpine-0.1.0.tgz fantastic-charts/
 ```
 
 ## Generate an updated index.yaml
-Use Helm to generate an updated index.yaml file by passing in the directory path and the url of the remote repository to the `helm repo index` command like this:
+Use Helm to generate an updated index.yaml file by passing in the directory path
+and the url of the remote repository to the `helm repo index` command like this:
 
 ```console
 $ helm repo index fantastic-charts/ --url https://fantastic-charts.storage.googleapis.com
 ```
-This will generate an updated index.yaml file and place in the `fantastic-charts/` directory.
+This will generate an updated index.yaml file and place in the
+`fantastic-charts/` directory.
 
 ## Sync your local and remote chart repositories
-Upload the contents of the directory to your GCS bucket by running `scripts/sync-repo.sh` and pass in the local directory name and the GCS bucket name.
+Upload the contents of the directory to your GCS bucket by running
+`scripts/sync-repo.sh` and pass in the local directory name and the GCS bucket
+name.
 
 For example:
 ```console
@@ -53,7 +62,9 @@ Uploading   gs://fantastic-charts/index.yaml:                    347 B/347 B
 Congratulations your remote chart repository now matches the contents of fantastic-charts/
 ```
 ## Updating your chart repository
-You'll want to keep a local copy of the contents of your chart repository or use `gsutil rsync` to copy the contents of your remote chart repository to a local directory.
+You'll want to keep a local copy of the contents of your chart repository or use
+`gsutil rsync` to copy the contents of your remote chart repository to a local
+directory.
 
 For example:
 ```console
@@ -72,8 +83,10 @@ Copying gs://bucket-name/index.yaml...
 Downloading file://local-dir/index.yaml:                              346 B/346 B
 ```
 
-
 Helpful Links:
-* Documentation on [gsutil rsync](https://cloud.google.com/storage/docs/gsutil/commands/rsync#description)
+* Documentation on [gsutil
+  rsync](https://cloud.google.com/storage/docs/gsutil/commands/rsync#description)
 * [The Chart Repository Guide](chart_repository.md)
-* Documentation on [object versioning and concurrency control](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#overview) in Google Cloud Storage
+* Documentation on [object versioning and concurrency
+  control](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#overview)
+  in Google Cloud Storage

--- a/content/docs/howto/charts_tips_and_tricks.md
+++ b/content/docs/howto/charts_tips_and_tricks.md
@@ -4,21 +4,21 @@ description: "Covers some of the tips and tricks Helm chart developers have lear
 weight: 1
 ---
 
-This guide covers some of the tips and tricks Helm chart developers have
-learned while building production-quality charts.
+This guide covers some of the tips and tricks Helm chart developers have learned
+while building production-quality charts.
 
 ## Know Your Template Functions
 
-Helm uses [Go templates](https://godoc.org/text/template) for templating
-your resource files. While Go ships several built-in functions, we have
-added many others.
+Helm uses [Go templates](https://godoc.org/text/template) for templating your
+resource files. While Go ships several built-in functions, we have added many
+others.
 
-First, we added all of the functions in the
-[Sprig library](https://godoc.org/github.com/Masterminds/sprig).
+First, we added all of the functions in the [Sprig
+library](https://godoc.org/github.com/Masterminds/sprig).
 
-We also added two special template functions: `include` and `required`. The `include`
-function allows you to bring in another template, and then pass the results to other
-template functions.
+We also added two special template functions: `include` and `required`. The
+`include` function allows you to bring in another template, and then pass the
+results to other template functions.
 
 For example, this template snippet includes a template called `mytpl`, then
 lowercases the result, then wraps that in double quotes.
@@ -27,12 +27,13 @@ lowercases the result, then wraps that in double quotes.
 value: {{ include "mytpl" . | lower | quote }}
 ```
 
-The `required` function allows you to declare a particular
-values entry as required for template rendering.  If the value is empty, the template
-rendering will fail with a user submitted error message.
+The `required` function allows you to declare a particular values entry as
+required for template rendering.  If the value is empty, the template rendering
+will fail with a user submitted error message.
 
-The following example of the `required` function declares an entry for .Values.who
-is required, and will print an error message when that entry is missing:
+The following example of the `required` function declares an entry for
+.Values.who is required, and will print an error message when that entry is
+missing:
 
 ```yaml
 value: {{ required "A valid .Values.who entry required!" .Values.who }}
@@ -40,21 +41,22 @@ value: {{ required "A valid .Values.who entry required!" .Values.who }}
 
 ## Quote Strings, Don't Quote Integers
 
-When you are working with string data, you are always safer quoting the
-strings than leaving them as bare words:
+When you are working with string data, you are always safer quoting the strings
+than leaving them as bare words:
 
 ```yaml
 name: {{ .Values.MyName | quote }}
 ```
 
-But when working with integers _do not quote the values._ That can, in
-many cases, cause parsing errors inside of Kubernetes.
+But when working with integers _do not quote the values._ That can, in many
+cases, cause parsing errors inside of Kubernetes.
 
 ```yaml
 port: {{ .Values.Port }}
 ```
 
-This remark does not apply to env variables values which are expected to be string, even if they represent integers:
+This remark does not apply to env variables values which are expected to be
+string, even if they represent integers:
 
 ```yaml
 env:
@@ -67,35 +69,35 @@ env:
 ## Using the 'include' Function
 
 Go provides a way of including one template in another using a built-in
-`template` directive. However, the built-in function cannot be used in
-Go template pipelines.
+`template` directive. However, the built-in function cannot be used in Go
+template pipelines.
 
-To make it possible to include a template, and then perform an operation
-on that template's output, Helm has a special `include` function:
+To make it possible to include a template, and then perform an operation on that
+template's output, Helm has a special `include` function:
 
 ```
 {{ include "toYaml" $value | indent 2 }}
 ```
 
-The above includes a template called `toYaml`, passes it `$value`, and
-then passes the output of that template to the `indent` function.
+The above includes a template called `toYaml`, passes it `$value`, and then
+passes the output of that template to the `indent` function.
 
-Because YAML ascribes significance to indentation levels and whitespace,
-this is one great way to include snippets of code, but handle
-indentation in a relevant context.
+Because YAML ascribes significance to indentation levels and whitespace, this is
+one great way to include snippets of code, but handle indentation in a relevant
+context.
 
 ## Using the 'required' function
 
-Go provides a way for setting template options to control behavior
-when a map is indexed with a key that's not present in the map. This
-is typically set with template.Options("missingkey=option"), where option
-can be default, zero, or error. While setting this option to error will
-stop execution with an error, this would apply to every missing key in the
-map. There may be situations where a chart developer wants to enforce this
-behavior for select values in the values.yml file.
+Go provides a way for setting template options to control behavior when a map is
+indexed with a key that's not present in the map. This is typically set with
+template.Options("missingkey=option"), where option can be default, zero, or
+error. While setting this option to error will stop execution with an error,
+this would apply to every missing key in the map. There may be situations where
+a chart developer wants to enforce this behavior for select values in the
+values.yml file.
 
-The `required` function gives developers the ability to declare a value entry
-as required for template rendering. If the entry is empty in values.yml, the
+The `required` function gives developers the ability to declare a value entry as
+required for template rendering. If the entry is empty in values.yml, the
 template will not render and will return an error message supplied by the
 developer.
 
@@ -105,13 +107,18 @@ For example:
 {{ required "A valid foo is required!" .Values.foo }}
 ```
 
-The above will render the template when .Values.foo is defined, but will fail
-to render and exit when .Values.foo is undefined.
+The above will render the template when .Values.foo is defined, but will fail to
+render and exit when .Values.foo is undefined.
 
 ## Creating Image Pull Secrets
-Image pull secrets are essentially a combination of _registry_, _username_, and _password_.  You may need them in an application you are deploying, but to create them requires running _base64_ a couple of times.  We can write a helper template to compose the Docker configuration file for use as the Secret's payload.  Here is an example:
+Image pull secrets are essentially a combination of _registry_, _username_, and
+_password_.  You may need them in an application you are deploying, but to
+create them requires running _base64_ a couple of times.  We can write a helper
+template to compose the Docker configuration file for use as the Secret's
+payload.  Here is an example:
 
-First, assume that the credentials are defined in the `values.yaml` file like so:
+First, assume that the credentials are defined in the `values.yaml` file like
+so:
 ```yaml
 imageCredentials:
   registry: quay.io
@@ -126,7 +133,8 @@ We then define our helper template as follows:
 {{- end }}
 ```
 
-Finally, we use the helper template in a larger template to create the Secret manifest:
+Finally, we use the helper template in a larger template to create the Secret
+manifest:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -183,8 +191,8 @@ declarative method above.
 ## Tell Helm Not To Uninstall a Resource
 
 Sometimes there are resources that should not be uninstalled when Helm runs a
-`helm uninstall`. Chart developers can add an annotation to a resource to prevent
-it from being uninstalled.
+`helm uninstall`. Chart developers can add an annotation to a resource to
+prevent it from being uninstalled.
 
 ```yaml
 kind: Secret
@@ -198,33 +206,32 @@ metadata:
 
 The annotation `"helm.sh/resource-policy": keep` instructs Helm to skip this
 resource during a `helm uninstall` operation. _However_, this resource becomes
-orphaned. Helm will no longer manage it in any way. This can lead to problems
-if using `helm install --replace` on a release that has already been uninstalled, but
-has kept resources.
+orphaned. Helm will no longer manage it in any way. This can lead to problems if
+using `helm install --replace` on a release that has already been uninstalled,
+but has kept resources.
 
 ## Using "Partials" and Template Includes
 
-Sometimes you want to create some reusable parts in your chart, whether
-they're blocks or template partials. And often, it's cleaner to keep
-these in their own files.
+Sometimes you want to create some reusable parts in your chart, whether they're
+blocks or template partials. And often, it's cleaner to keep these in their own
+files.
 
-In the `templates/` directory, any file that begins with an
-underscore(`_`) is not expected to output a Kubernetes manifest file. So
-by convention, helper templates and partials are placed in a
-`_helpers.tpl` file.
+In the `templates/` directory, any file that begins with an underscore(`_`) is
+not expected to output a Kubernetes manifest file. So by convention, helper
+templates and partials are placed in a `_helpers.tpl` file.
 
 ## Complex Charts with Many Dependencies
 
-Many of the charts in the [official charts repository](https://github.com/helm/charts)
-are "building blocks" for creating more advanced applications. But charts may be
-used to create instances of large-scale applications. In such cases, a single
-umbrella chart may have multiple subcharts, each of which functions as a piece
-of the whole.
+Many of the charts in the [official charts
+repository](https://github.com/helm/charts) are "building blocks" for creating
+more advanced applications. But charts may be used to create instances of
+large-scale applications. In such cases, a single umbrella chart may have
+multiple subcharts, each of which functions as a piece of the whole.
 
-The current best practice for composing a complex application from discrete parts
-is to create a top-level umbrella chart that
-exposes the global configurations, and then use the `charts/` subdirectory to
-embed each of the components.
+The current best practice for composing a complex application from discrete
+parts is to create a top-level umbrella chart that exposes the global
+configurations, and then use the `charts/` subdirectory to embed each of the
+components.
 
 Two strong design patterns are illustrated by these projects:
 
@@ -232,39 +239,40 @@ Two strong design patterns are illustrated by these projects:
 installs a full OpenStack IaaS on Kubernetes. All of the charts are collected
 together in one GitHub repository.
 
-**Deis's [Workflow](https://github.com/deis/workflow/tree/master/charts/workflow):**
-This chart exposes the entire Deis PaaS system with one chart. But it's different
+**Deis's
+[Workflow](https://github.com/deis/workflow/tree/master/charts/workflow):** This
+chart exposes the entire Deis PaaS system with one chart. But it's different
 from the SAP chart in that this umbrella chart is built from each component, and
 each component is tracked in a different Git repository. Check out the
 `requirements.yaml` file to see how this chart is composed by their CI/CD
 pipeline.
 
-Both of these charts illustrate proven techniques for standing up complex environments
-using Helm.
+Both of these charts illustrate proven techniques for standing up complex
+environments using Helm.
 
 ## YAML is a Superset of JSON
 
-According to the YAML specification, YAML is a superset of JSON. That
-means that any valid JSON structure ought to be valid in YAML.
+According to the YAML specification, YAML is a superset of JSON. That means that
+any valid JSON structure ought to be valid in YAML.
 
-This has an advantage: Sometimes template developers may find it easier
-to express a datastructure with a JSON-like syntax rather than deal with
-YAML's whitespace sensitivity.
+This has an advantage: Sometimes template developers may find it easier to
+express a datastructure with a JSON-like syntax rather than deal with YAML's
+whitespace sensitivity.
 
-As a best practice, templates should follow a YAML-like syntax _unless_
-the JSON syntax substantially reduces the risk of a formatting issue.
+As a best practice, templates should follow a YAML-like syntax _unless_ the JSON
+syntax substantially reduces the risk of a formatting issue.
 
 ## Be Careful with Generating Random Values
 
 There are functions in Helm that allow you to generate random data,
-cryptographic keys, and so on. These are fine to use. But be aware that
-during upgrades, templates are re-executed. When a template run
-generates data that differs from the last run, that will trigger an
-update of that resource.
+cryptographic keys, and so on. These are fine to use. But be aware that during
+upgrades, templates are re-executed. When a template run generates data that
+differs from the last run, that will trigger an update of that resource.
 
 ## Upgrade a release idempotently
 
-In order to use the same command when installing and upgrading a release, use the following command:
+In order to use the same command when installing and upgrading a release, use
+the following command:
 ```shell
 helm upgrade --install <release name> --values <values file> <chart directory>
 ```

--- a/content/docs/intro/getting_started.md
+++ b/content/docs/intro/getting_started.md
@@ -3,14 +3,16 @@ title: "Getting Started with a Chart Template"
 description: "A quick guide on Chart templates."
 ---
 
-In this section of the guide, we'll create a chart and then add a first template. The chart we created here will be used throughout the rest of the guide.
+In this section of the guide, we'll create a chart and then add a first
+template. The chart we created here will be used throughout the rest of the
+guide.
 
 To get going, let's take a brief look at a Helm chart.
 
 ## Charts
 
-As described in the [Charts Guide](../../topics/charts), Helm charts are structured like
-this:
+As described in the [Charts Guide](../../topics/charts), Helm charts are
+structured like this:
 
 ```
 mychart/
@@ -22,18 +24,18 @@ mychart/
 ```
 
 The `templates/` directory is for template files. When Helm evaluates a chart,
-it will send all of the files in the `templates/` directory through the
-template rendering engine. It then collects the results of those templates
-and sends them on to Kubernetes.
+it will send all of the files in the `templates/` directory through the template
+rendering engine. It then collects the results of those templates and sends them
+on to Kubernetes.
 
 The `values.yaml` file is also important to templates. This file contains the
 _default values_ for a chart. These values may be overridden by users during
 `helm install` or `helm upgrade`.
 
 The `Chart.yaml` file contains a description of the chart. You can access it
-from within a template. The `charts/` directory _may_ contain other charts (which
-we call _subcharts_). Later in this guide we will see how those work when it
-comes to template rendering.
+from within a template. The `charts/` directory _may_ contain other charts
+(which we call _subcharts_). Later in this guide we will see how those work when
+it comes to template rendering.
 
 ## A Starter Chart
 
@@ -49,22 +51,29 @@ From here on, we'll be working in the `mychart` directory.
 
 ### A Quick Glimpse of `mychart/templates/`
 
-If you take a look at the `mychart/templates/` directory, you'll notice a few files
-already there.
+If you take a look at the `mychart/templates/` directory, you'll notice a few
+files already there.
 
-- `NOTES.txt`: The "help text" for your chart. This will be displayed to your users
-  when they run `helm install`.
-- `deployment.yaml`: A basic manifest for creating a Kubernetes [deployment](http://kubernetes.io/docs/user-guide/deployments/)
-- `service.yaml`: A basic manifest for creating a [service endpoint](http://kubernetes.io/docs/user-guide/services/) for your deployment
-- `_helpers.tpl`: A place to put template helpers that you can re-use throughout the chart
+- `NOTES.txt`: The "help text" for your chart. This will be displayed to your
+  users when they run `helm install`.
+- `deployment.yaml`: A basic manifest for creating a Kubernetes
+  [deployment](http://kubernetes.io/docs/user-guide/deployments/)
+- `service.yaml`: A basic manifest for creating a [service
+  endpoint](http://kubernetes.io/docs/user-guide/services/) for your deployment
+- `_helpers.tpl`: A place to put template helpers that you can re-use throughout
+  the chart
 
-And what we're going to do is... _remove them all!_ That way we can work through our tutorial from scratch. We'll actually create our own `NOTES.txt` and `_helpers.tpl` as we go.
+And what we're going to do is... _remove them all!_ That way we can work through
+our tutorial from scratch. We'll actually create our own `NOTES.txt` and
+`_helpers.tpl` as we go.
 
 ```console
 $ rm -rf mychart/templates/*.*
 ```
 
-When you're writing production grade charts, having basic versions of these charts can be really useful. So in your day-to-day chart authoring, you probably won't want to remove them.
+When you're writing production grade charts, having basic versions of these
+charts can be really useful. So in your day-to-day chart authoring, you probably
+won't want to remove them.
 
 ## A First Template
 
@@ -85,15 +94,16 @@ data:
   myvalue: "Hello World"
 ```
 
-**TIP:** Template names do not follow a rigid naming pattern. However, we recommend
-using the suffix `.yaml` for YAML files and `.tpl` for helpers.
+**TIP:** Template names do not follow a rigid naming pattern. However, we
+recommend using the suffix `.yaml` for YAML files and `.tpl` for helpers.
 
-The YAML file above is a bare-bones ConfigMap, having the minimal necessary fields.
-In virtue of the fact that this file is in the `templates/` directory, it will
-be sent through the template engine.
+The YAML file above is a bare-bones ConfigMap, having the minimal necessary
+fields. In virtue of the fact that this file is in the `templates/` directory,
+it will be sent through the template engine.
 
-It is just fine to put a plain YAML file like this in the `templates/` directory.
-When Helm reads this template, it will simply send it to Kubernetes as-is.
+It is just fine to put a plain YAML file like this in the `templates/`
+directory. When Helm reads this template, it will simply send it to Kubernetes
+as-is.
 
 With this simple template, we now have an installable chart. And we can install
 it like this:
@@ -140,13 +150,14 @@ Now we can uninstall our release: `helm uninstall full-coral`.
 
 ### Adding a Simple Template Call
 
-Hard-coding the `name:` into a resource is usually considered to be bad practice.
-Names should be unique to a release. So we might want to generate a name field
-by inserting the release name.
+Hard-coding the `name:` into a resource is usually considered to be bad
+practice. Names should be unique to a release. So we might want to generate a
+name field by inserting the release name.
 
 **TIP:** The `name:` field is limited to 63 characters because of limitations to
 the DNS system. For that reason, release names are limited to 53 characters.
-Kubernetes 1.3 and earlier limited to only 24 characters (thus 14 character names).
+Kubernetes 1.3 and earlier limited to only 24 characters (thus 14 character
+names).
 
 Let's alter `configmap.yaml` accordingly.
 
@@ -159,18 +170,26 @@ data:
   myvalue: "Hello World"
 ```
 
-The big change comes in the value of the `name:` field, which is now
-`{{ .Release.Name }}-configmap`.
+The big change comes in the value of the `name:` field, which is now `{{
+.Release.Name }}-configmap`.
 
 > A template directive is enclosed in `{{` and `}}` blocks.
 
-The template directive `{{ .Release.Name }}` injects the release name into the template. The values that are passed into a template can be thought of as _namespaced objects_, where a dot (`.`) separates each namespaced element.
+The template directive `{{ .Release.Name }}` injects the release name into the
+template. The values that are passed into a template can be thought of as
+_namespaced objects_, where a dot (`.`) separates each namespaced element.
 
-The leading dot before `Release` indicates that we start with the top-most namespace for this scope (we'll talk about scope in a bit). So we could read `.Release.Name` as "start at the top namespace, find the `Release` object, then look inside of it for an object called `Name`".
+The leading dot before `Release` indicates that we start with the top-most
+namespace for this scope (we'll talk about scope in a bit). So we could read
+`.Release.Name` as "start at the top namespace, find the `Release` object, then
+look inside of it for an object called `Name`".
 
-The `Release` object is one of the built-in objects for Helm, and we'll cover it in more depth later. But for now, it is sufficient to say that this will display the release name that the library assigns to our release.
+The `Release` object is one of the built-in objects for Helm, and we'll cover it
+in more depth later. But for now, it is sufficient to say that this will display
+the release name that the library assigns to our release.
 
-Now when we install our resource, we'll immediately see the result of using this template directive:
+Now when we install our resource, we'll immediately see the result of using this
+template directive:
 
 ```console
 $ helm install ./mychart
@@ -185,12 +204,19 @@ NAME                      DATA      AGE
 clunky-serval-configmap   1         1m
 ```
 
-Note that in the `RESOURCES` section, the name we see there is `clunky-serval-configmap`
-instead of `mychart-configmap`.
+Note that in the `RESOURCES` section, the name we see there is
+`clunky-serval-configmap` instead of `mychart-configmap`.
 
 You can run `helm get manifest clunky-serval` to see the entire generated YAML.
 
-At this point, we've seen templates at their most basic: YAML files that have template directives embedded in `{{` and `}}`. In the next part, we'll take a deeper look into templates. But before moving on, there's one quick trick that can make building templates faster: When you want to test the template rendering, but not actually install anything, you can use `helm install --debug --dry-run ./mychart`. This will render the templates. But instead of installing the chart, it will return the rendered template to you so you can see the output:
+At this point, we've seen templates at their most basic: YAML files that have
+template directives embedded in `{{` and `}}`. In the next part, we'll take a
+deeper look into templates. But before moving on, there's one quick trick that
+can make building templates faster: When you want to test the template
+rendering, but not actually install anything, you can use `helm install --debug
+--dry-run ./mychart`. This will render the templates. But instead of installing
+the chart, it will return the rendered template to you so you can see the
+output:
 
 ```console
 $ helm install --debug --dry-run ./mychart
@@ -211,6 +237,10 @@ data:
 
 ```
 
-Using `--dry-run` will make it easier to test your code, but it won't ensure that Kubernetes itself will accept the templates you generate. It's best not to assume that your chart will install just because `--dry-run` works.
+Using `--dry-run` will make it easier to test your code, but it won't ensure
+that Kubernetes itself will accept the templates you generate. It's best not to
+assume that your chart will install just because `--dry-run` works.
 
-In the [Chart Template Guide](../../topics/chart_template_guide), we take the basic chart we defined here and explore the Helm template language in detail. And we'll get started with built-in objects.
+In the [Chart Template Guide](../../topics/chart_template_guide), we take the
+basic chart we defined here and explore the Helm template language in detail.
+And we'll get started with built-in objects.

--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -4,18 +4,19 @@ description: "Learn how to install and get running with Helm."
 weight: 2
 ---
 
-This guide shows how to install the Helm CLI. Helm can be installed either from source, or from pre-built binary releases.
+This guide shows how to install the Helm CLI. Helm can be installed either from
+source, or from pre-built binary releases.
 
 ### From the Binary Releases
 
-Every [release](https://github.com/helm/helm/releases) of Helm
-provides binary releases for a variety of OSes. These binary versions
-can be manually downloaded and installed.
+Every [release](https://github.com/helm/helm/releases) of Helm provides binary
+releases for a variety of OSes. These binary versions can be manually downloaded
+and installed.
 
 1. Download your [desired version](https://github.com/helm/helm/releases)
 2. Unpack it (`tar -zxvf helm-v2.0.0-linux-amd64.tgz`)
-3. Find the `helm` binary in the unpacked directory, and move it to its
-   desired destination (`mv linux-amd64/helm /usr/local/bin/helm`)
+3. Find the `helm` binary in the unpacked directory, and move it to its desired
+   destination (`mv linux-amd64/helm /usr/local/bin/helm`)
 
 From there, you should be able to run the client: `helm help`.
 
@@ -28,12 +29,12 @@ Homebrew. This formula is generally up to date.
 brew install kubernetes-helm
 ```
 
-(Note: There is also a formula for emacs-helm, which is a different
-project.)
+(Note: There is also a formula for emacs-helm, which is a different project.)
 
 ### From Chocolatey (Windows)
 
-Members of the Kubernetes community have contributed a [Helm package](https://chocolatey.org/packages/kubernetes-helm) build to
+Members of the Kubernetes community have contributed a [Helm
+package](https://chocolatey.org/packages/kubernetes-helm) build to
 [Chocolatey](https://chocolatey.org/). This package is generally up to date.
 
 ```console
@@ -43,7 +44,8 @@ choco install kubernetes-helm
 ## From Script
 
 Helm now has an installer script that will automatically grab the latest version
-of Helm and [install it locally](https://raw.githubusercontent.com/helm/helm/master/scripts/get).
+of Helm and [install it
+locally](https://raw.githubusercontent.com/helm/helm/master/scripts/get).
 
 You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
@@ -54,29 +56,31 @@ $ chmod 700 get_helm.sh
 $ ./get_helm.sh
 ```
 
-Yes, you can `curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash` that if you want to live on the edge.
+Yes, you can `curl
+https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash` that if
+you want to live on the edge.
 
 ### From Canary Builds
 
-"Canary" builds are versions of the Helm software that are built from
-the latest master branch. They are not official releases, and may not be
-stable. However, they offer the opportunity to test the cutting edge
-features.
+"Canary" builds are versions of the Helm software that are built from the latest
+master branch. They are not official releases, and may not be stable. However,
+they offer the opportunity to test the cutting edge features.
 
-Canary Helm binaries are stored at [get.helm.sh](https://get.helm.sh).
-Here are links to the common builds:
+Canary Helm binaries are stored at [get.helm.sh](https://get.helm.sh). Here are
+links to the common builds:
 
 - [Linux AMD64](https://get.helm.sh/helm-canary-linux-amd64.tar.gz)
 - [macOS AMD64](https://get.helm.sh/helm-canary-darwin-amd64.tar.gz)
-- [Experimental Windows AMD64](https://get.helm.sh/helm-canary-windows-amd64.zip)
+- [Experimental Windows
+  AMD64](https://get.helm.sh/helm-canary-windows-amd64.zip)
 
 ### From Source (Linux, macOS)
 
-Building Helm from source is slightly more work, but is the best way to
-go if you want to test the latest (pre-release) Helm version.
+Building Helm from source is slightly more work, but is the best way to go if
+you want to test the latest (pre-release) Helm version.
 
-You must have a working Go environment with
-[dep](https://github.com/golang/dep) installed.
+You must have a working Go environment with [dep](https://github.com/golang/dep)
+installed.
 
 ```console
 $ cd $GOPATH
@@ -87,15 +91,14 @@ $ cd helm
 $ make
 ```
 
-If required, it will first install dependencies, rebuild the
-`vendor/` tree, and validate configuration. It will then compile `helm` and
-place it in `bin/helm`.
+If required, it will first install dependencies, rebuild the `vendor/` tree, and
+validate configuration. It will then compile `helm` and place it in `bin/helm`.
 
 ## Conclusion
 
-In most cases, installation is as simple as getting a pre-built `helm`
-binary. This document covers additional cases for those who want to do
-more sophisticated things with Helm.
+In most cases, installation is as simple as getting a pre-built `helm` binary.
+This document covers additional cases for those who want to do more
+sophisticated things with Helm.
 
-Once you have the Helm Client successfully installed, you can
-move on to using Helm to manage charts.
+Once you have the Helm Client successfully installed, you can move on to using
+Helm to manage charts.

--- a/content/docs/intro/kubernetes_distros.md
+++ b/content/docs/intro/kubernetes_distros.md
@@ -5,25 +5,48 @@ weight: 4
 ---
 
 This document captures information about using Helm in specific Kubernetes
-environments.
+environments. Distros are sorted alphabetically so as to not imply any sort of
+preference.
 
 We are trying to add more details to this document. Please contribute via Pull
-Requests if you can.
+Requests if you can. 
 
-## MiniKube
+## DC/OS
 
-Helm is tested and known to work with [minikube](https://github.com/kubernetes/minikube).
-It requires no additional configuration.
+Helm has been tested and is working on Mesospheres DC/OS 1.11 Kubernetes
+platform, and requires no additional configuration.
+
+## GKE
+
+Google's GKE hosted Kubernetes platform is known to work with Helm, and requires
+no additional configuration.
 
 ## `scripts/local-cluster` and Hyperkube
 
 Hyperkube configured via `scripts/local-cluster.sh` is known to work. For raw
 Hyperkube you may need to do some manual configuration.
 
-## GKE
+## MiniKube
 
-Google's GKE hosted Kubernetes platform is known to work with Helm, and requires
-no additional configuration.
+Helm is tested and known to work with
+[minikube](https://github.com/kubernetes/minikube). It requires no additional
+configuration.
+
+## Openshift
+
+Helm works straightforward on OpenShift Online, OpenShift Dedicated, OpenShift
+Container Platform (version >= 3.6) or OpenShift Origin (version >= 3.6). To
+learn more read [this
+blog](https://blog.openshift.com/getting-started-helm-openshift/) post.
+
+## Platform9
+
+Helm is pre-installed with [Platform9 Managed
+Kubernetes](https://platform9.com/managed-kubernetes/?utm_source=helm_distro_notes).
+Platform9 provides access to all official Helm charts through the App Catalog UI
+and native Kubernetes CLI. Additional repositories can be manually added.
+Further details are available in this [Platform9 App Catalog
+article](https://platform9.com/support/deploying-kubernetes-apps-platform9-managed-kubernetes/?utm_source=helm_distro_notes).
 
 ## Ubuntu with 'kubeadm'
 
@@ -33,18 +56,5 @@ distributions:
 - Ubuntu 16.04
 - Fedora release 25
 
-Some versions of Helm (v2.0.0-beta2) require you to `export KUBECONFIG=/etc/kubernetes/admin.conf`
-or create a `~/.kube/config`.
-
-## Openshift
-
-Helm works straightforward on OpenShift Online, OpenShift Dedicated, OpenShift Container Platform (version >= 3.6) or OpenShift Origin (version >= 3.6). To learn more read [this blog](https://blog.openshift.com/getting-started-helm-openshift/) post.
-
-## Platform9
-
-Helm is pre-installed with [Platform9 Managed Kubernetes](https://platform9.com/managed-kubernetes/?utm_source=helm_distro_notes). Platform9 provides access to all official Helm charts through the App Catalog UI and native Kubernetes CLI. Additional repositories can be manually added. Further details are available in this [Platform9 App Catalog article](https://platform9.com/support/deploying-kubernetes-apps-platform9-managed-kubernetes/?utm_source=helm_distro_notes).
-
-## DC/OS
-
-Helm has been tested and is working on Mesospheres DC/OS 1.11 Kubernetes platform, and requires no additional configuration.
-
+Some versions of Helm (v2.0.0-beta2) require you to `export
+KUBECONFIG=/etc/kubernetes/admin.conf` or create a `~/.kube/config`.

--- a/content/docs/intro/quickstart.md
+++ b/content/docs/intro/quickstart.md
@@ -8,7 +8,8 @@ This guide covers how you can quickly get started using Helm.
 
 ## Prerequisites
 
-The following prerequisites are required for a successful and properly secured use of Helm.
+The following prerequisites are required for a successful and properly secured
+use of Helm.
 
 1. A Kubernetes cluster
 2. Deciding what security configurations to apply to your installation, if any
@@ -17,34 +18,48 @@ The following prerequisites are required for a successful and properly secured u
 
 ### Install Kubernetes or have access to a cluster
 
-- You must have Kubernetes installed. For the latest release of Helm, we recommend the latest stable release of Kubernetes, which in most cases is the second-latest minor release.
+- You must have Kubernetes installed. For the latest release of Helm, we
+  recommend the latest stable release of Kubernetes, which in most cases is the
+  second-latest minor release.
 - You should also have a local configured copy of `kubectl`.
 
-NOTE: Kubernetes versions prior to 1.6 have limited or no support for role-based access controls (RBAC).
+NOTE: Kubernetes versions prior to 1.6 have limited or no support for role-based
+access controls (RBAC).
 
 
 ### Understand your Security Context
 
-As with all powerful tools, ensure you are installing it correctly for your scenario.
+As with all powerful tools, ensure you are installing it correctly for your
+scenario.
 
-If you're using Helm on a cluster that you completely control, like minikube or a cluster on a private network in which sharing is not a concern, the default installation -- which applies no security configuration -- is fine, and it's definitely the easiest. To install Helm without additional security steps, [install Helm](#Install-Helm) and then [initialize Helm](#initialize-helm).
+If you're using Helm on a cluster that you completely control, like minikube or
+a cluster on a private network in which sharing is not a concern, the default
+installation -- which applies no security configuration -- is fine, and it's
+definitely the easiest. To install Helm without additional security steps,
+[install Helm](#Install-Helm) and then [initialize Helm](#initialize-helm).
 
-However, if your cluster is exposed to a larger network or if you share your cluster with others -- production clusters fall into this category -- you must take extra steps to secure your installation to prevent careless or malicious actors from damaging the cluster or its data. To apply configurations that secure Helm for use in production environments and other multi-tenant scenarios, see [Securing a Helm installation](securing_installation.md)
+However, if your cluster is exposed to a larger network or if you share your
+cluster with others -- production clusters fall into this category -- you must
+take extra steps to secure your installation to prevent careless or malicious
+actors from damaging the cluster or its data. To apply configurations that
+secure Helm for use in production environments and other multi-tenant scenarios,
+see [Securing a Helm installation](securing_installation.md)
 
-If your cluster has Role-Based Access Control (RBAC) enabled, you may want
-to [configure a service account and rules](rbac.md) before proceeding.
+If your cluster has Role-Based Access Control (RBAC) enabled, you may want to
+[configure a service account and rules](rbac.md) before proceeding.
 
 ## Install Helm
 
-Download a binary release of the Helm client. You can use tools like
-`homebrew`, or look at [the official releases page](https://github.com/helm/helm/releases).
+Download a binary release of the Helm client. You can use tools like `homebrew`,
+or look at [the official releases page](https://github.com/helm/helm/releases).
 
 For more details, or for other options, see [the installation
 guide](install.md).
 
 ## Initialize a Helm Chart Repository
 
-Once you have Helm ready, you can add a chart repository. One popular starting location is the official Helm stable charts:
+Once you have Helm ready, you can add a chart repository. One popular starting
+location is the official Helm stable charts:
 
 ```console
 $ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
@@ -54,19 +69,19 @@ Once this is installed, you will be able to list the charts you can install:
 
 ```console
 helm search repo stable
-NAME                                 	CHART VERSION	APP VERSION                 	DESCRIPTION
-stable/acs-engine-autoscaler         	2.2.2        	2.1.1                       	DEPRECATED Scales worker nodes within agent pools
-stable/aerospike                     	0.2.8        	v4.5.0.5                    	A Helm chart for Aerospike in Kubernetes
-stable/airflow                       	4.1.0        	1.10.4                      	Airflow is a platform to programmatically autho...
-stable/ambassador                    	4.1.0        	0.81.0                      	A Helm chart for Datawire Ambassador
+NAME                                    CHART VERSION   APP VERSION                     DESCRIPTION
+stable/acs-engine-autoscaler            2.2.2           2.1.1                           DEPRECATED Scales worker nodes within agent pools
+stable/aerospike                        0.2.8           v4.5.0.5                        A Helm chart for Aerospike in Kubernetes
+stable/airflow                          4.1.0           1.10.4                          Airflow is a platform to programmatically autho...
+stable/ambassador                       4.1.0           0.81.0                          A Helm chart for Datawire Ambassador
 # ... and many more
 ```
 
 ## Install an Example Chart
 
-To install a chart, you can run the `helm install` command. Helm has
-several ways to find and install a chart, but the easiest is to use one
-of the official `stable` charts.
+To install a chart, you can run the `helm install` command. Helm has several
+ways to find and install a chart, but the easiest is to use one of the official
+`stable` charts.
 
 ```console
 $ helm repo update              # Make sure we get the latest list of charts
@@ -74,17 +89,16 @@ $ helm install stable/mysql --generate-name
 Released smiling-penguin
 ```
 
-In the example above, the `stable/mysql` chart was released, and the name of
-our new release is `smiling-penguin`. You get a simple idea of the
-features of this MySQL chart by running `helm inspect stable/mysql`.
+In the example above, the `stable/mysql` chart was released, and the name of our
+new release is `smiling-penguin`. You get a simple idea of the features of this
+MySQL chart by running `helm inspect stable/mysql`.
 
-Whenever you install a chart, a new release is created. So one chart can
-be installed multiple times into the same cluster. And each can be
-independently managed and upgraded.
+Whenever you install a chart, a new release is created. So one chart can be
+installed multiple times into the same cluster. And each can be independently
+managed and upgraded.
 
-The `helm install` command is a very powerful command with many
-capabilities. To learn more about it, check out the [Using Helm
-Guide](using_helm.md)
+The `helm install` command is a very powerful command with many capabilities. To
+learn more about it, check out the [Using Helm Guide](using_helm.md)
 
 ## Learn About Releases
 
@@ -107,8 +121,8 @@ $ helm uninstall smiling-penguin
 Removed smiling-penguin
 ```
 
-This will uninstall `smiling-penguin` from Kubernetes, but you will
-still be able to request information about that release:
+This will uninstall `smiling-penguin` from Kubernetes, but you will still be
+able to request information about that release:
 
 ```console
 $ helm status smiling-penguin
@@ -116,14 +130,13 @@ Status: UNINSTALLED
 ...
 ```
 
-Because Helm tracks your releases even after you've uninstalled them, you
-can audit a cluster's history, and even undelete a release (with `helm
-rollback`).
+Because Helm tracks your releases even after you've uninstalled them, you can
+audit a cluster's history, and even undelete a release (with `helm rollback`).
 
 ## Reading the Help Text
 
-To learn more about the available Helm commands, use `helm help` or type
-a command followed by the `-h` flag:
+To learn more about the available Helm commands, use `helm help` or type a
+command followed by the `-h` flag:
 
 ```console
 $ helm get -h

--- a/content/docs/intro/rbac.md
+++ b/content/docs/intro/rbac.md
@@ -4,39 +4,76 @@ description: "Explains how Helm interacts with Kubernetes' Role-Based Access Con
 weight: 3
 ---
 
-In Kubernetes, granting roles to a user or an application-specific service account is a best practice to ensure that your application is operating in the scope that you have specified. Read more about service account permissions [in the official Kubernetes docs](https://kubernetes.io/docs/admin/authorization/rbac/#service-account-permissions).
+In Kubernetes, granting roles to a user or an application-specific service
+account is a best practice to ensure that your application is operating in the
+scope that you have specified. Read more about service account permissions [in
+the official Kubernetes
+docs](https://kubernetes.io/docs/admin/authorization/rbac/#service-account-permissions).
 
-From Kubernetes 1.6 onwards, Role-based Access Control is enabled by default. RBAC allows you to specify which types of actions are permitted depending on the user and their role in your organization.
+From Kubernetes 1.6 onwards, Role-based Access Control is enabled by default.
+RBAC allows you to specify which types of actions are permitted depending on the
+user and their role in your organization.
 
 With RBAC, you can
 
-- grant privileged operations (creating cluster-wide resources, like new roles) to administrators
-- limit a user's ability to create resources (pods, persistent volumes, deployments) to specific namespaces, or in cluster-wide scopes (resource quotas, roles, custom resource definitions)
-- limit a user's ability to view resources either in specific namespaces or at a cluster-wide scope.
+- grant privileged operations (creating cluster-wide resources, like new roles)
+  to administrators
+- limit a user's ability to create resources (pods, persistent volumes,
+  deployments) to specific namespaces, or in cluster-wide scopes (resource
+  quotas, roles, custom resource definitions)
+- limit a user's ability to view resources either in specific namespaces or at a
+  cluster-wide scope.
 
-This guide is for administrators who want to restrict the scope of a user's interaction with the Kubernetes API.
+This guide is for administrators who want to restrict the scope of a user's
+interaction with the Kubernetes API.
 
 ## Managing user accounts
 
-All Kubernetes clusters have two categories of users: service accounts managed by Kubernetes, and normal users.
+All Kubernetes clusters have two categories of users: service accounts managed
+by Kubernetes, and normal users.
 
-Normal users are assumed to be managed by an outside, independent service. An administrator distributing private keys, a user store like Keystone or Google Accounts, even a file with a list of usernames and passwords. In this regard, Kubernetes does not have objects which represent normal user accounts. Normal users cannot be added to a cluster through an API call.
+Normal users are assumed to be managed by an outside, independent service. An
+administrator distributing private keys, a user store like Keystone or Google
+Accounts, even a file with a list of usernames and passwords. In this regard,
+Kubernetes does not have objects which represent normal user accounts. Normal
+users cannot be added to a cluster through an API call.
 
-In contrast, service accounts are users managed by the Kubernetes API. They are bound to specific namespaces, and created automatically by the API server or manually through API calls. Service accounts are tied to a set of credentials stored as Secrets, which are mounted into pods allowing in-cluster processes to talk to the Kubernetes API.
+In contrast, service accounts are users managed by the Kubernetes API. They are
+bound to specific namespaces, and created automatically by the API server or
+manually through API calls. Service accounts are tied to a set of credentials
+stored as Secrets, which are mounted into pods allowing in-cluster processes to
+talk to the Kubernetes API.
 
-API requests are tied to either a normal user or a service account, or are treated as anonymous requests. This means every process inside or outside the cluster, from a human user typing `kubectl` on a workstation, to kubelets on nodes, to members of the control plane, must authenticate when making requests to the API server, or be treated as an anonymous user.
+API requests are tied to either a normal user or a service account, or are
+treated as anonymous requests. This means every process inside or outside the
+cluster, from a human user typing `kubectl` on a workstation, to kubelets on
+nodes, to members of the control plane, must authenticate when making requests
+to the API server, or be treated as an anonymous user.
 
 ## Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings
 
-In Kubernetes, user accounts and service accounts can only view and edit resources they have been granted access to. This access is granted through the use of Roles and RoleBindings. Roles and RoleBindings are bound to a particular namespace, which grant users the ability to view and/pr edit resources within that namespace the Role provides them access to.
+In Kubernetes, user accounts and service accounts can only view and edit
+resources they have been granted access to. This access is granted through the
+use of Roles and RoleBindings. Roles and RoleBindings are bound to a particular
+namespace, which grant users the ability to view and/pr edit resources within
+that namespace the Role provides them access to.
 
-At a cluster scope, these are called ClusterRoles and ClusterRoleBindings. Granting a user a ClusterRole grants them access to view and/or edit resources across the entire cluster. It is also required to view and/or edit resources at the cluster scope (namespaces, resource quotas, nodes).
+At a cluster scope, these are called ClusterRoles and ClusterRoleBindings.
+Granting a user a ClusterRole grants them access to view and/or edit resources
+across the entire cluster. It is also required to view and/or edit resources at
+the cluster scope (namespaces, resource quotas, nodes).
 
-ClusterRoles can be bound to a particular namespace through reference in a RoleBinding. The `admin`, `edit` and `view` default ClusterRoles are commonly used in this manner.
+ClusterRoles can be bound to a particular namespace through reference in a
+RoleBinding. The `admin`, `edit` and `view` default ClusterRoles are commonly
+used in this manner.
 
-These are a few ClusterRoles available by default in Kubernetes. They are intended to be user-facing roles. They include super-user roles (`cluster-admin`), and roles with more granular access (`admin`, `edit`, `view`).
+These are a few ClusterRoles available by default in Kubernetes. They are
+intended to be user-facing roles. They include super-user roles
+(`cluster-admin`), and roles with more granular access (`admin`, `edit`,
+`view`).
 
 | Default ClusterRole | Default ClusterRoleBinding | Description
+|---------------------|----------------------------|-------------
 | `cluster-admin`     | `system:masters` group     | Allows super-user access to perform any action on any resource. When used in a ClusterRoleBinding, it gives full control over every resource in the cluster and in all namespaces. When used in a RoleBinding, it gives full control over every resource in the rolebinding's namespace, including the namespace itself.
 | `admin`             | None                       | Allows admin access, intended to be granted within a namespace using a RoleBinding. If used in a RoleBinding, allows read/write access to most resources in a namespace, including the ability to create roles and rolebindings within the namespace. It does not allow write access to resource quota or to the namespace itself.
 | `edit`              | None                       | Allows read/write access to most objects in a namespace. It does not allow viewing or modifying roles or rolebindings.
@@ -44,15 +81,21 @@ These are a few ClusterRoles available by default in Kubernetes. They are intend
 
 ## Restricting a user account's access using RBAC
 
-Now that we understand the basics or Role-based Access Control, let's discuss how an administrator can restrict a user's scope of access.
+Now that we understand the basics or Role-based Access Control, let's discuss
+how an administrator can restrict a user's scope of access.
 
 ### Example: Grant a user read/write access to a particular namespace
 
-To restrict a user's access to a particular namespace, we can use either the `edit` or the `admin` role. If your charts create or interact with Roles and Rolebindings, you'll want to use the `admin` ClusterRole.
+To restrict a user's access to a particular namespace, we can use either the
+`edit` or the `admin` role. If your charts create or interact with Roles and
+Rolebindings, you'll want to use the `admin` ClusterRole.
 
-Additionally, you may also create a RoleBinding with `cluster-admin` access. Granting a user `cluster-admin` access at the namespace scope provides full control over every resource in the namespace, including the namespace itself.
+Additionally, you may also create a RoleBinding with `cluster-admin` access.
+Granting a user `cluster-admin` access at the namespace scope provides full
+control over every resource in the namespace, including the namespace itself.
 
-For this example, we will create a user with the `edit` Role. First, create the namespace:
+For this example, we will create a user with the `edit` Role. First, create the
+namespace:
 
 ```console
 $ kubectl create namespace foo
@@ -69,11 +112,17 @@ $ kubectl create rolebinding sam-edit
 
 ### Example: Grant a user read/write access at the cluster scope
 
-If a user wishes to install a chart that installs cluster-scope resources (namespaces, roles, custom resource definitions, etc.), they will require cluster-scope write access.
+If a user wishes to install a chart that installs cluster-scope resources
+(namespaces, roles, custom resource definitions, etc.), they will require
+cluster-scope write access.
 
 To do that, grant the user either `admin` or `cluster-admin` access.
 
-Granting a user `cluster-admin` access grants them access to absolutely every resource available in Kubernetes, including node access with `kubectl drain` and other administrative tasks. It is highly recommended to consider providing the user `admin` access instead, or to create a custom ClusterRole tailored to their needs.
+Granting a user `cluster-admin` access grants them access to absolutely every
+resource available in Kubernetes, including node access with `kubectl drain` and
+other administrative tasks. It is highly recommended to consider providing the
+user `admin` access instead, or to create a custom ClusterRole tailored to their
+needs.
 
 ```console
 $ kubectl create clusterrolebinding sam-view
@@ -87,11 +136,15 @@ $ kubectl create clusterrolebinding sam-secret-reader
 
 ### Example: Grant a user read-only access to a particular namespace
 
-You might've noticed that there is no ClusterRole available for viewing secrets. The `view` ClusterRole does not grant a user read access to Secrets due to escalation concerns. Helm stores release metadata as Secrets by default.
+You might've noticed that there is no ClusterRole available for viewing secrets.
+The `view` ClusterRole does not grant a user read access to Secrets due to
+escalation concerns. Helm stores release metadata as Secrets by default.
 
-In order for a user to run `helm list`, they need to be able to read these secrets. For that, we will create a special `secret-reader` ClusterRole.
+In order for a user to run `helm list`, they need to be able to read these
+secrets. For that, we will create a special `secret-reader` ClusterRole.
 
-Create the file `cluster-role-secret-reader.yaml` and write the following content into the file:
+Create the file `cluster-role-secret-reader.yaml` and write the following
+content into the file:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1​
@@ -110,7 +163,8 @@ Then, create the ClusterRole using
 $ kubectl create -f clusterrole-secret-reader.yaml​
 ```
 
-Once that's done, we can grant a user read access to most resources, and then grant them read access to secrets:
+Once that's done, we can grant a user read access to most resources, and then
+grant them read access to secrets:
 
 ```console
 $ kubectl create namespace foo
@@ -128,9 +182,12 @@ $ kubectl create rolebinding sam-secret-reader
 
 ### Example: Grant a user read-only access at the cluster scope
 
-In certain scenarios, it may be beneficial to grant a user cluster-scope access. For example, if a user wants to run the command `helm list --all-namespaces`, the API requires the user has cluster-scope read access.
+In certain scenarios, it may be beneficial to grant a user cluster-scope access.
+For example, if a user wants to run the command `helm list --all-namespaces`,
+the API requires the user has cluster-scope read access.
 
-To do that, grant the user both `view` and `secret-reader` access as described above, but with a ClusterRoleBinding.
+To do that, grant the user both `view` and `secret-reader` access as described
+above, but with a ClusterRoleBinding.
 
 ```console
 $ kubectl create clusterrolebinding sam-view
@@ -144,4 +201,8 @@ $ kubectl create clusterrolebinding sam-secret-reader
 
 ## Additional Thoughts
 
-The examples shown above utilize the default ClusterRoles provided with Kubernetes. For more fine-grained control over what resources users are granted access to, have a look at [the Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) on creating your own custom Roles and ClusterRoles.
+The examples shown above utilize the default ClusterRoles provided with
+Kubernetes. For more fine-grained control over what resources users are granted
+access to, have a look at [the Kubernetes
+documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) on
+creating your own custom Roles and ClusterRoles.

--- a/content/docs/intro/using_helm.md
+++ b/content/docs/intro/using_helm.md
@@ -4,73 +4,68 @@ description: "Explains the basics of Helm."
 weight: 3
 ---
 
-This guide explains the basics of using Helm to manage
-packages on your Kubernetes cluster. It assumes that you have already
-[installed](install.md) the Helm client and library (typically by `helm
-init`).
+This guide explains the basics of using Helm to manage packages on your
+Kubernetes cluster. It assumes that you have already [installed](install.md) the
+Helm client and library (typically by `helm init`).
 
-If you are simply interested in running a few quick commands, you may
-wish to begin with the [Quickstart Guide](quickstart.md). This chapter
-covers the particulars of Helm commands, and explains how to use Helm.
+If you are simply interested in running a few quick commands, you may wish to
+begin with the [Quickstart Guide](quickstart.md). This chapter covers the
+particulars of Helm commands, and explains how to use Helm.
 
 ## Three Big Concepts
 
 A *Chart* is a Helm package. It contains all of the resource definitions
 necessary to run an application, tool, or service inside of a Kubernetes
-cluster. Think of it like the Kubernetes equivalent of a Homebrew formula,
-an Apt dpkg, or a Yum RPM file.
+cluster. Think of it like the Kubernetes equivalent of a Homebrew formula, an
+Apt dpkg, or a Yum RPM file.
 
-A *Repository* is the place where charts can be collected and shared.
-It's like Perl's [CPAN archive](http://www.cpan.org) or the
-[Fedora Package Database](https://admin.fedoraproject.org/pkgdb/), but for
-Kubernetes packages.
+A *Repository* is the place where charts can be collected and shared. It's like
+Perl's [CPAN archive](http://www.cpan.org) or the [Fedora Package
+Database](https://admin.fedoraproject.org/pkgdb/), but for Kubernetes packages.
 
-A *Release* is an instance of a chart running in a Kubernetes cluster.
-One chart can often be installed many times into the same cluster. And
-each time it is installed, a new _release_ is created. Consider a MySQL
-chart. If you want two databases running in your cluster, you can
-install that chart twice. Each one will have its own _release_, which
-will in turn have its own _release name_.
+A *Release* is an instance of a chart running in a Kubernetes cluster. One chart
+can often be installed many times into the same cluster. And each time it is
+installed, a new _release_ is created. Consider a MySQL chart. If you want two
+databases running in your cluster, you can install that chart twice. Each one
+will have its own _release_, which will in turn have its own _release name_.
 
 With these concepts in mind, we can now explain Helm like this:
 
-Helm installs _charts_ into Kubernetes, creating a new _release_ for
-each installation. And to find new charts, you can search Helm chart
-_repositories_.
+Helm installs _charts_ into Kubernetes, creating a new _release_ for each
+installation. And to find new charts, you can search Helm chart _repositories_.
 
 ## 'helm search': Finding Charts
 
 When you first install Helm, it is preconfigured to talk to the official
-Kubernetes charts repository. This repository contains a number of
-carefully curated and maintained charts. This chart repository is named
-`stable` by default.
+Kubernetes charts repository. This repository contains a number of carefully
+curated and maintained charts. This chart repository is named `stable` by
+default.
 
 You can see which charts are available by running `helm search`:
 
 ```console
 $ helm search
-NAME                 	VERSION 	DESCRIPTION
-stable/drupal   	0.3.2   	One of the most versatile open source content m...
-stable/jenkins  	0.1.0   	A Jenkins Helm chart for Kubernetes.
-stable/mariadb  	0.5.1   	Chart for MariaDB
-stable/mysql    	0.1.0   	Chart for MySQL
+NAME                  VERSION   DESCRIPTION
+stable/drupal     0.3.2     One of the most versatile open source content m...
+stable/jenkins    0.1.0     A Jenkins Helm chart for Kubernetes.
+stable/mariadb    0.5.1     Chart for MariaDB
+stable/mysql      0.1.0     Chart for MySQL
 ...
 ```
 
-With no filter, `helm search` shows you all of the available charts. You
-can narrow down your results by searching with a filter:
+With no filter, `helm search` shows you all of the available charts. You can
+narrow down your results by searching with a filter:
 
 ```console
 $ helm search mysql
-NAME               	VERSION	DESCRIPTION
-stable/mysql  	0.1.0  	Chart for MySQL
-stable/mariadb	0.5.1  	Chart for MariaDB
+NAME                VERSION DESCRIPTION
+stable/mysql    0.1.0   Chart for MySQL
+stable/mariadb  0.5.1   Chart for MariaDB
 ```
 
 Now you will only see the results that match your filter.
 
-Why is
-`mariadb` in the list? Because its package description relates it to
+Why is `mariadb` in the list? Because its package description relates it to
 MySQL. We can use `helm inspect chart` to see this:
 
 ```console
@@ -86,13 +81,13 @@ keywords:
 ...
 ```
 
-Search is a good way to find available packages. Once you have found a
-package you want to install, you can use `helm install` to install it.
+Search is a good way to find available packages. Once you have found a package
+you want to install, you can use `helm install` to install it.
 
 ## 'helm install': Installing a Package
 
-To install a new package, use the `helm install` command. At its
-simplest, it takes only one argument: The name of the chart.
+To install a new package, use the `helm install` command. At its simplest, it
+takes only one argument: The name of the chart.
 
 ```console
 $ helm install --generate-name stable/mariadb
@@ -125,22 +120,20 @@ To connect to your database run the following command:
    kubectl run happy-panda-mariadb-client --rm --tty -i --image bitnami/mariadb --command -- mysql -h happy-panda-mariadb
 ```
 
-Now the `mariadb` chart is installed. Note that installing a chart
-creates a new _release_ object. The release above is named
-`happy-panda`. (If you want to use your own release name, simply use the
-`--name` flag on `helm install`.)
+Now the `mariadb` chart is installed. Note that installing a chart creates a new
+_release_ object. The release above is named `happy-panda`. (If you want to use
+your own release name, simply use the `--name` flag on `helm install`.)
 
-During installation, the `helm` client will print useful information
-about which resources were created, what the state of the release is,
-and also whether there are additional configuration steps you can or
-should take.
+During installation, the `helm` client will print useful information about which
+resources were created, what the state of the release is, and also whether there
+are additional configuration steps you can or should take.
 
-Helm does not wait until all of the resources are running before it
-exits. Many charts require Docker images that are over 600M in size, and
-may take a long time to install into the cluster.
+Helm does not wait until all of the resources are running before it exits. Many
+charts require Docker images that are over 600M in size, and may take a long
+time to install into the cluster.
 
-To keep track of a release's state, or to re-read configuration
-information, you can use `helm status`:
+To keep track of a release's state, or to re-read configuration information, you
+can use `helm status`:
 
 ```console
 $ helm status happy-panda
@@ -175,12 +168,11 @@ The above shows the current state of your release.
 
 ### Customizing the Chart Before Installing
 
-Installing the way we have here will only use the default configuration
-options for this chart. Many times, you will want to customize the chart
-to use your preferred configuration.
+Installing the way we have here will only use the default configuration options
+for this chart. Many times, you will want to customize the chart to use your
+preferred configuration.
 
-To see what options are configurable on a chart, use `helm inspect
-values`:
+To see what options are configurable on a chart, use `helm inspect values`:
 
 ```console
 helm inspect values stable/mariadb
@@ -214,29 +206,29 @@ imageTag: 10.1.14-r3
 # mariadbDatabase:
 ```
 
-You can then override any of these settings in a YAML formatted file,
-and then pass that file during installation.
+You can then override any of these settings in a YAML formatted file, and then
+pass that file during installation.
 
 ```console
 $ echo '{mariadbUser: user0, mariadbDatabase: user0db}' > config.yaml
 $ helm install -f config.yaml stable/mariadb
 ```
 
-The above will create a default MariaDB user with the name `user0`, and
-grant this user access to a newly created `user0db` database, but will
-accept all the rest of the defaults for that chart.
+The above will create a default MariaDB user with the name `user0`, and grant
+this user access to a newly created `user0db` database, but will accept all the
+rest of the defaults for that chart.
 
 There are two ways to pass configuration data during install:
 
-- `--values` (or `-f`): Specify a YAML file with overrides. This can be specified multiple times
-  and the rightmost file will take precedence
+- `--values` (or `-f`): Specify a YAML file with overrides. This can be
+  specified multiple times and the rightmost file will take precedence
 - `--set`: Specify overrides on the command line.
 
-If both are used, `--set` values are merged into `--values` with higher precedence.
-Overrides specified with `--set` are persisted in a configmap. Values that have been
-`--set` can be viewed for a given release with `helm get values <release-name>`.
-Values that have been `--set` can be cleared by running `helm upgrade` with `--reset-values`
-specified.
+If both are used, `--set` values are merged into `--values` with higher
+precedence. Overrides specified with `--set` are persisted in a configmap.
+Values that have been `--set` can be viewed for a given release with `helm get
+values <release-name>`. Values that have been `--set` can be cleared by running
+`helm upgrade` with `--reset-values` specified.
 
 #### The Format and Limitations of `--set`
 
@@ -254,15 +246,15 @@ a: b
 c: d
 ```
 
-More complex expressions are supported. For example, `--set outer.inner=value` is
-translated into this:
+More complex expressions are supported. For example, `--set outer.inner=value`
+is translated into this:
 ```yaml
 outer:
   inner: value
 ```
 
-Lists can be expressed by enclosing values in `{` and `}`. For example,
-`--set name={a, b, c}` translates to:
+Lists can be expressed by enclosing values in `{` and `}`. For example, `--set
+name={a, b, c}` translates to:
 
 ```yaml
 name:
@@ -271,15 +263,16 @@ name:
   - c
 ```
 
-As of Helm 2.5.0, it is possible to access list items using an array index syntax.
-For example, `--set servers[0].port=80` becomes:
+As of Helm 2.5.0, it is possible to access list items using an array index
+syntax. For example, `--set servers[0].port=80` becomes:
 
 ```yaml
 servers:
   - port: 80
 ```
 
-Multiple values can be set this way. The line `--set servers[0].port=80,servers[0].host=example` becomes:
+Multiple values can be set this way. The line `--set
+servers[0].port=80,servers[0].host=example` becomes:
 
 ```yaml
 servers:
@@ -294,9 +287,10 @@ a backslash to escape the characters; `--set name=value1\,value2` will become:
 name: "value1,value2"
 ```
 
-Similarly, you can escape dot sequences as well, which may come in handy when charts use the
-`toYaml` function to parse annotations, labels and node selectors. The syntax for
-`--set nodeSelector."kubernetes\.io/role"=master` becomes:
+Similarly, you can escape dot sequences as well, which may come in handy when
+charts use the `toYaml` function to parse annotations, labels and node
+selectors. The syntax for `--set nodeSelector."kubernetes\.io/role"=master`
+becomes:
 
 ```yaml
 nodeSelector:
@@ -318,14 +312,13 @@ The `helm install` command can install from several sources:
 
 ## 'helm upgrade' and 'helm rollback': Upgrading a Release, and Recovering on Failure
 
-When a new version of a chart is released, or when you want to change
-the configuration of your release, you can use the `helm upgrade`
-command.
+When a new version of a chart is released, or when you want to change the
+configuration of your release, you can use the `helm upgrade` command.
 
 An upgrade takes an existing release and upgrades it according to the
-information you provide. Because Kubernetes charts can be large and
-complex, Helm tries to perform the least invasive upgrade. It will only
-update things that have changed since the last release.
+information you provide. Because Kubernetes charts can be large and complex,
+Helm tries to perform the least invasive upgrade. It will only update things
+that have changed since the last release.
 
 ```console
 $ helm upgrade -f panda.yaml happy-panda stable/mariadb
@@ -337,54 +330,53 @@ Status: DEPLOYED
 ...
 ```
 
-In the above case, the `happy-panda` release is upgraded with the same
-chart, but with a new YAML file:
+In the above case, the `happy-panda` release is upgraded with the same chart,
+but with a new YAML file:
 
 ```yaml
 mariadbUser: user1
 ```
 
-We can use `helm get values` to see whether that new setting took
-effect.
+We can use `helm get values` to see whether that new setting took effect.
 
 ```console
 $ helm get values happy-panda
 mariadbUser: user1
 ```
 
-The `helm get` command is a useful tool for looking at a release in the
-cluster. And as we can see above, it shows that our new values from
-`panda.yaml` were deployed to the cluster.
+The `helm get` command is a useful tool for looking at a release in the cluster.
+And as we can see above, it shows that our new values from `panda.yaml` were
+deployed to the cluster.
 
-Now, if something does not go as planned during a release, it is easy to
-roll back to a previous release using `helm rollback [RELEASE] [REVISION]`.
+Now, if something does not go as planned during a release, it is easy to roll
+back to a previous release using `helm rollback [RELEASE] [REVISION]`.
 
 ```console
 $ helm rollback happy-panda 1
 ```
 
-The above rolls back our happy-panda to its very first release version.
-A release version is an incremental revision. Every time an install,
-upgrade, or rollback happens, the revision number is incremented by 1.
-The first revision number is always 1. And we can use `helm history [RELEASE]`
-to see revision numbers for a certain release.
+The above rolls back our happy-panda to its very first release version. A
+release version is an incremental revision. Every time an install, upgrade, or
+rollback happens, the revision number is incremented by 1. The first revision
+number is always 1. And we can use `helm history [RELEASE]` to see revision
+numbers for a certain release.
 
 ## Helpful Options for Install/Upgrade/Rollback
 There are several other helpful options you can specify for customizing the
-behavior of Helm during an install/upgrade/rollback. Please note that this
-is not a full list of cli flags. To see a description of all flags, just run
-`helm <command> --help`.
+behavior of Helm during an install/upgrade/rollback. Please note that this is
+not a full list of cli flags. To see a description of all flags, just run `helm
+<command> --help`.
 
 - `--timeout`: A value in seconds to wait for Kubernetes commands to complete
   This defaults to 300 (5 minutes)
-- `--wait`: Waits until all Pods are in a ready state, PVCs are bound, Deployments
-  have minimum (`Desired` minus `maxUnavailable`) Pods in ready state and
-  Services have an IP address (and Ingress if a `LoadBalancer`) before
-  marking the release as successful. It will wait for as long as the
-  `--timeout` value. If timeout is reached, the release will be marked as
-  `FAILED`. Note: In scenario where Deployment has `replicas` set to 1 and
-  `maxUnavailable` is not set to 0 as part of rolling update strategy,
-  `--wait` will return as ready as it has satisfied the minimum Pod in ready condition.
+- `--wait`: Waits until all Pods are in a ready state, PVCs are bound,
+  Deployments have minimum (`Desired` minus `maxUnavailable`) Pods in ready
+  state and Services have an IP address (and Ingress if a `LoadBalancer`) before
+  marking the release as successful. It will wait for as long as the `--timeout`
+  value. If timeout is reached, the release will be marked as `FAILED`. Note: In
+  scenario where Deployment has `replicas` set to 1 and `maxUnavailable` is not
+  set to 0 as part of rolling update strategy, `--wait` will return as ready as
+  it has satisfied the minimum Pod in ready condition.
 - `--no-hooks`: This skips running hooks for the command
 - `--recreate-pods` (only available for `upgrade` and `rollback`): This flag
   will cause all pods to be recreated (with the exception of pods belonging to
@@ -392,60 +384,60 @@ is not a full list of cli flags. To see a description of all flags, just run
 
 ## 'helm uninstall': Uninstalling a Release
 
-When it is time to uninstall or uninstall a release from the cluster, use
-the `helm uninstall` command:
+When it is time to uninstall or uninstall a release from the cluster, use the
+`helm uninstall` command:
 
 ```console
 $ helm uninstall happy-panda
 ```
 
-This will remove the release from the cluster. You can see all of your
-currently deployed releases with the `helm list` command:
+This will remove the release from the cluster. You can see all of your currently
+deployed releases with the `helm list` command:
 
 ```console
 $ helm list
-NAME           	VERSION	UPDATED                        	STATUS         	CHART
-inky-cat       	1      	Wed Sep 28 12:59:46 2016       	DEPLOYED       	alpine-0.1.0
+NAME            VERSION UPDATED                         STATUS          CHART
+inky-cat        1       Wed Sep 28 12:59:46 2016        DEPLOYED        alpine-0.1.0
 ```
 
 From the output above, we can see that the `happy-panda` release was
 uninstalled.
 
-However, Helm always keeps records of what releases happened. Need to
-see the uninstalled releases? `helm list --uninstalled` shows those, and `helm
-list --all` shows all of the releases (uninstalled and currently deployed,
-as well as releases that failed):
+However, Helm always keeps records of what releases happened. Need to see the
+uninstalled releases? `helm list --uninstalled` shows those, and `helm list
+--all` shows all of the releases (uninstalled and currently deployed, as well as
+releases that failed):
 
 ```console
 ⇒  helm list --all
-NAME           	VERSION	UPDATED                        	STATUS         	CHART
-happy-panda   	2      	Wed Sep 28 12:47:54 2016       	UNINSTALLED    	mariadb-0.3.0
-inky-cat       	1      	Wed Sep 28 12:59:46 2016       	DEPLOYED       	alpine-0.1.0
-kindred-angelf 	2      	Tue Sep 27 16:16:10 2016       	UNINSTALLED    	alpine-0.1.0
+NAME            VERSION UPDATED                         STATUS          CHART
+happy-panda     2       Wed Sep 28 12:47:54 2016        UNINSTALLED     mariadb-0.3.0
+inky-cat        1       Wed Sep 28 12:59:46 2016        DEPLOYED        alpine-0.1.0
+kindred-angelf  2       Tue Sep 27 16:16:10 2016        UNINSTALLED     alpine-0.1.0
 ```
 
-Because Helm keeps records of uninstalled releases, a release name cannot
-be re-used. (If you _really_ need to re-use a release name, you can use
-the `--replace` flag, but it will simply re-use the existing release and
-replace its resources.)
+Because Helm keeps records of uninstalled releases, a release name cannot be
+re-used. (If you _really_ need to re-use a release name, you can use the
+`--replace` flag, but it will simply re-use the existing release and replace its
+resources.)
 
 Note that because releases are preserved in this way, you can rollback a
 uninstalled resource, and have it re-activate.
 
 ## 'helm repo': Working with Repositories
 
-So far, we've been installing charts only from the `stable` repository.
-But you can configure `helm` to use other repositories. Helm provides
-several repository tools under the `helm repo` command.
+So far, we've been installing charts only from the `stable` repository. But you
+can configure `helm` to use other repositories. Helm provides several repository
+tools under the `helm repo` command.
 
 You can see which repositories are configured using `helm repo list`:
 
 ```console
 $ helm repo list
-NAME           	URL
-stable         	https://kubernetes-charts.storage.googleapis.com
-local          	http://localhost:8879/charts
-mumoshu        	https://mumoshu.github.io/charts
+NAME            URL
+stable          https://kubernetes-charts.storage.googleapis.com
+local           http://localhost:8879/charts
+mumoshu         https://mumoshu.github.io/charts
 ```
 
 And new repositories can be added with `helm repo add`:
@@ -454,28 +446,27 @@ And new repositories can be added with `helm repo add`:
 $ helm repo add dev https://example.com/dev-charts
 ```
 
-Because chart repositories change frequently, at any point you can make
-sure your Helm client is up to date by running `helm repo update`.
+Because chart repositories change frequently, at any point you can make sure
+your Helm client is up to date by running `helm repo update`.
 
 ## Creating Your Own Charts
 
 The [Chart Development Guide](charts.md) explains how to develop your own
-charts. But you can get started quickly by using the `helm create`
-command:
+charts. But you can get started quickly by using the `helm create` command:
 
 ```console
 $ helm create deis-workflow
 Creating deis-workflow
 ```
 
-Now there is a chart in `./deis-workflow`. You can edit it and create
-your own templates.
+Now there is a chart in `./deis-workflow`. You can edit it and create your own
+templates.
 
-As you edit your chart, you can validate that it is well-formatted by
-running `helm lint`.
+As you edit your chart, you can validate that it is well-formatted by running
+`helm lint`.
 
-When it's time to package the chart up for distribution, you can run the
-`helm package` command:
+When it's time to package the chart up for distribution, you can run the `helm
+package` command:
 
 ```console
 $ helm package deis-workflow
@@ -492,18 +483,17 @@ $ helm install ./deis-workflow-0.1.0.tgz
 Charts that are archived can be loaded into chart repositories. See the
 documentation for your chart repository server to learn how to upload.
 
-Note: The `stable` repository is managed on the [Kubernetes Charts
-GitHub repository](https://github.com/helm/charts). That project
-accepts chart source code, and (after audit) packages those for you.
+Note: The `stable` repository is managed on the [Kubernetes Charts GitHub
+repository](https://github.com/helm/charts). That project accepts chart source
+code, and (after audit) packages those for you.
 
 ## Conclusion
 
 This chapter has covered the basic usage patterns of the `helm` client,
 including searching, installation, upgrading, and uninstalling. It has also
-covered useful utility commands like `helm status`, `helm get`, and
-`helm repo`.
+covered useful utility commands like `helm status`, `helm get`, and `helm repo`.
 
-For more information on these commands, take a look at Helm's built-in
-help: `helm help`.
+For more information on these commands, take a look at Helm's built-in help:
+`helm help`.
 
 In the next chapter, we look at the process of developing charts.

--- a/content/docs/intro/v2_v3_migration.md
+++ b/content/docs/intro/v2_v3_migration.md
@@ -4,28 +4,40 @@ description: "Learn how to migrate Helm v2 to v3."
 weight: 5
 ---
 
-This guide shows how to migrate  Helm v2 to v3. Helm v2 needs to be installed and managing releases in one to many clusters.
+This guide shows how to migrate  Helm v2 to v3. Helm v2 needs to be installed
+and managing releases in one to many clusters.
 
 ## Overview of Helm 3 Changes
 
-The full list of changes from Helm 2 to 3 are documented in the [FAQ section](https://v3.helm.sh/docs/faq/#changes-since-helm-2).
-The following is a summary of some of those changes that a user should be aware of before and during migration:
+The full list of changes from Helm 2 to 3 are documented in the [FAQ
+section](https://v3.helm.sh/docs/faq/#changes-since-helm-2). The following is a
+summary of some of those changes that a user should be aware of before and
+during migration:
 
 1. Removal of Tiller: 
-   - Replaces client/server with client/library architecture (`helm` binary only)
-   - Security is now on per user basis (delegated to Kubernetes user cluster security)
-   - Releases are now stored as in-cluster secrets and the release object metadata has changed
-   - Releases are persisted on a release namespace basis and not in the Tiller namespace anymore
+   - Replaces client/server with client/library architecture (`helm` binary
+     only)
+   - Security is now on per user basis (delegated to Kubernetes user cluster
+     security)
+   - Releases are now stored as in-cluster secrets and the release object
+     metadata has changed
+   - Releases are persisted on a release namespace basis and not in the Tiller
+     namespace anymore
 2. Chart repository updated:
-   - `helm search` now supports both local repository searches and making search queries against Helm Hub
+   - `helm search` now supports both local repository searches and making search
+     queries against Helm Hub
 3. Chart apiVersion bumped to "v2" for following specification changes:
-   - Dynamically linked chart dependencies moved to `Chart.yaml` (`requirements.yaml` removed and  requirements --> dependencies)
-   - Library charts (helper/common charts) can now be added as dynamically linked chart dependencies
-   - Charts have a `type` metadata field to define the chart to be of an `application` or `library` chart. It is application by
-     default which means it is renderable and installable
+   - Dynamically linked chart dependencies moved to `Chart.yaml`
+     (`requirements.yaml` removed and  requirements --> dependencies)
+   - Library charts (helper/common charts) can now be added as dynamically
+     linked chart dependencies
+   - Charts have a `type` metadata field to define the chart to be of an
+     `application` or `library` chart. It is application by default which means
+     it is renderable and installable
    - Helm 2 charts (apiVersion=v1) are still installable
 4. XDG directory specification added:
-   - Helm home removed and replaced with XDG directory specification for storing configuration files
+   - Helm home removed and replaced with XDG directory specification for storing
+     configuration files
    - No longer need to initialize Helm
    - `helm init` and `helm home` removed
 5. Additional changes:
@@ -33,10 +45,13 @@ The following is a summary of some of those changes that a user should be aware 
      - Helm client (helm) only (no tiller)
      - Run-as-is paradigm
    - `local` or `stable` repositories are not set-up by default
-   - `crd-install` hook removed and replaced with `crds` directory in chart where all CRDs defined in it will be installed before any rendering of the chart
+   - `crd-install` hook removed and replaced with `crds` directory in chart
+     where all CRDs defined in it will be installed before any rendering of the
+     chart
    - `test-failure` target removed. Use `test-success` instead
    - Commands removed/replaced/added:
-       - delete --> uninstall : removes all release history by default (previously needed `--purge`)
+       - delete --> uninstall : removes all release history by default
+         (previously needed `--purge`)
        - fetch --> pull
        - home (removed)
        - init (removed)
@@ -44,8 +59,10 @@ The following is a summary of some of those changes that a user should be aware 
        - inspect --> show
        - reset (removed)
        - serve (removed)
-       - upgrade: Added argument `maxHistory` which limits the maximum number of revisions saved per release (0 for no limit)
-   - Helm 3 Go library has undergone a lot of changes and is incompatible with the Helm 2 library
+       - upgrade: Added argument `maxHistory` which limits the maximum number of
+         revisions saved per release (0 for no limit)
+   - Helm 3 Go library has undergone a lot of changes and is incompatible with
+     the Helm 2 library
    - Release binaries are now hosted on `get.helm.sh`
 
 ## Migration Use Cases
@@ -53,28 +70,56 @@ The following is a summary of some of those changes that a user should be aware 
 The migration use cases are as follows:
 
 1. Helm v2 and v3 managing the same cluster:
-   - This use case is only recommended if you intend to phase out Helm v2 gradually and do not require v3 to manage any releases deployed by v2. All new releases being deployed should be performed by v3 and existing v2 deployed releases are updated/removed by v2 only
-   - Helm v2 and v3 can quite happily manage the same cluster. The Helm versions can be installed on the same or separate systems
-   - If installing Helm v3 on the same system, you need to to perform an additional step to ensure that both client versions can co-exist until ready to remove Helm v2 client. Rename or put the Helm v3 binary in a different folder to avoid conflict
-   - Otherwise there are no conflicts between both versions because of the following distinctions: 
-     - v2 and v3 release (history) storage are independent of each other. The changes includes the Kubernetes resource for storage and the release object metadata contained in the resource. Releases will also be on a per user namespace instead of using the Tiller namespace (for example, v2 default Tiller namespace kube-system). v2 uses "ConfigMaps" or "Secrets" under the Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in the user namespace and `helm` ownership. Releases are incremental in both v2 and v3
-     - The only issue could be if Kubernetes cluster scoped resources (e.g. `clusterroles.rbac`) are defined in a chart. The v3 deployment would then fail even if unique in the namespace as the resources would clash
-     - v3 configuration no longer uses `HELM_HOME` and uses XDG directory specification instead. It is also created on the fly as need be. It is therefore independent of v2 configuration. This is applicable only when both versions are installed on the same system
- 
+   - This use case is only recommended if you intend to phase out Helm v2
+     gradually and do not require v3 to manage any releases deployed by v2. All
+     new releases being deployed should be performed by v3 and existing v2
+     deployed releases are updated/removed by v2 only
+   - Helm v2 and v3 can quite happily manage the same cluster. The Helm versions
+     can be installed on the same or separate systems
+   - If installing Helm v3 on the same system, you need to to perform an
+     additional step to ensure that both client versions can co-exist until
+     ready to remove Helm v2 client. Rename or put the Helm v3 binary in a
+     different folder to avoid conflict
+   - Otherwise there are no conflicts between both versions because of the
+     following distinctions: 
+     - v2 and v3 release (history) storage are independent of each other. The
+       changes includes the Kubernetes resource for storage and the release
+       object metadata contained in the resource. Releases will also be on a per
+       user namespace instead of using the Tiller namespace (for example, v2
+       default Tiller namespace kube-system). v2 uses "ConfigMaps" or "Secrets"
+       under the Tiller namespace and `TILLER`ownership. v3 uses "Secrets" in
+       the user namespace and `helm` ownership. Releases are incremental in both
+       v2 and v3
+     - The only issue could be if Kubernetes cluster scoped resources (e.g.
+       `clusterroles.rbac`) are defined in a chart. The v3 deployment would then
+       fail even if unique in the namespace as the resources would clash
+     - v3 configuration no longer uses `HELM_HOME` and uses XDG directory
+       specification instead. It is also created on the fly as need be. It is
+       therefore independent of v2 configuration. This is applicable only when
+       both versions are installed on the same system
+
 2. Migrating Helm v2 to Helm v3:
-   - This use case applies when you want Helm v3 to manage existing Helm v2 releases
+   - This use case applies when you want Helm v3 to manage existing Helm v2
+     releases
    - It should be noted that a Helm client: 
      - can manage 1 to many Kubernetes clusters
      - can connect to 1 to many Tiller instances for  a cluster 
-   - This means that you have to be cognisant of this when migrating as releases are deployed into clusters by Tiller and its namespace. You have to therefore be aware of migrating for each cluster and each Tiller instance that is managed by the Helm v2 client instance
+   - This means that you have to be cognisant of this when migrating as releases
+     are deployed into clusters by Tiller and its namespace. You have to
+     therefore be aware of migrating for each cluster and each Tiller instance
+     that is managed by the Helm v2 client instance
    - The recommended data migration path is as follows:
      1. Backup v2 data
      2. Migrate Helm v2 configuration
      3. Migrate Helm v2 releases
-     4. When happy that Helm v3 is managing all Helm v2 data (for all clusters and Tiller instances of the Helm v2 client instance) as expected, then clean up Helm v2 data
-   - The migration process is automated by the Helm v3 [2to3](https://github.com/helm/helm-2to3) plugin  
+     4. When happy that Helm v3 is managing all Helm v2 data (for all clusters
+        and Tiller instances of the Helm v2 client instance) as expected, then
+        clean up Helm v2 data
+   - The migration process is automated by the Helm v3
+     [2to3](https://github.com/helm/helm-2to3) plugin  
 
 ## Reference
 
    - Helm v3 [2to3](https://github.com/helm/helm-2to3) plugin
-   - Blog [post](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) explaining `2to3` plugin usage with examples
+   - Blog [post](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)
+     explaining `2to3` plugin usage with examples

--- a/content/docs/topics/_index.md
+++ b/content/docs/topics/_index.md
@@ -5,4 +5,5 @@ weight: 3
 
 # Topic Guides
 
-Here you’ll find introductions to all the key parts of Helm you’ll need or want to know.
+Here you’ll find introductions to all the key parts of Helm you’ll need or want
+to know.

--- a/content/docs/topics/architecture.md
+++ b/content/docs/topics/architecture.md
@@ -3,15 +3,14 @@ title: "Helm Architecture"
 description: "Describes the Helm architecture at a high level."
 ---
 
-
 # The Kubernetes Helm Architecture
 
 This document describes the Helm architecture at a high level.
 
 ## The Purpose of Helm
 
-Helm is a tool for managing Kubernetes packages called _charts_. Helm
-can do the following:
+Helm is a tool for managing Kubernetes packages called _charts_. Helm can do the
+following:
 
 - Create new charts from scratch
 - Package charts into chart archive (tgz) files
@@ -21,19 +20,19 @@ can do the following:
 
 For Helm, there are three important concepts:
 
-1. The _chart_ is a bundle of information necessary to create an
-   instance of a Kubernetes application.
-2. The _config_ contains configuration information that can be merged
-   into a packaged chart to create a releasable object.
-3. A _release_ is a running instance of a _chart_, combined with a
-   specific _config_.
+1. The _chart_ is a bundle of information necessary to create an instance of a
+   Kubernetes application.
+2. The _config_ contains configuration information that can be merged into a
+   packaged chart to create a releasable object.
+3. A _release_ is a running instance of a _chart_, combined with a specific
+   _config_.
 
 ## Components
 
 Helm is an executable which is implemented into two distinct parts:
 
-**The Helm Client** is a command-line client for end users. The client
-is responsible for the following:
+**The Helm Client** is a command-line client for end users. The client is
+responsible for the following:
 
 - Local chart development
 - Managing repositories
@@ -42,21 +41,22 @@ is responsible for the following:
   - Sending charts to be installed
   - Requesting upgrading or uninstalling of existing releases
 
-**The Helm Library** provides the logic for executing all Helm operations.
-It interfaces with the Kubernetes API server and provides the following capability:
+**The Helm Library** provides the logic for executing all Helm operations. It
+interfaces with the Kubernetes API server and provides the following capability:
 
 - Combining a chart and configuration to build a release
 - Installing charts into Kubernetes, and providing the subsequent release object
 - Upgrading and uninstalling charts by interacting with Kubernetes
 
-The standalone Helm library encapsulates the Helm logic so that it can be leveraged by different clients.
+The standalone Helm library encapsulates the Helm logic so that it can be
+leveraged by different clients.
 
 ## Implementation
 
 The Helm client and library is written in the Go programming language.
 
-The library uses the Kubernetes client library to communicate with Kubernetes. Currently,
-that library uses REST+JSON. It stores information in Secrets located inside of Kubernetes.
-It does not need its own database.
+The library uses the Kubernetes client library to communicate with Kubernetes.
+Currently, that library uses REST+JSON. It stores information in Secrets located
+inside of Kubernetes. It does not need its own database.
 
 Configuration files are, when possible, written in YAML.

--- a/content/docs/topics/chart_best_practices/_index.md
+++ b/content/docs/topics/chart_best_practices/_index.md
@@ -6,8 +6,9 @@ weight: 4
 
 # The Chart Best Practices Guide
 
-This guide covers the Helm Team's considered best practices for creating charts. It focuses on how charts should be
-structured.
+This guide covers the Helm Team's considered best practices for creating charts.
+It focuses on how charts should be structured.
 
-We focus primarily on best practices for charts that may be publicly deployed. We know that many charts are for
-internal-use only, and authors of such charts may find that their internal interests override our suggestions here.
+We focus primarily on best practices for charts that may be publicly deployed.
+We know that many charts are for internal-use only, and authors of such charts
+may find that their internal interests override our suggestions here.

--- a/content/docs/topics/chart_best_practices/conventions.md
+++ b/content/docs/topics/chart_best_practices/conventions.md
@@ -7,7 +7,8 @@ This part of the Best Practices Guide explains general conventions.
 
 ## Chart Names
 
-Chart names should be lower case letters and numbers. Words _may_ be separated with dashes (-):
+Chart names should be lower case letters and numbers. Words _may_ be separated
+with dashes (-):
 
 Examples:
 
@@ -17,15 +18,22 @@ nginx-lego
 aws-cluster-autoscaler
 ```
 
-Neither uppercase letters nor underscores should be used in chart names. Dots should not be used in chart names.
+Neither uppercase letters nor underscores should be used in chart names. Dots
+should not be used in chart names.
 
-The directory that contains a chart MUST have the same name as the chart. Thus, the chart `nginx-lego` MUST be created in a directory called `nginx-lego/`. This is not merely a stylistic detail, but a requirement of the Helm Chart format.
+The directory that contains a chart MUST have the same name as the chart. Thus,
+the chart `nginx-lego` MUST be created in a directory called `nginx-lego/`. This
+is not merely a stylistic detail, but a requirement of the Helm Chart format.
 
 ## Version Numbers
 
-Wherever possible, Helm uses [SemVer 2](http://semver.org) to represent version numbers. (Note that Docker image tags do not necessarily follow SemVer, and are thus considered an unfortunate exception to the rule.)
+Wherever possible, Helm uses [SemVer 2](http://semver.org) to represent version
+numbers. (Note that Docker image tags do not necessarily follow SemVer, and are
+thus considered an unfortunate exception to the rule.)
 
-When SemVer versions are stored in Kubernetes labels, we conventionally alter the `+` character to an `_` character, as labels do not allow the `+` sign as a value.
+When SemVer versions are stored in Kubernetes labels, we conventionally alter
+the `+` character to an `_` character, as labels do not allow the `+` sign as a
+value.
 
 ## Formatting YAML
 

--- a/content/docs/topics/chart_best_practices/custom_resource_definitions.md
+++ b/content/docs/topics/chart_best_practices/custom_resource_definitions.md
@@ -3,15 +3,17 @@ title: "Custom Resource Definitions"
 description: "How to handle creating and using CRDs."
 ---
 
-This section of the Best Practices Guide deals with creating and using Custom Resource Definition
-objects.
+This section of the Best Practices Guide deals with creating and using Custom
+Resource Definition objects.
 
-When working with Custom Resource Definitions (CRDs), it is important to distinguish
-two different pieces:
+When working with Custom Resource Definitions (CRDs), it is important to
+distinguish two different pieces:
 
-- There is a declaration of a CRD. This is the YAML file that has the kind `CustomResourceDefinition`
-- Then there are resources that _use_ the CRD. Say a CRD defines `foo.example.com/v1`. Any resource
-  that has `apiVersion: example.com/v1` and kind `Foo` is a resource that uses the CRD.
+- There is a declaration of a CRD. This is the YAML file that has the kind
+  `CustomResourceDefinition`
+- Then there are resources that _use_ the CRD. Say a CRD defines
+  `foo.example.com/v1`. Any resource that has `apiVersion: example.com/v1` and
+  kind `Foo` is a resource that uses the CRD.
 
 ## Install a CRD Declaration Before Using the Resource
 

--- a/content/docs/topics/chart_best_practices/dependencies.md
+++ b/content/docs/topics/chart_best_practices/dependencies.md
@@ -3,27 +3,35 @@ title: "Dependencies"
 description: "Covers best practices for Chart dependencies."
 ---
 
-This section of the guide covers best practices for `dependencies` declared in `Chart.yaml`.
+This section of the guide covers best practices for `dependencies` declared in
+`Chart.yaml`.
 
 ## Versions
 
-Where possible, use version ranges instead of pinning to an exact version. The suggested default is to use a patch-level version match:
+Where possible, use version ranges instead of pinning to an exact version. The
+suggested default is to use a patch-level version match:
 
 ```yaml
 version: ~1.2.3
 ```
 
-This will match version `1.2.3` and any patches to that release.  In other words, `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+This will match version `1.2.3` and any patches to that release.  In other
+words, `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
 
-For the complete version matching syntax, please see the [semver documentation](https://github.com/Masterminds/semver#checking-version-constraints)
+For the complete version matching syntax, please see the [semver
+documentation](https://github.com/Masterminds/semver#checking-version-constraints)
 
 ### Repository URLs
 
 Where possible, use `https://` repository URLs, followed by `http://` URLs.
 
-If the repository has been added to the repository index file, the repository name can be used as an alias of URL. Use `alias:` or `@` followed by repository names.
+If the repository has been added to the repository index file, the repository
+name can be used as an alias of URL. Use `alias:` or `@` followed by repository
+names.
 
-File URLs (`file://...`) are considered a "special case" for charts that are assembled by a fixed deployment pipeline. Charts that use `file://` are not allowed in the official Helm repository.
+File URLs (`file://...`) are considered a "special case" for charts that are
+assembled by a fixed deployment pipeline. Charts that use `file://` are not
+allowed in the official Helm repository.
 
 ## Conditions and Tags
 
@@ -37,10 +45,13 @@ condition: somechart.enabled
 
 Where `somechart` is the chart name of the dependency.
 
-When multiple subcharts (dependencies) together provide an optional or swappable feature, those charts should share the same tags.
+When multiple subcharts (dependencies) together provide an optional or swappable
+feature, those charts should share the same tags.
 
-For example, if both `nginx` and `memcached` together provided performance optimizations for the main app in the chart, and were required to both be present when that feature is enabled, then they might both have a
-tags section like this:
+For example, if both `nginx` and `memcached` together provided performance
+optimizations for the main app in the chart, and were required to both be
+present when that feature is enabled, then they might both have a tags section
+like this:
 
 ```yaml
 tags:

--- a/content/docs/topics/chart_best_practices/labels.md
+++ b/content/docs/topics/chart_best_practices/labels.md
@@ -13,18 +13,22 @@ An item of metadata should be a label under the following conditions:
 - It is used by Kubernetes to identify this resource
 - It is useful to expose to operators for the purpose of querying the system.
 
-For example, we suggest using `helm.sh/chart: NAME-VERSION` as a label so that operators
-can conveniently find all of the instances of a particular chart to use.
+For example, we suggest using `helm.sh/chart: NAME-VERSION` as a label so that
+operators can conveniently find all of the instances of a particular chart to
+use.
 
-If an item of metadata is not used for querying, it should be set as an annotation
-instead.
+If an item of metadata is not used for querying, it should be set as an
+annotation instead.
 
 Helm hooks are always annotations.
 
 ## Standard Labels
 
-The following table defines common labels that Helm charts use. Helm itself never requires that a particular label be present. Labels that are marked REC
-are recommended, and _should_ be placed onto a chart for global consistency. Those marked OPT are optional. These are idiomatic or commonly in use, but are not relied upon frequently for operational purposes.
+The following table defines common labels that Helm charts use. Helm itself
+never requires that a particular label be present. Labels that are marked REC
+are recommended, and _should_ be placed onto a chart for global consistency.
+Those marked OPT are optional. These are idiomatic or commonly in use, but are
+not relied upon frequently for operational purposes.
 
 Name|Status|Description
 -----|------|----------
@@ -36,4 +40,6 @@ Name|Status|Description
 `app.kubernetes.io/component` | OPT | This is a common label for marking the different roles that pieces may play in an application. For example, `app.kubernetes.io/component: frontend`.
 `app.kubernetes.io/part-of` | OPT | When multiple charts or pieces of software are used together to make one application. For example, application software and a database to produce a website. This can be set to the top level application being supported.
 
-You can find more information on the Kubernetes labels, prefixed with `app.kubernetes.io`, in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
+You can find more information on the Kubernetes labels, prefixed with
+`app.kubernetes.io`, in the [Kubernetes
+documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).

--- a/content/docs/topics/chart_best_practices/pods.md
+++ b/content/docs/topics/chart_best_practices/pods.md
@@ -3,8 +3,8 @@ title: "Pods and PodTemplates"
 description: "Discusses formatting the Pod and PodTemplate portions in Chart manifests."
 ---
 
-This part of the Best Practices Guide discusses formatting the Pod and PodTemplate
-portions in chart manifests.
+This part of the Best Practices Guide discusses formatting the Pod and
+PodTemplate portions in chart manifests.
 
 The following (non-exhaustive) list of resources use PodTemplates:
 
@@ -16,10 +16,13 @@ The following (non-exhaustive) list of resources use PodTemplates:
 
 ## Images
 
-A container image should use a fixed tag or the SHA of the image. It should not use the tags `latest`, `head`, `canary`, or other tags that are designed to be "floating".
+A container image should use a fixed tag or the SHA of the image. It should not
+use the tags `latest`, `head`, `canary`, or other tags that are designed to be
+"floating".
 
 
-Images _may_ be defined in the `values.yaml` file to make it easy to swap out images.
+Images _may_ be defined in the `values.yaml` file to make it easy to swap out
+images.
 
 ```yaml
 image: {{ .Values.redisImage | quote }}
@@ -33,7 +36,8 @@ image: "{{ .Values.redisImage }}:{{ .Values.redisTag }}"
 
 ## ImagePullPolicy
 
-`helm create` sets the `imagePullPolicy` to `IfNotPresent` by default by doing the following in your `deployment.yaml`:
+`helm create` sets the `imagePullPolicy` to `IfNotPresent` by default by doing
+the following in your `deployment.yaml`:
 
 ```yaml
 imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -45,7 +49,9 @@ And `values.yaml`:
 pullPolicy: IfNotPresent
 ```
 
-Similarly, Kubernetes defaults the `imagePullPolicy` to `IfNotPresent` if it is not defined at all. If you want a value other than `IfNotPresent`, simply update the value in `values.yaml` to your desired value.
+Similarly, Kubernetes defaults the `imagePullPolicy` to `IfNotPresent` if it is
+not defined at all. If you want a value other than `IfNotPresent`, simply update
+the value in `values.yaml` to your desired value.
 
 
 ## PodTemplates Should Declare Selectors
@@ -65,8 +71,6 @@ template:
 This is a good practice because it makes the relationship between the set and
 the pod.
 
-But this is even more important for sets like Deployment.
-Without this, the _entire_ set of labels is used to select matching pods, and
-this will break if you use labels that change, like version or release date.
-
-
+But this is even more important for sets like Deployment. Without this, the
+_entire_ set of labels is used to select matching pods, and this will break if
+you use labels that change, like version or release date.

--- a/content/docs/topics/chart_best_practices/rbac.md
+++ b/content/docs/topics/chart_best_practices/rbac.md
@@ -3,7 +3,8 @@ title: "Role-Based Access Control"
 description: "Discusses the creation and formatting of RBAC resources in Chart manifests."
 ---
 
-This part of the Best Practices Guide discusses the creation and formatting of RBAC resources in chart manifests.
+This part of the Best Practices Guide discusses the creation and formatting of
+RBAC resources in chart manifests.
 
 RBAC resources are:
 
@@ -15,7 +16,9 @@ RBAC resources are:
 
 ## YAML Configuration
 
-RBAC and ServiceAccount configuration should happen under separate keys. They are separate things. Splitting these two concepts out in the YAML disambiguates them and make this clearer.
+RBAC and ServiceAccount configuration should happen under separate keys. They
+are separate things. Splitting these two concepts out in the YAML disambiguates
+them and make this clearer.
 
 ```yaml
 rbac:
@@ -30,7 +33,8 @@ serviceAccount:
   name:
 ```
 
-This structure can be extended for more complex charts that require multiple ServiceAccounts.
+This structure can be extended for more complex charts that require multiple
+ServiceAccounts.
 
 ```yaml
 serviceAccounts:
@@ -44,11 +48,21 @@ serviceAccounts:
 
 ## RBAC Resources Should be Created by Default
 
-`rbac.create` should be a boolean value controlling whether RBAC resources are created.  The default should be `true`.  Users who wish to manage RBAC access controls themselves can set this value to `false` (in which case see below).
+`rbac.create` should be a boolean value controlling whether RBAC resources are
+created.  The default should be `true`.  Users who wish to manage RBAC access
+controls themselves can set this value to `false` (in which case see below).
 
 ## Using RBAC Resources
 
-`serviceAccount.name` should set to the name of the ServiceAccount to be used by access-controlled resources created by the chart.  If `serviceAccount.create` is true, then a ServiceAccount with this name should be created.  If the name is not set, then a name is generated using the `fullname` template, If `serviceAccount.create` is false, then it should not be created, but it should still be associated with the same resources so that manually-created RBAC resources created later that reference it will function correctly.  If `serviceAccount.create` is false and the name is not specified, then the default ServiceAccount is used.
+`serviceAccount.name` should set to the name of the ServiceAccount to be used by
+access-controlled resources created by the chart.  If `serviceAccount.create` is
+true, then a ServiceAccount with this name should be created.  If the name is
+not set, then a name is generated using the `fullname` template, If
+`serviceAccount.create` is false, then it should not be created, but it should
+still be associated with the same resources so that manually-created RBAC
+resources created later that reference it will function correctly.  If
+`serviceAccount.create` is false and the name is not specified, then the default
+ServiceAccount is used.
 
 The following helper template should be used for the ServiceAccount.
 

--- a/content/docs/topics/chart_best_practices/templates.md
+++ b/content/docs/topics/chart_best_practices/templates.md
@@ -9,12 +9,14 @@ This part of the Best Practices Guide focuses on templates.
 
 The templates directory should be structured as follows:
 
-- Template files should have the extension `.yaml` if they produce YAML output. The
-  extension `.tpl` may be used for template files that produce no formatted content.
-- Template file names should use dashed notation (`my-example-configmap.yaml`), not camelcase.
+- Template files should have the extension `.yaml` if they produce YAML output.
+  The extension `.tpl` may be used for template files that produce no formatted
+  content.
+- Template file names should use dashed notation (`my-example-configmap.yaml`),
+  not camelcase.
 - Each resource definition should be in its own template file.
-- Template file names should reflect the resource kind in the name. e.g. `foo-pod.yaml`,
-  `bar-svc.yaml`
+- Template file names should reflect the resource kind in the name. e.g.
+  `foo-pod.yaml`, `bar-svc.yaml`
 
 ## Names of Defined Templates
 
@@ -39,14 +41,15 @@ Incorrect:
 {{/* ... */}}
 {{ end -}}
 ```
-It is highly recommended that new charts are created via `helm create` command as the template names are automatically defined as per this best practice.
+It is highly recommended that new charts are created via `helm create` command
+as the template names are automatically defined as per this best practice.
 
 ## Formatting Templates
 
 Templates should be indented using _two spaces_ (never tabs).
 
-Template directives should have whitespace after the opening  braces and before the
-closing braces:
+Template directives should have whitespace after the opening  braces and before
+the closing braces:
 
 Correct:
 ```
@@ -71,7 +74,8 @@ foo:
   {{ end -}}
 ```
 
-Blocks (such as control structures) may be indented to indicate flow of the template code.
+Blocks (such as control structures) may be indented to indicate flow of the
+template code.
 
 ```
 {{ if $foo -}}
@@ -79,12 +83,13 @@ Blocks (such as control structures) may be indented to indicate flow of the temp
 {{- end -}}
 ```
 
-However, since YAML is a whitespace-oriented language, it is often not possible for code indentation to follow that convention.
+However, since YAML is a whitespace-oriented language, it is often not possible
+for code indentation to follow that convention.
 
 ## Whitespace in Generated Templates
 
-It is preferable to keep the amount of whitespace in generated templates to
-a minimum. In particular, numerous blank lines should not appear adjacent to each
+It is preferable to keep the amount of whitespace in generated templates to a
+minimum. In particular, numerous blank lines should not appear adjacent to each
 other. But occasional empty lines (particularly between logical sections) is
 fine.
 
@@ -153,7 +158,8 @@ This is a comment.
 type: frobnitz
 ```
 
-Template comments should be used when documenting features of a template, such as explaining a defined template:
+Template comments should be used when documenting features of a template, such
+as explaining a defined template:
 
 ```yaml
 {{- /*
@@ -165,7 +171,8 @@ mychart.shortname provides a 6 char truncated version of the release name.
 
 ```
 
-Inside of templates, YAML comments may be used when it is useful for Helm users to (possibly) see the comments during debugging.
+Inside of templates, YAML comments may be used when it is useful for Helm users
+to (possibly) see the comments during debugging.
 
 ```
 # This may cause problems if the value is more than 100Gi
@@ -194,8 +201,8 @@ But it is easier to read when collapsed into a JSON list style:
 arguments: ["--dirname", "/foo"]
 ```
 
-Using JSON for increased legibility is good. However, JSON syntax should not
-be used for representing more complex constructs.
+Using JSON for increased legibility is good. However, JSON syntax should not be
+used for representing more complex constructs.
 
 When dealing with pure JSON embedded inside of YAML (such as init container
 configuration), it is of course appropriate to use the JSON format.

--- a/content/docs/topics/chart_best_practices/values.md
+++ b/content/docs/topics/chart_best_practices/values.md
@@ -69,21 +69,21 @@ and use.
 {{ default "none" .Values.serverName }}
 ```
 
-When there are a large number of related variables, and at least one of them
-is non-optional, nested values may be used to improve readability.
+When there are a large number of related variables, and at least one of them is
+non-optional, nested values may be used to improve readability.
 
 ## Make Types Clear
 
-YAML's type coercion rules are sometimes counterintuitive. For example,
-`foo: false` is not the same as `foo: "false"`. Large integers like `foo: 12345678`
+YAML's type coercion rules are sometimes counterintuitive. For example, `foo:
+false` is not the same as `foo: "false"`. Large integers like `foo: 12345678`
 will get converted to scientific notation in some cases.
 
 The easiest way to avoid type conversion errors is to be explicit about strings,
 and implicit about everything else. Or, in short, _quote all strings_.
 
 Often, to avoid the integer casting issues, it is advantageous to store your
-integers as strings as well, and use `{{ int $value }}` in the template to convert
-from a string back to an integer.
+integers as strings as well, and use `{{ int $value }}` in the template to
+convert from a string back to an integer.
 
 In most cases, explicit type tags are respected, so `foo: !!string 1234` should
 treat `1234` as a string. _However_, the YAML parser consumes tags, so the type
@@ -95,14 +95,15 @@ There are three potential sources of values:
 
 - A chart's `values.yaml` file
 - A values file supplied by `helm install -f` or `helm upgrade -f`
-- The values passed to a `--set` or `--set-string` flag on `helm install` or `helm upgrade`
+- The values passed to a `--set` or `--set-string` flag on `helm install` or
+  `helm upgrade`
 
 When designing the structure of your values, keep in mind that users of your
 chart may want to override them via either the `-f` flag or with the `--set`
 option.
 
-Since `--set` is more limited in expressiveness, the first guidelines for writing
-your `values.yaml` file is _make it easy to override from `--set`_.
+Since `--set` is more limited in expressiveness, the first guidelines for
+writing your `values.yaml` file is _make it easy to override from `--set`_.
 
 For this reason, it's often better to structure your values file using maps.
 
@@ -135,7 +136,9 @@ Accessing foo's port is much more obvious: `--set servers.foo.port=80`.
 
 ## Document 'values.yaml'
 
-Every defined property in 'values.yaml' should be documented. The documentation string should begin with the name of the property that it describes, and then give at least a one-sentence description.
+Every defined property in 'values.yaml' should be documented. The documentation
+string should begin with the name of the property that it describes, and then
+give at least a one-sentence description.
 
 Incorrect:
 
@@ -155,4 +158,6 @@ serverPort = 9191
 
 ```
 
-Beginning each comment with the name of the parameter it documents makes it easy to grep out documentation, and will enable documentation tools to reliably correlate doc strings with the parameters they describe.
+Beginning each comment with the name of the parameter it documents makes it easy
+to grep out documentation, and will enable documentation tools to reliably
+correlate doc strings with the parameters they describe.

--- a/content/docs/topics/chart_repository.md
+++ b/content/docs/topics/chart_repository.md
@@ -6,13 +6,13 @@ description: "How to create and work with Helm chart repositories."
 # The Chart Repository Guide
 
 This section explains how to create and work with Helm chart repositories. At a
-high level, a chart repository is a location where packaged charts can be
-stored and shared.
+high level, a chart repository is a location where packaged charts can be stored
+and shared.
 
-The official chart repository is maintained by the
-[Kubernetes Charts](https://github.com/helm/charts), and we welcome
-participation. But Helm also makes it easy to create and run your own chart
-repository. This guide explains how to do so.
+The official chart repository is maintained by the [Kubernetes
+Charts](https://github.com/helm/charts), and we welcome participation. But Helm
+also makes it easy to create and run your own chart repository. This guide
+explains how to do so.
 
 ## Prerequisites
 
@@ -26,8 +26,8 @@ optionally some packaged charts.  When you're ready to share your charts, the
 preferred way to do so is by uploading them to a chart repository.
 
 **Note:** For Helm 2.0.0, chart repositories do not have any intrinsic
-authentication. There is an [issue tracking progress](https://github.com/helm/helm/issues/1038)
-in GitHub.
+authentication. There is an [issue tracking
+progress](https://github.com/helm/helm/issues/1038) in GitHub.
 
 Because a chart repository can be any HTTP server that can serve YAML and tar
 files and can answer GET requests, you have a plethora of options when it comes
@@ -55,21 +55,21 @@ charts/
   |- alpine-0.1.2.tgz.prov
 ```
 
-In this case, the index file would contain information about one chart, the Alpine
-chart, and provide the download URL `https://example.com/charts/alpine-0.1.2.tgz`
-for that chart.
+In this case, the index file would contain information about one chart, the
+Alpine chart, and provide the download URL
+`https://example.com/charts/alpine-0.1.2.tgz` for that chart.
 
 It is not required that a chart package be located on the same server as the
 `index.yaml` file. However, doing so is often the easiest.
 
 ### The index file
 
-The index file is a yaml file called `index.yaml`. It
-contains some metadata about the package, including the contents of a
-chart's `Chart.yaml` file. A valid chart repository must have an index file. The
-index file contains information about each chart in the chart repository. The
-`helm repo index` command will generate an index file based on a given local
-directory that contains packaged charts.
+The index file is a yaml file called `index.yaml`. It contains some metadata
+about the package, including the contents of a chart's `Chart.yaml` file. A
+valid chart repository must have an index file. The index file contains
+information about each chart in the chart repository. The `helm repo index`
+command will generate an index file based on a given local directory that
+contains packaged charts.
 
 This is an example of an index file:
 
@@ -111,8 +111,9 @@ entries:
 generated: 2016-10-06T16:23:20.499029981-06:00
 ```
 
-A generated index and packages can be served from a basic webserver. You can test
-things out locally with the `helm serve` command, which starts a local server.
+A generated index and packages can be served from a basic webserver. You can
+test things out locally with the `helm serve` command, which starts a local
+server.
 
 ```console
 $ helm serve --repo-path ./charts
@@ -120,9 +121,9 @@ Regenerating index. This may take a moment.
 Now serving you on 127.0.0.1:8879
 ```
 
-The above starts a local webserver, serving the charts it finds in `./charts`. The
-serve command will automatically generate an `index.yaml` file for you during
-startup.
+The above starts a local webserver, serving the charts it finds in `./charts`.
+The serve command will automatically generate an `index.yaml` file for you
+during startup.
 
 ## Hosting Chart Repositories
 
@@ -147,16 +148,17 @@ Congratulations, now you have an empty GCS bucket ready to serve charts!
 
 You may upload your chart repository using the Google Cloud Storage command line
 tool, or using the GCS web UI. This is the technique the official Kubernetes
-Charts repository hosts its charts, so you may want to take a
-[peek at that project](https://github.com/helm/charts) if you get stuck.
+Charts repository hosts its charts, so you may want to take a [peek at that
+project](https://github.com/helm/charts) if you get stuck.
 
 **Note:** A public GCS bucket can be accessed via simple HTTPS at this address
 `https://bucket-name.storage.googleapis.com/`.
 
 ### JFrog Artifactory
 
-You can also set up chart repositories using JFrog Artifactory.
-Read more about chart repositories with JFrog Artifactory [here](https://www.jfrog.com/confluence/display/RTF/Helm+Chart+Repositories)
+You can also set up chart repositories using JFrog Artifactory. Read more about
+chart repositories with JFrog Artifactory
+[here](https://www.jfrog.com/confluence/display/RTF/Helm+Chart+Repositories)
 
 ### Github Pages example
 
@@ -186,7 +188,8 @@ set as per below:
 
 ![Create Github Pages branch](images/set-a-gh-page.png)
 
-By default **Source** usually gets set to **gh-pages branch**. If this is not set by default, then select it.
+By default **Source** usually gets set to **gh-pages branch**. If this is not
+set by default, then select it.
 
 You can use a **custom domain** there if you wish so.
 
@@ -195,8 +198,9 @@ charts are served.
 
 In such setup you can use **master branch** to store your charts code, and
 **gh-pages branch** as charts repository, e.g.:
-`https://USERNAME.github.io/REPONAME`. The demonstration [TS Charts](https://github.com/technosophos/tscharts)
-repository is accessible at `https://technosophos.github.io/tscharts/`.
+`https://USERNAME.github.io/REPONAME`. The demonstration [TS
+Charts](https://github.com/technosophos/tscharts) repository is accessible at
+`https://technosophos.github.io/tscharts/`.
 
 ### Ordinary web servers
 
@@ -204,12 +208,13 @@ To configure an ordinary web server to serve Helm charts, you merely need to do
 the following:
 
 - Put your index and charts in a directory that the server can serve
-- Make sure the `index.yaml` file can be accessed with no authentication requirement
-- Make sure `yaml` files are served with the correct content type (`text/yaml` or
-  `text/x-yaml`)
+- Make sure the `index.yaml` file can be accessed with no authentication
+  requirement
+- Make sure `yaml` files are served with the correct content type (`text/yaml`
+  or `text/x-yaml`)
 
-For example, if you want to serve your charts out of `$WEBROOT/charts`, make sure
-there is a `charts/` directory in your web root, and put the index file and
+For example, if you want to serve your charts out of `$WEBROOT/charts`, make
+sure there is a `charts/` directory in your web root, and put the index file and
 charts inside of that folder.
 
 
@@ -222,9 +227,9 @@ to maintain charts in that repository.
 ### Store charts in your chart repository
 
 Now that you have a chart repository, let's upload a chart and an index file to
-the repository.  Charts in a chart repository must be packaged
-(`helm package chart-name/`) and versioned correctly (following
-[SemVer 2](https://semver.org/) guidelines).
+the repository.  Charts in a chart repository must be packaged (`helm package
+chart-name/`) and versioned correctly (following [SemVer 2](https://semver.org/)
+guidelines).
 
 These next steps compose an example workflow, but you are welcome to use
 whatever workflow you fancy for storing and updating charts in your chart
@@ -241,19 +246,19 @@ $ helm repo index fantastic-charts --url https://fantastic-charts.storage.google
 ```
 
 The last command takes the path of the local directory that you just created and
-the URL of your remote chart repository and composes an `index.yaml` file inside the
-given directory path.
+the URL of your remote chart repository and composes an `index.yaml` file inside
+the given directory path.
 
-Now you can upload the chart and the index file to your chart repository using
-a sync tool or manually. If you're using Google Cloud Storage, check out this
-[example workflow](chart_repository_sync_example.md) using the gsutil client. For
-GitHub, you can simply put the charts in the appropriate destination branch.
+Now you can upload the chart and the index file to your chart repository using a
+sync tool or manually. If you're using Google Cloud Storage, check out this
+[example workflow](chart_repository_sync_example.md) using the gsutil client.
+For GitHub, you can simply put the charts in the appropriate destination branch.
 
 ### Add new charts to an existing repository
 
 Each time you want to add a new chart to your repository, you must regenerate
-the index. The `helm repo index` command will completely rebuild the `index.yaml`
-file from scratch, including only the charts that it finds locally.
+the index. The `helm repo index` command will completely rebuild the
+`index.yaml` file from scratch, including only the charts that it finds locally.
 
 However, you can use the `--merge` flag to incrementally add new charts to an
 existing `index.yaml` file (a great option when working with a remote repository
@@ -267,9 +272,9 @@ if you generated a provenance file, upload that too.
 When you're ready to share your charts, simply let someone know what the URL of
 your repository is.
 
-From there, they will add the repository to their helm client via the `helm
-repo add [NAME] [URL]` command with any name they would like to use to
-reference the repository.
+From there, they will add the repository to their helm client via the `helm repo
+add [NAME] [URL]` command with any name they would like to use to reference the
+repository.
 
 ```console
 $ helm repo add fantastic-charts https://fantastic-charts.storage.googleapis.com
@@ -289,11 +294,11 @@ fantastic-charts    https://fantastic-charts.storage.googleapis.com
 **Note:** A repository will not be added if it does not contain a valid
 `index.yaml`.
 
-After that, your users will be able to search through your charts. After you've updated
-the repository, they can use the `helm repo update` command to get the latest
-chart information.
+After that, your users will be able to search through your charts. After you've
+updated the repository, they can use the `helm repo update` command to get the
+latest chart information.
 
 *Under the hood, the `helm repo add` and `helm repo update` commands are
 fetching the index.yaml file and storing them in the
-`$XDG_CACHE_HOME/helm/repository/cache/` directory. This is where the `helm search`
-function finds information about charts.*
+`$XDG_CACHE_HOME/helm/repository/cache/` directory. This is where the `helm
+search` function finds information about charts.*

--- a/content/docs/topics/chart_template_guide/_index.md
+++ b/content/docs/topics/chart_template_guide/_index.md
@@ -6,9 +6,13 @@ weight: 5
 
 # The Chart Template Developer's Guide
 
-This guide provides an introduction to Helm's chart templates, with emphasis on the template language.
+This guide provides an introduction to Helm's chart templates, with emphasis on
+the template language.
 
-Templates generate manifest files, which are YAML-formatted resource descriptions that Kubernetes can understand. We'll look at how templates are structured, how they can be used, how to write Go templates, and how to debug your work.
+Templates generate manifest files, which are YAML-formatted resource
+descriptions that Kubernetes can understand. We'll look at how templates are
+structured, how they can be used, how to write Go templates, and how to debug
+your work.
 
 This guide focuses on the following concepts:
 
@@ -16,4 +20,6 @@ This guide focuses on the following concepts:
 - Using values
 - Techniques for working with templates
 
-This guide is oriented toward learning the ins and outs of the Helm template language. Other guides provide introductory material, examples, and best practices.
+This guide is oriented toward learning the ins and outs of the Helm template
+language. Other guides provide introductory material, examples, and best
+practices.

--- a/content/docs/topics/chart_template_guide/accessing_files.md
+++ b/content/docs/topics/chart_template_guide/accessing_files.md
@@ -3,15 +3,26 @@ title: "Accessing Files Inside Templates"
 description: "How to access files from within a template."
 ---
 
-In the previous section we looked at several ways to create and access named templates. This makes it easy to import one template from within another template. But sometimes it is desirable to import a _file that is not a template_ and inject its contents without sending the contents through the template renderer.
+In the previous section we looked at several ways to create and access named
+templates. This makes it easy to import one template from within another
+template. But sometimes it is desirable to import a _file that is not a
+template_ and inject its contents without sending the contents through the
+template renderer.
 
-Helm provides access to files through the `.Files` object. Before we get going with the template examples, though, there are a few things to note about how this works:
+Helm provides access to files through the `.Files` object. Before we get going
+with the template examples, though, there are a few things to note about how
+this works:
 
-- It is okay to add extra files to your Helm chart. These files will be bundled. Be careful, though. Charts must be smaller than 1M because of the storage limitations of Kubernetes objects.
-- Some files cannot be accessed through the `.Files` object, usually for security reasons.
-	- Files in `templates/` cannot be accessed.
-	- Files excluded using `.helmignore` cannot be accessed.
-- Charts do not preserve UNIX mode information, so file-level permissions will have no impact on the availability of a file when it comes to the `.Files` object.
+- It is okay to add extra files to your Helm chart. These files will be bundled.
+  Be careful, though. Charts must be smaller than 1M because of the storage
+  limitations of Kubernetes objects.
+- Some files cannot be accessed through the `.Files` object, usually for
+  security reasons.
+  - Files in `templates/` cannot be accessed.
+  - Files excluded using `.helmignore` cannot be accessed.
+- Charts do not preserve UNIX mode information, so file-level permissions will
+  have no impact on the availability of a file when it comes to the `.Files`
+  object.
 
 <!-- (see https://github.com/jonschlinkert/markdown-toc) -->
 
@@ -28,7 +39,9 @@ Helm provides access to files through the `.Files` object. Before we get going w
 
 ## Basic example
 
-With those caveats behind, let's write a template that reads three files into our ConfigMap. To get started, we will add three files to the chart, putting all three directly inside of the `mychart/` directory.
+With those caveats behind, let's write a template that reads three files into
+our ConfigMap. To get started, we will add three files to the chart, putting all
+three directly inside of the `mychart/` directory.
 
 `config1.toml`:
 
@@ -48,7 +61,9 @@ message = This is config 2
 message = Goodbye from config 3
 ```
 
-Each of these is a simple TOML file (think old-school Windows INI files). We know the names of these files, so we can use a `range` function to loop through them and inject their contents into our ConfigMap.
+Each of these is a simple TOML file (think old-school Windows INI files). We
+know the names of these files, so we can use a `range` function to loop through
+them and inject their contents into our ConfigMap.
 
 ```yaml
 apiVersion: v1
@@ -63,9 +78,14 @@ data:
   {{- end }}
 ```
 
-This config map uses several of the techniques discussed in previous sections. For example, we create a `$files` variable to hold a reference to the `.Files` object. We also use the `tuple` function to create a list of files that we loop through. Then we print each file name (`{{ . }}: |-`) followed by the contents of the file `{{ $files.Get . }}`.
+This config map uses several of the techniques discussed in previous sections.
+For example, we create a `$files` variable to hold a reference to the `.Files`
+object. We also use the `tuple` function to create a list of files that we loop
+through. Then we print each file name (`{{ . }}: |-`) followed by the contents
+of the file `{{ $files.Get . }}`.
 
-Running this template will produce a single ConfigMap with the contents of all three files:
+Running this template will produce a single ConfigMap with the contents of all
+three files:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -89,8 +109,8 @@ data:
 When working with files, it can be very useful to perform some standard
 operations on the file paths themselves. To help with this, Helm imports many of
 the functions from Go's [path](https://golang.org/pkg/path/) package for your
-use. They are all accessible with the same names as in the Go package, but
-with a lowercase first letter. For example, `Base` becomes `base`, etc.
+use. They are all accessible with the same names as in the Go package, but with
+a lowercase first letter. For example, `Base` becomes `base`, etc.
 
 The imported functions are:
 - Base
@@ -101,9 +121,10 @@ The imported functions are:
 
 ## Glob patterns
 
-As your chart grows, you may find you have a greater need to organize your
-files more, and so we provide a `Files.Glob(pattern string)` method to assist
-in extracting certain files with all the flexibility of [glob patterns](https://godoc.org/github.com/gobwas/glob).
+As your chart grows, you may find you have a greater need to organize your files
+more, and so we provide a `Files.Glob(pattern string)` method to assist in
+extracting certain files with all the flexibility of [glob
+patterns](https://godoc.org/github.com/gobwas/glob).
 
 `.Glob` returns a `Files` type, so you may call any of the `Files` methods on
 the returned object.
@@ -141,8 +162,8 @@ Or
 (Not present in version 2.0.2 or prior)
 
 It is very common to want to place file content into both configmaps and
-secrets, for mounting into your pods at run time. To help with this, we provide a
-couple utility methods on the `Files` type.
+secrets, for mounting into your pods at run time. To help with this, we provide
+a couple utility methods on the `Files` type.
 
 For further organization, it is especially useful to use these methods in
 conjunction with the `Glob` method.
@@ -168,7 +189,8 @@ data:
 
 ## Encoding
 
-You can import a file and have the template base-64 encode it to ensure successful transmission:
+You can import a file and have the template base-64 encode it to ensure
+successful transmission:
 
 ```yaml
 apiVersion: v1
@@ -206,7 +228,12 @@ data:
     {{ . }}{{ end }}
 ```
 
-Currently, there is no way to pass files external to the chart during `helm install`. So if you are asking users to supply data, it must be loaded using `helm install -f` or `helm install --set`.
+Currently, there is no way to pass files external to the chart during `helm
+install`. So if you are asking users to supply data, it must be loaded using
+`helm install -f` or `helm install --set`.
 
-This discussion wraps up our dive into the tools and techniques for writing Helm templates. In the next section we will see how you can use one special file, `templates/NOTES.txt`, to send post-installation instructions to the users of your chart.
+This discussion wraps up our dive into the tools and techniques for writing Helm
+templates. In the next section we will see how you can use one special file,
+`templates/NOTES.txt`, to send post-installation instructions to the users of
+your chart.
 

--- a/content/docs/topics/chart_template_guide/builtin_objects.md
+++ b/content/docs/topics/chart_template_guide/builtin_objects.md
@@ -3,35 +3,67 @@ title: "Built-in Objects"
 description: "Built-in objects available to templates."
 ---
 
-Objects are passed into a template from the template engine. And your code can pass objects around (we'll see examples when we look at the `with` and `range` statements). There are even a few ways to create new objects within your templates, like with the `tuple` function we'll see later.
+Objects are passed into a template from the template engine. And your code can
+pass objects around (we'll see examples when we look at the `with` and `range`
+statements). There are even a few ways to create new objects within your
+templates, like with the `tuple` function we'll see later.
 
-Objects can be simple, and have just one value. Or they can contain other objects or functions. For example. the `Release` object contains several objects (like `Release.Name`) and the `Files` object has a few functions.
+Objects can be simple, and have just one value. Or they can contain other
+objects or functions. For example. the `Release` object contains several objects
+(like `Release.Name`) and the `Files` object has a few functions.
 
-In the previous section, we use `{{ .Release.Name }}` to insert the name of a release into a template. `Release` is one of the top-level objects that you can access in your templates.
+In the previous section, we use `{{ .Release.Name }}` to insert the name of a
+release into a template. `Release` is one of the top-level objects that you can
+access in your templates.
 
-- `Release`: This object describes the release itself. It has several objects inside of it:
+- `Release`: This object describes the release itself. It has several objects
+  inside of it:
   - `Release.Name`: The release name
-  - `Release.Namespace`: The namespace to be released into (if the manifest doesn’t override)
-  - `Release.IsUpgrade`: This is set to `true` if the current operation is an upgrade or rollback.
-  - `Release.IsInstall`: This is set to `true` if the current operation is an install.
-- `Values`: Values passed into the template from the `values.yaml` file and from user-supplied files. By default, `Values` is empty.
-- `Chart`: The contents of the `Chart.yaml` file. Any data in `Chart.yaml` will be accessible here. For example `{{ .Chart.Name }}-{{ .Chart.Version }}` will print out the `mychart-0.1.0`.
-  - The available fields are listed in the [Charts Guide](https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file)
-- `Files`: This provides access to all non-special files in a chart. While you cannot use it to access templates, you can use it to access other files in the chart. See the section _Accessing Files_ for more.
-  - `Files.Get` is a function for getting a file by name (`.Files.Get config.ini`)
-  - `Files.GetBytes` is a function for getting the contents of a file as an array of bytes instead of as a string. This is useful for things like images.
-- `Capabilities`: This provides information about what capabilities the Kubernetes cluster supports.
+  - `Release.Namespace`: The namespace to be released into (if the manifest
+    doesn’t override)
+  - `Release.IsUpgrade`: This is set to `true` if the current operation is an
+    upgrade or rollback.
+  - `Release.IsInstall`: This is set to `true` if the current operation is an
+    install.
+- `Values`: Values passed into the template from the `values.yaml` file and from
+  user-supplied files. By default, `Values` is empty.
+- `Chart`: The contents of the `Chart.yaml` file. Any data in `Chart.yaml` will
+  be accessible here. For example `{{ .Chart.Name }}-{{ .Chart.Version }}` will
+  print out the `mychart-0.1.0`.
+  - The available fields are listed in the [Charts
+    Guide](https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file)
+- `Files`: This provides access to all non-special files in a chart. While you
+  cannot use it to access templates, you can use it to access other files in the
+  chart. See the section _Accessing Files_ for more.
+  - `Files.Get` is a function for getting a file by name (`.Files.Get
+    config.ini`)
+  - `Files.GetBytes` is a function for getting the contents of a file as an
+    array of bytes instead of as a string. This is useful for things like
+    images.
+- `Capabilities`: This provides information about what capabilities the
+  Kubernetes cluster supports.
   - `Capabilities.APIVersions` is a set of versions.
-  - `Capabilities.APIVersions.Has $version` indicates whether a version (e.g., `batch/v1`) or resource (e.g., `apps/v1/Deployment`) is available on the cluster.
+  - `Capabilities.APIVersions.Has $version` indicates whether a version (e.g.,
+    `batch/v1`) or resource (e.g., `apps/v1/Deployment`) is available on the
+    cluster.
   - `Capabilities.Kube.Version` is the Kubernetes version.
   - `Capabilities.Kube` is a short form for Kubernetes version.
   - `Capabilities.Kube.Major` is the Kubernetes major version.
   - `Capabilities.Kube.Minor` is the Kubernetes minor version.
-- `Template`: Contains information about the current template that is being executed
-  - `Name`: A namespaced filepath to the current template (e.g. `mychart/templates/mytemplate.yaml`)
-  - `BasePath`: The namespaced path to the templates directory of the current chart (e.g. `mychart/templates`).
+- `Template`: Contains information about the current template that is being
+  executed
+  - `Name`: A namespaced filepath to the current template (e.g.
+    `mychart/templates/mytemplate.yaml`)
+  - `BasePath`: The namespaced path to the templates directory of the current
+    chart (e.g. `mychart/templates`).
 
-The values are available to any top-level template. As we will see later, this does not necessarily mean that they will be available _everywhere_.
+The values are available to any top-level template. As we will see later, this
+does not necessarily mean that they will be available _everywhere_.
 
-The built-in values always begin with a capital letter. This is in keeping with Go's naming convention. When you create your own names, you are free to use a convention that suits your team. Some teams, like the [Kubernetes Charts](https://github.com/helm/charts) team, choose to use only initial lower case letters in order to distinguish local names from those built-in. In this guide, we follow that convention.
+The built-in values always begin with a capital letter. This is in keeping with
+Go's naming convention. When you create your own names, you are free to use a
+convention that suits your team. Some teams, like the [Kubernetes
+Charts](https://github.com/helm/charts) team, choose to use only initial lower
+case letters in order to distinguish local names from those built-in. In this
+guide, we follow that convention.
 

--- a/content/docs/topics/chart_template_guide/control_structures.md
+++ b/content/docs/topics/chart_template_guide/control_structures.md
@@ -3,23 +3,28 @@ title: "Flow Control"
 description: "A quick overview on the flow structure within templates."
 ---
 
-Control structures (called "actions" in template parlance) provide you, the template author, with the ability to control the flow of a template's generation. Helm's template language provides the following control structures:
+Control structures (called "actions" in template parlance) provide you, the
+template author, with the ability to control the flow of a template's
+generation. Helm's template language provides the following control structures:
 
 - `if`/`else` for creating conditional blocks
 - `with` to specify a scope
 - `range`, which provides a "for each"-style loop
 
-In addition to these, it provides a few actions for declaring and using named template segments:
+In addition to these, it provides a few actions for declaring and using named
+template segments:
 
 - `define` declares a new named template inside of your template
 - `template` imports a named template
 - `block` declares a special kind of fillable template area
 
-In this section, we'll talk about `if`, `with`, and `range`. The others are covered in the "Named Templates" section later in this guide.
+In this section, we'll talk about `if`, `with`, and `range`. The others are
+covered in the "Named Templates" section later in this guide.
 
 ## If/Else
 
-The first control structure we'll look at is for conditionally including blocks of text in a template. This is the `if`/`else` block.
+The first control structure we'll look at is for conditionally including blocks
+of text in a template. This is the `if`/`else` block.
 
 The basic structure for a conditional looks like this:
 
@@ -33,7 +38,9 @@ The basic structure for a conditional looks like this:
 {{ end }}
 ```
 
-Notice that we're now talking about _pipelines_ instead of values. The reason for this is to make it clear that control structures can execute an entire pipeline, not just evaluate a value.
+Notice that we're now talking about _pipelines_ instead of values. The reason
+for this is to make it clear that control structures can execute an entire
+pipeline, not just evaluate a value.
 
 A pipeline is evaluated as _false_ if the value is:
 
@@ -45,7 +52,8 @@ A pipeline is evaluated as _false_ if the value is:
 
 Under all other conditions, the condition is true.
 
-Let's add a simple conditional to our ConfigMap. We'll add another setting if the drink is set to coffee:
+Let's add a simple conditional to our ConfigMap. We'll add another setting if
+the drink is set to coffee:
 
 ```yaml
 apiVersion: v1
@@ -59,7 +67,9 @@ data:
   {{ if eq .Values.favorite.drink "coffee" }}mug: true{{ end }}
 ```
 
-Since we commented out `drink: coffee` in our last example, the output should not include a `mug: true` flag. But if we add that line back into our `values.yaml` file, the output should look like this:
+Since we commented out `drink: coffee` in our last example, the output should
+not include a `mug: true` flag. But if we add that line back into our
+`values.yaml` file, the output should look like this:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -76,7 +86,9 @@ data:
 
 ## Controlling Whitespace
 
-While we're looking at conditionals, we should take a quick look at the way whitespace is controlled in templates. Let's take the previous example and format it to be a little easier to read:
+While we're looking at conditionals, we should take a quick look at the way
+whitespace is controlled in templates. Let's take the previous example and
+format it to be a little easier to read:
 
 ```yaml
 apiVersion: v1
@@ -92,7 +104,8 @@ data:
   {{ end }}
 ```
 
-Initially, this looks good. But if we run it through the template engine, we'll get an unfortunate result:
+Initially, this looks good. But if we run it through the template engine, we'll
+get an unfortunate result:
 
 ```console
 $ helm install --dry-run --debug ./mychart
@@ -149,13 +162,22 @@ data:
 
 ```
 
-Notice that we received a few empty lines in our YAML. Why? When the template engine runs, it _removes_ the contents inside of `{{` and `}}`, but it leaves the remaining whitespace exactly as is.
+Notice that we received a few empty lines in our YAML. Why? When the template
+engine runs, it _removes_ the contents inside of `{{` and `}}`, but it leaves
+the remaining whitespace exactly as is.
 
-YAML ascribes meaning to whitespace, so managing the whitespace becomes pretty important. Fortunately, Helm templates have a few tools to help.
+YAML ascribes meaning to whitespace, so managing the whitespace becomes pretty
+important. Fortunately, Helm templates have a few tools to help.
 
-First, the curly brace syntax of template declarations can be modified with special characters to tell the template engine to chomp whitespace. `{{- ` (with the dash and space added) indicates that whitespace should be chomped left, while ` -}}` means whitespace to the right should be consumed. _Be careful! Newlines are whitespace!_
+First, the curly brace syntax of template declarations can be modified with
+special characters to tell the template engine to chomp whitespace. `{{- ` (with
+the dash and space added) indicates that whitespace should be chomped left,
+while ` -}}` means whitespace to the right should be consumed. _Be careful!
+Newlines are whitespace!_
 
-> Make sure there is a space between the `-` and the rest of your directive. `{{- 3 }}` means "trim left whitespace and print 3" while `{{-3 }}` means "print -3".
+> Make sure there is a space between the `-` and the rest of your directive.
+> `{{- 3 }}` means "trim left whitespace and print 3" while `{{-3 }}` means
+> "print -3".
 
 Using this syntax, we can modify our template to get rid of those new lines:
 
@@ -173,7 +195,10 @@ data:
   {{- end }}
 ```
 
-Just for the sake of making this point clear, let's adjust the above, and substitute an `*` for each whitespace that will be deleted following this rule. an `*` at the end of the line indicates a newline character that would be removed
+Just for the sake of making this point clear, let's adjust the above, and
+substitute an `*` for each whitespace that will be deleted following this rule.
+an `*` at the end of the line indicates a newline character that would be
+removed
 
 ```yaml
 apiVersion: v1
@@ -205,7 +230,8 @@ data:
   mug: true
 ```
 
-Be careful with the chomping modifiers. It is easy to accidentally do things like this:
+Be careful with the chomping modifiers. It is easy to accidentally do things
+like this:
 
 ```yaml
   food: {{ .Values.favorite.food | upper | quote }}
@@ -215,15 +241,22 @@ Be careful with the chomping modifiers. It is easy to accidentally do things lik
 
 ```
 
-That will produce `food: "PIZZA"mug:true` because it consumed newlines on both sides.
+That will produce `food: "PIZZA"mug:true` because it consumed newlines on both
+sides.
 
-> For the details on whitespace control in templates, see the [Official Go template documentation](https://godoc.org/text/template)
+> For the details on whitespace control in templates, see the [Official Go
+> template documentation](https://godoc.org/text/template)
 
-Finally, sometimes it's easier to tell the template system how to indent for you instead of trying to master the spacing of template directives. For that reason, you may sometimes find it useful to use the `indent` function (`{{ indent 2 "mug:true" }}`).
+Finally, sometimes it's easier to tell the template system how to indent for you
+instead of trying to master the spacing of template directives. For that reason,
+you may sometimes find it useful to use the `indent` function (`{{ indent 2
+"mug:true" }}`).
 
 ## Modifying scope using `with`
 
-The next control structure to look at is the `with` action. This controls variable scoping. Recall that `.` is a reference to _the current scope_. So `.Values` tells the template to find the `Values` object in the current scope.
+The next control structure to look at is the `with` action. This controls
+variable scoping. Recall that `.` is a reference to _the current scope_. So
+`.Values` tells the template to find the `Values` object in the current scope.
 
 The syntax for `with` is similar to a simple `if` statement:
 
@@ -233,7 +266,10 @@ The syntax for `with` is similar to a simple `if` statement:
 {{ end }}
 ```
 
-Scopes can be changed. `with` can allow you to set the current scope (`.`) to a particular object. For example, we've been working with `.Values.favorites`. Let's rewrite our ConfigMap to alter the `.` scope to point to `.Values.favorites`:
+Scopes can be changed. `with` can allow you to set the current scope (`.`) to a
+particular object. For example, we've been working with `.Values.favorites`.
+Let's rewrite our ConfigMap to alter the `.` scope to point to
+`.Values.favorites`:
 
 ```yaml
 apiVersion: v1
@@ -250,9 +286,13 @@ data:
 
 (Note that we removed the `if` conditional from the previous exercise)
 
-Notice that now we can reference `.drink` and `.food` without qualifying them. That is because the `with` statement sets `.` to point to `.Values.favorite`. The `.` is reset to its previous scope after `{{ end }}`.
+Notice that now we can reference `.drink` and `.food` without qualifying them.
+That is because the `with` statement sets `.` to point to `.Values.favorite`.
+The `.` is reset to its previous scope after `{{ end }}`.
 
-But here's a note of caution! Inside of the restricted scope, you will not be able to access the other objects from the parent scope. This, for example, will fail:
+But here's a note of caution! Inside of the restricted scope, you will not be
+able to access the other objects from the parent scope. This, for example, will
+fail:
 
 ```yaml
   {{- with .Values.favorite }}
@@ -262,7 +302,9 @@ But here's a note of caution! Inside of the restricted scope, you will not be ab
   {{- end }}
 ```
 
-It will produce an error because `Release.Name` is not inside of the restricted scope for `.`. However, if we swap the last two lines, all will work as expected because the scope is reset after `{{ end }}`.
+It will produce an error because `Release.Name` is not inside of the restricted
+scope for `.`. However, if we swap the last two lines, all will work as expected
+because the scope is reset after `{{ end }}`.
 
 ```yaml
   {{- with .Values.favorite }}
@@ -272,11 +314,14 @@ It will produce an error because `Release.Name` is not inside of the restricted 
   release: {{ .Release.Name }}
 ```
 
-After looking a `range`, we will take a look at template variables, which offer one solution to the scoping issue above.
+After looking a `range`, we will take a look at template variables, which offer
+one solution to the scoping issue above.
 
 ## Looping with the `range` action
 
-Many programming languages have support for looping using `for` loops, `foreach` loops, or similar functional mechanisms. In Helm's template language, the way to iterate through a collection is to use the `range` operator.
+Many programming languages have support for looping using `for` loops, `foreach`
+loops, or similar functional mechanisms. In Helm's template language, the way to
+iterate through a collection is to use the `range` operator.
 
 To start, let's add a list of pizza toppings to our `values.yaml` file:
 
@@ -291,7 +336,8 @@ pizzaToppings:
   - onions
 ```
 
-Now we have a list (called a `slice` in templates) of `pizzaToppings`. We can modify our template to print this list into our ConfigMap:
+Now we have a list (called a `slice` in templates) of `pizzaToppings`. We can
+modify our template to print this list into our ConfigMap:
 
 ```yaml
 apiVersion: v1
@@ -311,9 +357,16 @@ data:
 
 ```
 
-Let's take a closer look at the `toppings:` list. The `range` function will "range over" (iterate through) the `pizzaToppings` list. But now something interesting happens. Just like `with` sets the scope of `.`, so does a `range` operator. Each time through the loop, `.` is set to the current pizza topping. That is, the first time, `.` is set to `mushrooms`. The second iteration it is set to `cheese`, and so on.
+Let's take a closer look at the `toppings:` list. The `range` function will
+"range over" (iterate through) the `pizzaToppings` list. But now something
+interesting happens. Just like `with` sets the scope of `.`, so does a `range`
+operator. Each time through the loop, `.` is set to the current pizza topping.
+That is, the first time, `.` is set to `mushrooms`. The second iteration it is
+set to `cheese`, and so on.
 
-We can send the value of `.` directly down a pipeline, so when we do `{{ . | title | quote }}`, it sends `.` to `title` (title case function) and then to `quote`. If we run this template, the output will be:
+We can send the value of `.` directly down a pipeline, so when we do `{{ . |
+title | quote }}`, it sends `.` to `title` (title case function) and then to
+`quote`. If we run this template, the output will be:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -332,11 +385,23 @@ data:
     - "Onions"
 ```
 
-Now, in this example we've done something tricky. The `toppings: |-` line is declaring a multi-line string. So our list of toppings is actually not a YAML list. It's a big string. Why would we do this? Because the data in ConfigMaps `data` is composed of key/value pairs, where both the key and the value are simple strings. To understand why this is the case, take a look at the [Kubernetes ConfigMap docs](http://kubernetes.io/docs/user-guide/configmap/). For us, though, this detail doesn't matter much.
+Now, in this example we've done something tricky. The `toppings: |-` line is
+declaring a multi-line string. So our list of toppings is actually not a YAML
+list. It's a big string. Why would we do this? Because the data in ConfigMaps
+`data` is composed of key/value pairs, where both the key and the value are
+simple strings. To understand why this is the case, take a look at the
+[Kubernetes ConfigMap docs](http://kubernetes.io/docs/user-guide/configmap/).
+For us, though, this detail doesn't matter much.
 
-> The `|-` marker in YAML takes a multi-line string. This can be a useful technique for embedding big blocks of data inside of your manifests, as exemplified here.
+> The `|-` marker in YAML takes a multi-line string. This can be a useful
+> technique for embedding big blocks of data inside of your manifests, as
+> exemplified here.
 
-Sometimes it's useful to be able to quickly make a list inside of your template, and then iterate over that list. Helm templates have a function to make this easy: `tuple`. In computer science, a tuple is a list-like collection of fixed size, but with arbitrary data types. This roughly conveys the way a `tuple` is used.
+Sometimes it's useful to be able to quickly make a list inside of your template,
+and then iterate over that list. Helm templates have a function to make this
+easy: `tuple`. In computer science, a tuple is a list-like collection of fixed
+size, but with arbitrary data types. This roughly conveys the way a `tuple` is
+used.
 
 ```yaml
   sizes: |-
@@ -354,4 +419,6 @@ The above will produce this:
     - large
 ```
 
-In addition to lists and tuples, `range` can be used to iterate over collections that have a key and a value (like a `map` or `dict`). We'll see how to do that in the next section when we introduce template variables.
+In addition to lists and tuples, `range` can be used to iterate over collections
+that have a key and a value (like a `map` or `dict`). We'll see how to do that
+in the next section when we introduce template variables.

--- a/content/docs/topics/chart_template_guide/data_types.md
+++ b/content/docs/topics/chart_template_guide/data_types.md
@@ -3,15 +3,23 @@ title: "Appendix: Go Data Types and Templates"
 description: "A quick overview on variables in templates."
 ---
 
-The Helm template language is implemented in the strongly typed Go programming language. For that reason, variables in templates are _typed_. For the most part, variables will be exposed as one of the following types:
+The Helm template language is implemented in the strongly typed Go programming
+language. For that reason, variables in templates are _typed_. For the most
+part, variables will be exposed as one of the following types:
 
 - string: A string of text
 - bool: a `true` or `false`
-- int: An integer value (there are also 8, 16, 32, and 64 bit signed and unsigned variants of this)
-- float64: a 64-bit floating point value (there are also 8, 16, and 32 bit varieties of this)
+- int: An integer value (there are also 8, 16, 32, and 64 bit signed and
+  unsigned variants of this)
+- float64: a 64-bit floating point value (there are also 8, 16, and 32 bit
+  varieties of this)
 - a byte slice (`[]byte`), often used to hold (potentially) binary data
 - struct: an object with properties and methods
 - a slice (indexed list) of one of the previous types
-- a string-keyed map (`map[string]interface{}`) where the value is one of the previous types
+- a string-keyed map (`map[string]interface{}`) where the value is one of the
+  previous types
 
-There are many other types in Go, and sometimes you will have to convert between them in your templates. The easiest way to debug an object's type is to pass it through `printf "%t"` in a template, which will print the type. Also see the `typeOf` and `kindOf` functions.
+There are many other types in Go, and sometimes you will have to convert between
+them in your templates. The easiest way to debug an object's type is to pass it
+through `printf "%t"` in a template, which will print the type. Also see the
+`typeOf` and `kindOf` functions.

--- a/content/docs/topics/chart_template_guide/debugging.md
+++ b/content/docs/topics/chart_template_guide/debugging.md
@@ -3,17 +3,23 @@ title: "Debugging Templates"
 description: "Troubleshooting charts that are failing to deploy."
 ---
 
-Debugging templates can be tricky because the rendered templates are sent to the Kubernetes API server, which may reject the YAML files for reasons other than formatting.
+Debugging templates can be tricky because the rendered templates are sent to the
+Kubernetes API server, which may reject the YAML files for reasons other than
+formatting.
 
 There are a few commands that can help you debug.
 
-- `helm lint` is your go-to tool for verifying that your chart follows best practices
-- `helm install --dry-run --debug`: We've seen this trick already. It's a great way to have the server render your templates, then return the resulting manifest file.
-- `helm get manifest`: This is a good way to see what templates are installed on the server.
+- `helm lint` is your go-to tool for verifying that your chart follows best
+  practices
+- `helm install --dry-run --debug`: We've seen this trick already. It's a great
+  way to have the server render your templates, then return the resulting
+  manifest file.
+- `helm get manifest`: This is a good way to see what templates are installed on
+  the server.
 
 When your YAML is failing to parse, but you want to see what is generated, one
-easy way to retrieve the YAML is to comment out the problem section in the template,
-and then re-run `helm install --dry-run --debug`:
+easy way to retrieve the YAML is to comment out the problem section in the
+template, and then re-run `helm install --dry-run --debug`:
 
 ```yaml
 apiVersion: v1

--- a/content/docs/topics/chart_template_guide/functions_and_pipelines.md
+++ b/content/docs/topics/chart_template_guide/functions_and_pipelines.md
@@ -3,9 +3,13 @@ title: "Template Functions and Pipelines"
 description: "Using functions in templates."
 ---
 
-So far, we've seen how to place information into a template. But that information is placed into the template unmodified. Sometimes we want to transform the supplied data in a way that makes it more useable to us.
+So far, we've seen how to place information into a template. But that
+information is placed into the template unmodified. Sometimes we want to
+transform the supplied data in a way that makes it more useable to us.
 
-Let's start with a best practice: When injecting strings from the `.Values` object into the template, we ought to quote these strings. We can do that by calling the `quote` function in the template directive:
+Let's start with a best practice: When injecting strings from the `.Values`
+object into the template, we ought to quote these strings. We can do that by
+calling the `quote` function in the template directive:
 
 ```yaml
 apiVersion: v1
@@ -18,15 +22,29 @@ data:
   food: {{ quote .Values.favorite.food }}
 ```
 
-Template functions follow the syntax `functionName arg1 arg2...`. In the snippet above, `quote .Values.favorite.drink` calls the `quote` function and passes it a single argument.
+Template functions follow the syntax `functionName arg1 arg2...`. In the snippet
+above, `quote .Values.favorite.drink` calls the `quote` function and passes it a
+single argument.
 
-Helm has over 60 available functions. Some of them are defined by the [Go template language](https://godoc.org/text/template) itself. Most of the others are part of the [Sprig template library](https://godoc.org/github.com/Masterminds/sprig). We'll see many of them as we progress through the examples.
+Helm has over 60 available functions. Some of them are defined by the [Go
+template language](https://godoc.org/text/template) itself. Most of the others
+are part of the [Sprig template
+library](https://godoc.org/github.com/Masterminds/sprig). We'll see many of them
+as we progress through the examples.
 
-> While we talk about the "Helm template language" as if it is Helm-specific, it is actually a combination of the Go template language, some extra functions, and a variety of wrappers to expose certain objects to the templates. Many resources on Go templates may be helpful as you learn about templating.
+> While we talk about the "Helm template language" as if it is Helm-specific, it
+> is actually a combination of the Go template language, some extra functions,
+> and a variety of wrappers to expose certain objects to the templates. Many
+> resources on Go templates may be helpful as you learn about templating.
 
 ## Pipelines
 
-One of the powerful features of the template language is its concept of _pipelines_. Drawing on a concept from UNIX, pipelines are a tool for chaining together a series of template commands to compactly express a series of transformations. In other words, pipelines are an efficient way of getting several things done in sequence. Let's rewrite the above example using a pipeline.
+One of the powerful features of the template language is its concept of
+_pipelines_. Drawing on a concept from UNIX, pipelines are a tool for chaining
+together a series of template commands to compactly express a series of
+transformations. In other words, pipelines are an efficient way of getting
+several things done in sequence. Let's rewrite the above example using a
+pipeline.
 
 ```yaml
 apiVersion: v1
@@ -39,7 +57,10 @@ data:
   food: {{ .Values.favorite.food | quote }}
 ```
 
-In this example, instead of calling `quote ARGUMENT`, we inverted the order. We "sent" the argument to the function using a pipeline (`|`): `.Values.favorite.drink | quote`. Using pipelines, we can chain several functions together:
+In this example, instead of calling `quote ARGUMENT`, we inverted the order. We
+"sent" the argument to the function using a pipeline (`|`):
+`.Values.favorite.drink | quote`. Using pipelines, we can chain several
+functions together:
 
 ```yaml
 apiVersion: v1
@@ -52,7 +73,8 @@ data:
   food: {{ .Values.favorite.food | upper | quote }}
 ```
 
-> Inverting the order is a common practice in templates. You will see `.val | quote` more often than `quote .val`. Either practice is fine.
+> Inverting the order is a common practice in templates. You will see `.val |
+> quote` more often than `quote .val`. Either practice is fine.
 
 When evaluated, that template will produce this:
 
@@ -70,7 +92,10 @@ data:
 
 Note that our original `pizza` has now been transformed to `"PIZZA"`.
 
-When pipelining arguments like this, the result of the first evaluation (`.Values.favorite.drink`) is sent as the _last argument to the function_. We can modify the drink example above to illustrate with a function that takes two arguments: `repeat COUNT STRING`:
+When pipelining arguments like this, the result of the first evaluation
+(`.Values.favorite.drink`) is sent as the _last argument to the function_. We
+can modify the drink example above to illustrate with a function that takes two
+arguments: `repeat COUNT STRING`:
 
 ```yaml
 apiVersion: v1
@@ -83,7 +108,8 @@ data:
   food: {{ .Values.favorite.food | upper | quote }}
 ```
 
-The `repeat` function will echo the given string the given number of times, so we will get this for output:
+The `repeat` function will echo the given string the given number of times, so
+we will get this for output:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -99,7 +125,10 @@ data:
 
 ## Using the `default` function
 
-One function frequently used in templates is the `default` function: `default DEFAULT_VALUE GIVEN_VALUE`. This function allows you to specify a default value inside of the template, in case the value is omitted. Let's use it to modify the drink example above:
+One function frequently used in templates is the `default` function: `default
+DEFAULT_VALUE GIVEN_VALUE`. This function allows you to specify a default value
+inside of the template, in case the value is omitted. Let's use it to modify the
+drink example above:
 
 ```yaml
 drink: {{ .Values.favorite.drink | default "tea" | quote }}
@@ -127,7 +156,8 @@ favorite:
   food: pizza
 ```
 
-Now re-running `helm install --dry-run --debug ./mychart` will produce this YAML:
+Now re-running `helm install --dry-run --debug ./mychart` will produce this
+YAML:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -141,18 +171,29 @@ data:
   food: "PIZZA"
 ```
 
-In an actual chart, all static default values should live in the values.yaml, and should not be repeated using the `default` command (otherwise they would be redundant). However, the `default` command is perfect for computed values, which can not be declared inside values.yaml. For example:
+In an actual chart, all static default values should live in the values.yaml,
+and should not be repeated using the `default` command (otherwise they would be
+redundant). However, the `default` command is perfect for computed values, which
+can not be declared inside values.yaml. For example:
 
 ```yaml
 drink: {{ .Values.favorite.drink | default (printf "%s-tea" (include "fullname" .)) }}
 ```
 
-In some places, an `if` conditional guard may be better suited than `default`. We'll see those in the next section.
+In some places, an `if` conditional guard may be better suited than `default`.
+We'll see those in the next section.
 
-Template functions and pipelines are a powerful way to transform information and then insert it into your YAML. But sometimes it's necessary to add some template logic that is a little more sophisticated than just inserting a string. In the next section we will look at the control structures provided by the template language.
+Template functions and pipelines are a powerful way to transform information and
+then insert it into your YAML. But sometimes it's necessary to add some template
+logic that is a little more sophisticated than just inserting a string. In the
+next section we will look at the control structures provided by the template
+language.
 
 ## Operators are functions
 
-For templates, the operators (`eq`, `ne`, `lt`, `gt`, `and`, `or` and so on) are all implemented as functions. In pipelines, operations can be grouped with parentheses (`(`, and `)`).
+For templates, the operators (`eq`, `ne`, `lt`, `gt`, `and`, `or` and so on) are
+all implemented as functions. In pipelines, operations can be grouped with
+parentheses (`(`, and `)`).
 
-Now we can turn from functions and pipelines to flow control with conditions, loops, and scope modifiers.
+Now we can turn from functions and pipelines to flow control with conditions,
+loops, and scope modifiers.

--- a/content/docs/topics/chart_template_guide/named_templates.md
+++ b/content/docs/topics/chart_template_guide/named_templates.md
@@ -3,29 +3,52 @@ title: "Named Templates"
 description: "How to define named templates."
 ---
 
-It is time to move beyond one template, and begin to create others. In this section, we will see how to define _named templates_ in one file, and then use them elsewhere. A _named template_ (sometimes called a _partial_ or a _subtemplate_) is simply a template defined inside of a file, and given a name. We'll see two ways to create them, and a few different ways to use them.
+It is time to move beyond one template, and begin to create others. In this
+section, we will see how to define _named templates_ in one file, and then use
+them elsewhere. A _named template_ (sometimes called a _partial_ or a
+_subtemplate_) is simply a template defined inside of a file, and given a name.
+We'll see two ways to create them, and a few different ways to use them.
 
-In the [Flow Control](../control_structures) section we introduced three actions for declaring and managing templates: `define`, `template`, and `block`. In this section, we'll cover those three actions, and also introduce a special-purpose `include` function that works similarly to the `template` action.
+In the [Flow Control](../control_structures) section we introduced three actions
+for declaring and managing templates: `define`, `template`, and `block`. In this
+section, we'll cover those three actions, and also introduce a special-purpose
+`include` function that works similarly to the `template` action.
 
-An important detail to keep in mind when naming templates: **template names are global**. If you declare two templates with the same name, whichever one is loaded last will be the one used. Because templates in subcharts are compiled together with top-level templates, you should be careful to name your templates with _chart-specific names_.
+An important detail to keep in mind when naming templates: **template names are
+global**. If you declare two templates with the same name, whichever one is
+loaded last will be the one used. Because templates in subcharts are compiled
+together with top-level templates, you should be careful to name your templates
+with _chart-specific names_.
 
-One popular naming convention is to prefix each defined template with the name of the chart: `{{ define "mychart.labels" }}`. By using the specific chart name as a prefix we can avoid any conflicts that may arise due to two different charts that implement templates of the same name.
+One popular naming convention is to prefix each defined template with the name
+of the chart: `{{ define "mychart.labels" }}`. By using the specific chart name
+as a prefix we can avoid any conflicts that may arise due to two different
+charts that implement templates of the same name.
 
 ## Partials and `_` files
 
-So far, we've used one file, and that one file has contained a single template. But Helm's template language allows you to create named embedded templates, that can be accessed by name elsewhere.
+So far, we've used one file, and that one file has contained a single template.
+But Helm's template language allows you to create named embedded templates, that
+can be accessed by name elsewhere.
 
-Before we get to the nuts-and-bolts of writing those templates, there is file naming convention that deserves mention:
+Before we get to the nuts-and-bolts of writing those templates, there is file
+naming convention that deserves mention:
 
 * Most files in `templates/` are treated as if they contain Kubernetes manifests
 * The `NOTES.txt` is one exception
-* But files whose name begins with an underscore (`_`) are assumed to _not_ have a manifest inside. These files are not rendered to Kubernetes object definitions, but are available everywhere within other chart templates for use.
+* But files whose name begins with an underscore (`_`) are assumed to _not_ have
+  a manifest inside. These files are not rendered to Kubernetes object
+  definitions, but are available everywhere within other chart templates for
+  use.
 
-These files are used to store partials and helpers. In fact, when we first created `mychart`, we saw a file called `_helpers.tpl`. That file is the default location for template partials.
+These files are used to store partials and helpers. In fact, when we first
+created `mychart`, we saw a file called `_helpers.tpl`. That file is the default
+location for template partials.
 
 ## Declaring and using templates with `define` and `template`
 
-The `define` action allows us to create a named template inside of a template file. Its syntax goes like this:
+The `define` action allows us to create a named template inside of a template
+file. Its syntax goes like this:
 
 ```yaml
 {{ define "MY.NAME" }}
@@ -33,7 +56,8 @@ The `define` action allows us to create a named template inside of a template fi
 {{ end }}
 ```
 
-For example, we can define a template to encapsulate a Kubernetes block of labels:
+For example, we can define a template to encapsulate a Kubernetes block of
+labels:
 
 ```yaml
 {{- define "mychart.labels" }}
@@ -43,7 +67,8 @@ For example, we can define a template to encapsulate a Kubernetes block of label
 {{- end }}
 ```
 
-Now we can embed this template inside of our existing ConfigMap, and then include it with the `template` action:
+Now we can embed this template inside of our existing ConfigMap, and then
+include it with the `template` action:
 
 ```yaml
 {{- define "mychart.labels" }}
@@ -63,7 +88,9 @@ data:
   {{- end }}
 ```
 
-When the template engine reads this file, it will store away the reference to `mychart.labels` until `template "mychart.labels"` is called. Then it will render that template inline. So the result will look like this:
+When the template engine reads this file, it will store away the reference to
+`mychart.labels` until `template "mychart.labels"` is called. Then it will
+render that template inline. So the result will look like this:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -80,7 +107,8 @@ data:
   food: "pizza"
 ```
 
-Conventionally, Helm charts put these templates inside of a partials file, usually `_helpers.tpl`. Let's move this function there:
+Conventionally, Helm charts put these templates inside of a partials file,
+usually `_helpers.tpl`. Let's move this function there:
 
 ```yaml
 {{/* Generate basic labels */}}
@@ -91,9 +119,11 @@ Conventionally, Helm charts put these templates inside of a partials file, usual
 {{- end }}
 ```
 
-By convention, `define` functions should have a simple documentation block (`{{/* ... */}}`) describing what they do.
+By convention, `define` functions should have a simple documentation block
+(`{{/* ... */}}`) describing what they do.
 
-Even though this definition is in `_helpers.tpl`, it can still be accessed in `configmap.yaml`:
+Even though this definition is in `_helpers.tpl`, it can still be accessed in
+`configmap.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -108,11 +138,18 @@ data:
   {{- end }}
 ```
 
-As mentioned above, **template names are global**. As a result of this, if two templates are declared with the same name the last occurrence will be the one that is used. Since templates in subcharts are compiled together with top-level templates, it is best to name your templates with _chart specific names_. A popular naming convention is to prefix each defined template with the name of the chart: `{{ define "mychart.labels" }}`.
+As mentioned above, **template names are global**. As a result of this, if two
+templates are declared with the same name the last occurrence will be the one
+that is used. Since templates in subcharts are compiled together with top-level
+templates, it is best to name your templates with _chart specific names_. A
+popular naming convention is to prefix each defined template with the name of
+the chart: `{{ define "mychart.labels" }}`.
 
 ## Setting the scope of a template
 
-In the template we defined above, we did not use any objects. We just used functions. Let's modify our defined template to include the chart name and chart version:
+In the template we defined above, we did not use any objects. We just used
+functions. Let's modify our defined template to include the chart name and chart
+version:
 
 ```yaml
 {{/* Generate basic labels */}}
@@ -140,13 +177,17 @@ metadata:
     version:
 ```
 
-What happened to the name and version? They weren't in the scope for our defined template. When a named template (created with `define`) is rendered, it will receive the scope passed in by the `template` call. In our example, we included the template like this:
+What happened to the name and version? They weren't in the scope for our defined
+template. When a named template (created with `define`) is rendered, it will
+receive the scope passed in by the `template` call. In our example, we included
+the template like this:
 
 ```yaml
 {{- template "mychart.labels" }}
 ```
 
-No scope was passed in, so within the template we cannot access anything in `.`. This is easy enough to fix, though. We simply pass a scope to the template:
+No scope was passed in, so within the template we cannot access anything in `.`.
+This is easy enough to fix, though. We simply pass a scope to the template:
 
 ```yaml
 apiVersion: v1
@@ -156,9 +197,12 @@ metadata:
   {{- template "mychart.labels" . }}
 ```
 
-Note that we pass `.` at the end of the `template` call. We could just as easily pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want is the top-level scope.
+Note that we pass `.` at the end of the `template` call. We could just as easily
+pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want
+is the top-level scope.
 
-Now when we execute this template with `helm install --dry-run --debug ./mychart`, we get this:
+Now when we execute this template with `helm install --dry-run --debug
+./mychart`, we get this:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -173,7 +217,8 @@ metadata:
     version: 0.1.0
 ```
 
-Now `{{ .Chart.Name }}` resolves to `mychart`, and `{{ .Chart.Version }}` resolves to `0.1.0`.
+Now `{{ .Chart.Name }}` resolves to `mychart`, and `{{ .Chart.Version }}`
+resolves to `0.1.0`.
 
 ## The `include` function
 
@@ -186,7 +231,8 @@ app_version: "{{ .Chart.Version }}"
 {{- end -}}
 ```
 
-Now say I want to insert this both into the `labels:` section of my template, and also the `data:` section:
+Now say I want to insert this both into the `labels:` section of my template,
+and also the `data:` section:
 
 ```yaml
 apiVersion: v1
@@ -222,11 +268,17 @@ data:
 app_version: "0.1.0+1478129847"
 ```
 
-Note that the indentation on `app_version` is wrong in both places. Why? Because the template that is substituted in has the text aligned to the right. Because `template` is an action, and not a function, there is no way to pass the output of a `template` call to other functions; the data is simply inserted inline.
+Note that the indentation on `app_version` is wrong in both places. Why? Because
+the template that is substituted in has the text aligned to the right. Because
+`template` is an action, and not a function, there is no way to pass the output
+of a `template` call to other functions; the data is simply inserted inline.
 
-To work around this case, Helm provides an alternative to `template` that will import the contents of a template into the present pipeline where it can be passed along to other functions in the pipeline.
+To work around this case, Helm provides an alternative to `template` that will
+import the contents of a template into the present pipeline where it can be
+passed along to other functions in the pipeline.
 
-Here's the example above, corrected to use `indent` to indent the `mychart_app` template correctly:
+Here's the example above, corrected to use `indent` to indent the `mychart_app`
+template correctly:
 
 ```yaml
 apiVersion: v1
@@ -262,6 +314,9 @@ data:
   app_version: "0.1.0+1478129987"
 ```
 
-> It is considered preferable to use `include` over `template` in Helm templates simply so that the output formatting can be handled better for YAML documents.
+> It is considered preferable to use `include` over `template` in Helm templates
+> simply so that the output formatting can be handled better for YAML documents.
 
-Sometimes we want to import content, but not as templates. That is, we want to import files verbatim. We can achieve this by accessing files through the `.Files` object described in the next section.
+Sometimes we want to import content, but not as templates. That is, we want to
+import files verbatim. We can achieve this by accessing files through the
+`.Files` object described in the next section.

--- a/content/docs/topics/chart_template_guide/notes_files.md
+++ b/content/docs/topics/chart_template_guide/notes_files.md
@@ -3,9 +3,14 @@ title: "Creating a NOTES.txt File"
 description: "How to provide instructions to your Chart users."
 ---
 
-In this section we are going to look at Helm's tool for providing instructions to your chart users. At the end of a `chart install` or `chart upgrade`, Helm can print out a block of helpful information for users. This information is highly customizable using templates.
+In this section we are going to look at Helm's tool for providing instructions
+to your chart users. At the end of a `chart install` or `chart upgrade`, Helm
+can print out a block of helpful information for users. This information is
+highly customizable using templates.
 
-To add installation notes to your chart, simply create a `templates/NOTES.txt` file. This file is plain text, but it is processed like as a template, and has all the normal template functions and objects available.
+To add installation notes to your chart, simply create a `templates/NOTES.txt`
+file. This file is plain text, but it is processed like as a template, and has
+all the normal template functions and objects available.
 
 Let's create a simple `NOTES.txt` file:
 
@@ -45,4 +50,6 @@ To learn more about the release, try:
   $ helm get rude-cardinal
 ```
 
-Using `NOTES.txt` this way is a great way to give your users detailed information about how to use their newly installed chart. Creating a `NOTES.txt` file is strongly recommended, though it is not required.
+Using `NOTES.txt` this way is a great way to give your users detailed
+information about how to use their newly installed chart. Creating a `NOTES.txt`
+file is strongly recommended, though it is not required.

--- a/content/docs/topics/chart_template_guide/subcharts_and_globals.md
+++ b/content/docs/topics/chart_template_guide/subcharts_and_globals.md
@@ -3,20 +3,27 @@ title: "Subcharts and Global Values"
 description: "Interacting with a subchart's and global values."
 ---
 
-To this point we have been working only with one chart. But charts can have dependencies, called _subcharts_, that also have their own values and templates. In this section we will create a subchart and see the different ways we can access values from within templates.
+To this point we have been working only with one chart. But charts can have
+dependencies, called _subcharts_, that also have their own values and templates.
+In this section we will create a subchart and see the different ways we can
+access values from within templates.
 
-Before we dive into the code, there are a few important details to learn about subcharts.
+Before we dive into the code, there are a few important details to learn about
+subcharts.
 
-1. A subchart is considered "stand-alone", which means a subchart can never explicitly depend on its parent chart.
+1. A subchart is considered "stand-alone", which means a subchart can never
+   explicitly depend on its parent chart.
 2. For that reason, a subchart cannot access the values of its parent.
 3. A parent chart can override values for subcharts.
 4. Helm has a concept of _global values_ that can be accessed by all charts.
 
-As we walk through the examples in this section, many of these concepts will become clearer.
+As we walk through the examples in this section, many of these concepts will
+become clearer.
 
 ## Creating a Subchart
 
-For these exercises, we'll start with the `mychart/` chart we created at the beginning of this guide, and we'll add a new chart inside of it.
+For these exercises, we'll start with the `mychart/` chart we created at the
+beginning of this guide, and we'll add a new chart inside of it.
 
 ```console
 $ cd mychart/charts
@@ -25,17 +32,23 @@ Creating mysubchart
 $ rm -rf mysubchart/templates/*.*
 ```
 
-Notice that just as before, we deleted all of the base templates so that we can start from scratch. In this guide, we are focused on how templates work, not on managing dependencies. But the [Charts Guide](../charts.md) has more information on how subcharts work.
+Notice that just as before, we deleted all of the base templates so that we can
+start from scratch. In this guide, we are focused on how templates work, not on
+managing dependencies. But the [Charts Guide](../charts.md) has more information
+on how subcharts work.
 
 ## Adding Values and a Template to the Subchart
 
-Next, let's create a simple template and values file for our `mysubchart` chart. There should already be a `values.yaml` in `mychart/charts/mysubchart`. We'll set it up like this:
+Next, let's create a simple template and values file for our `mysubchart` chart.
+There should already be a `values.yaml` in `mychart/charts/mysubchart`. We'll
+set it up like this:
 
 ```yaml
 dessert: cake
 ```
 
-Next, we'll create a new ConfigMap template in `mychart/charts/mysubchart/templates/configmap.yaml`:
+Next, we'll create a new ConfigMap template in
+`mychart/charts/mysubchart/templates/configmap.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -46,7 +59,8 @@ data:
   dessert: {{ .Values.dessert }}
 ```
 
-Because every subchart is a _stand-alone chart_, we can test `mysubchart` on its own:
+Because every subchart is a _stand-alone chart_, we can test `mysubchart` on its
+own:
 
 ```console
 $ helm install --dry-run --debug mychart/charts/mysubchart
@@ -68,9 +82,13 @@ data:
 
 ## Overriding Values from a Parent Chart
 
-Our original chart, `mychart` is now the _parent_ chart of `mysubchart`. This relationship is based entirely on the fact that `mysubchart` is within `mychart/charts`.
+Our original chart, `mychart` is now the _parent_ chart of `mysubchart`. This
+relationship is based entirely on the fact that `mysubchart` is within
+`mychart/charts`.
 
-Because `mychart` is a parent, we can specify configuration in `mychart` and have that configuration pushed into `mysubchart`. For example, we can modify `mychart/values.yaml` like this:
+Because `mychart` is a parent, we can specify configuration in `mychart` and
+have that configuration pushed into `mysubchart`. For example, we can modify
+`mychart/values.yaml` like this:
 
 ```yaml
 favorite:
@@ -86,7 +104,9 @@ mysubchart:
   dessert: ice cream
 ```
 
-Note the last two lines. Any directives inside of the `mysubchart` section will be sent to the `mysubchart` chart. So if we run `helm install --dry-run --debug mychart`, one of the things we will see is the `mysubchart` ConfigMap:
+Note the last two lines. Any directives inside of the `mysubchart` section will
+be sent to the `mysubchart` chart. So if we run `helm install --dry-run --debug
+mychart`, one of the things we will see is the `mysubchart` ConfigMap:
 
 ```yaml
 # Source: mychart/charts/mysubchart/templates/configmap.yaml
@@ -100,15 +120,24 @@ data:
 
 The value at the top level has now overridden the value of the subchart.
 
-There's an important detail to notice here. We didn't change the template of `mychart/charts/mysubchart/templates/configmap.yaml` to point to `.Values.mysubchart.dessert`. From that template's perspective, the value is still located at `.Values.dessert`. As the template engine passes values along, it sets the scope. So for the `mysubchart` templates, only values specifically for `mysubchart` will be available in `.Values`.
+There's an important detail to notice here. We didn't change the template of
+`mychart/charts/mysubchart/templates/configmap.yaml` to point to
+`.Values.mysubchart.dessert`. From that template's perspective, the value is
+still located at `.Values.dessert`. As the template engine passes values along,
+it sets the scope. So for the `mysubchart` templates, only values specifically
+for `mysubchart` will be available in `.Values`.
 
-Sometimes, though, you do want certain values to be available to all of the templates. This is accomplished using global chart values.
+Sometimes, though, you do want certain values to be available to all of the
+templates. This is accomplished using global chart values.
 
 ## Global Chart Values
 
-Global values are values that can be accessed from any chart or subchart by exactly the same name. Globals require explicit declaration. You can't use an existing non-global as if it were a global.
+Global values are values that can be accessed from any chart or subchart by
+exactly the same name. Globals require explicit declaration. You can't use an
+existing non-global as if it were a global.
 
-The Values data type has a reserved section called `Values.global` where global values can be set. Let's set one in our `mychart/values.yaml` file.
+The Values data type has a reserved section called `Values.global` where global
+values can be set. Let's set one in our `mychart/values.yaml` file.
 
 ```yaml
 favorite:
@@ -127,7 +156,9 @@ global:
   salad: caesar
 ```
 
-Because of the way globals work, both `mychart/templates/configmap.yaml` and `mysubchart/templates/configmap.yaml` should be able to access that value as `{{ .Values.global.salad }}`.
+Because of the way globals work, both `mychart/templates/configmap.yaml` and
+`mysubchart/templates/configmap.yaml` should be able to access that value as
+`{{ .Values.global.salad }}`.
 
 `mychart/templates/configmap.yaml`:
 
@@ -174,12 +205,13 @@ data:
   salad: caesar
 ```
 
-Globals are useful for passing information like this, though it does take some planning to make sure the right templates are configured to use globals.
+Globals are useful for passing information like this, though it does take some
+planning to make sure the right templates are configured to use globals.
 
 ## Sharing Templates with Subcharts
 
-Parent charts and subcharts can share templates. Any defined block in any chart is
-available to other charts.
+Parent charts and subcharts can share templates. Any defined block in any chart
+is available to other charts.
 
 For example, we can define a simple template like this:
 
@@ -187,11 +219,12 @@ For example, we can define a simple template like this:
 {{- define "labels" }}from: mychart{{ end }}
 ```
 
-Recall how the labels on templates are _globally shared_. Thus, the `labels` chart
-can be included from any other chart.
+Recall how the labels on templates are _globally shared_. Thus, the `labels`
+chart can be included from any other chart.
 
-While chart developers have a choice between `include` and `template`, one advantage
-of using `include` is that `include` can dynamically reference templates:
+While chart developers have a choice between `include` and `template`, one
+advantage of using `include` is that `include` can dynamically reference
+templates:
 
 ```yaml
 {{ include $mytemplate }}
@@ -202,9 +235,10 @@ will only accept a string literal.
 
 ## Avoid Using Blocks
 
-The Go template language provides a `block` keyword that allows developers to provide
-a default implementation which is overridden later. In Helm charts, blocks are not
-the best tool for overriding because it if multiple implementations of the same block
-are provided, the one selected is unpredictable.
+The Go template language provides a `block` keyword that allows developers to
+provide a default implementation which is overridden later. In Helm charts,
+blocks are not the best tool for overriding because it if multiple
+implementations of the same block are provided, the one selected is
+unpredictable.
 
 The suggestion is to instead use `include`.

--- a/content/docs/topics/chart_template_guide/values_files.md
+++ b/content/docs/topics/chart_template_guide/values_files.md
@@ -3,16 +3,24 @@ title: "Values Files"
 description: "Instructions on how to use the --values flag."
 ---
 
-In the previous section we looked at the built-in objects that Helm templates offer. One of the four built-in objects is `Values`. This object provides access to values passed into the chart. Its contents come from four sources:
+In the previous section we looked at the built-in objects that Helm templates
+offer. One of the four built-in objects is `Values`. This object provides access
+to values passed into the chart. Its contents come from four sources:
 
 - The `values.yaml` file in the chart
 - If this is a subchart, the `values.yaml` file of a parent chart
-- A values file if passed into `helm install` or `helm upgrade` with the `-f` flag (`helm install -f myvals.yaml ./mychart`)
-- Individual parameters passed with `--set` (such as `helm install --set foo=bar ./mychart`)
+- A values file if passed into `helm install` or `helm upgrade` with the `-f`
+  flag (`helm install -f myvals.yaml ./mychart`)
+- Individual parameters passed with `--set` (such as `helm install --set foo=bar
+  ./mychart`)
 
-The list above is in order of specificity: `values.yaml` is the default, which can be overridden by a parent chart's `values.yaml`, which can in turn be overridden by a user-supplied values file, which can in turn be overridden by `--set` parameters.
+The list above is in order of specificity: `values.yaml` is the default, which
+can be overridden by a parent chart's `values.yaml`, which can in turn be
+overridden by a user-supplied values file, which can in turn be overridden by
+`--set` parameters.
 
-Values files are plain YAML files. Let's edit `mychart/values.yaml` and then edit our ConfigMap template.
+Values files are plain YAML files. Let's edit `mychart/values.yaml` and then
+edit our ConfigMap template.
 
 Removing the defaults in `values.yaml`, we'll set just one parameter:
 
@@ -32,7 +40,8 @@ data:
   drink: {{ .Values.favoriteDrink }}
 ```
 
-Notice on the last line we access `favoriteDrink` as an attribute of `Values`: `{{ .Values.favoriteDrink }}`.
+Notice on the last line we access `favoriteDrink` as an attribute of `Values`:
+`{{ .Values.favoriteDrink }}`.
 
 Let's see how this renders.
 
@@ -55,7 +64,9 @@ data:
   drink: coffee
 ```
 
-Because `favoriteDrink` is set in the default `values.yaml` file to `coffee`, that's the value displayed in the template. We can easily override that by adding a `--set` flag in our call to `helm install`:
+Because `favoriteDrink` is set in the default `values.yaml` file to `coffee`,
+that's the value displayed in the template. We can easily override that by
+adding a `--set` flag in our call to `helm install`:
 
 ```console
 helm install --dry-run --debug --set favoriteDrink=slurm ./mychart
@@ -76,9 +87,12 @@ data:
   drink: slurm
 ```
 
-Since `--set` has a higher precedence than the default `values.yaml` file, our template generates `drink: slurm`.
+Since `--set` has a higher precedence than the default `values.yaml` file, our
+template generates `drink: slurm`.
 
-Values files can contain more structured content, too. For example, we could create a `favorite` section in our `values.yaml` file, and then add several keys there:
+Values files can contain more structured content, too. For example, we could
+create a `favorite` section in our `values.yaml` file, and then add several keys
+there:
 
 ```yaml
 favorite:
@@ -99,13 +113,18 @@ data:
   food: {{ .Values.favorite.food }}
 ```
 
-While structuring data this way is possible, the recommendation is that you keep your values trees shallow, favoring flatness. When we look at assigning values to subcharts, we'll see how values are named using a tree structure.
+While structuring data this way is possible, the recommendation is that you keep
+your values trees shallow, favoring flatness. When we look at assigning values
+to subcharts, we'll see how values are named using a tree structure.
 
 ## Deleting a default key
 
-If you need to delete a key from the default values, you may override the value of the key to be `null`, in which case Helm will remove the key from the overridden values merge.
+If you need to delete a key from the default values, you may override the value
+of the key to be `null`, in which case Helm will remove the key from the
+overridden values merge.
 
-For example, the stable Drupal chart allows configuring the liveness probe, in case you configure a custom image. Here are the default values:
+For example, the stable Drupal chart allows configuring the liveness probe, in
+case you configure a custom image. Here are the default values:
 ```yaml
 livenessProbe:
   httpGet:
@@ -114,7 +133,10 @@ livenessProbe:
   initialDelaySeconds: 120
 ```
 
-If you try to override the livenessProbe handler to `exec` instead of `httpGet` using `--set livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt]`, Helm will coalesce the default and overridden keys together, resulting in the following YAML:
+If you try to override the livenessProbe handler to `exec` instead of `httpGet`
+using `--set livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt]`, Helm will
+coalesce the default and overridden keys together, resulting in the following
+YAML:
 ```yaml
 livenessProbe:
   httpGet:
@@ -127,9 +149,13 @@ livenessProbe:
   initialDelaySeconds: 120
 ```
 
-However, Kubernetes would then fail because you can not declare more than one livenessProbe handler. To overcome this, you may instruct Helm to delete the `livenessProbe.httpGet` by setting it to null:
+However, Kubernetes would then fail because you can not declare more than one
+livenessProbe handler. To overcome this, you may instruct Helm to delete the
+`livenessProbe.httpGet` by setting it to null:
 ```sh
 helm install stable/drupal --set image=my-registry/drupal:0.1.0 --set livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt] --set livenessProbe.httpGet=null
 ```
 
-At this point, we've seen several built-in objects, and used them to inject information into a template. Now we will take a look at another aspect of the template engine: functions and pipelines.
+At this point, we've seen several built-in objects, and used them to inject
+information into a template. Now we will take a look at another aspect of the
+template engine: functions and pipelines.

--- a/content/docs/topics/chart_template_guide/variables.md
+++ b/content/docs/topics/chart_template_guide/variables.md
@@ -3,7 +3,10 @@ title: "Variables"
 description: "Using variables in templates."
 ---
 
-With functions, pipelines, objects, and control structures under our belts, we can turn to one of the more basic ideas in many programming languages: variables. In templates, they are less frequently used. But we will see how to use them to simplify code, and to make better use of `with` and `range`.
+With functions, pipelines, objects, and control structures under our belts, we
+can turn to one of the more basic ideas in many programming languages:
+variables. In templates, they are less frequently used. But we will see how to
+use them to simplify code, and to make better use of `with` and `range`.
 
 In an earlier example, we saw that this code will fail:
 
@@ -15,9 +18,13 @@ In an earlier example, we saw that this code will fail:
   {{- end }}
 ```
 
-`Release.Name` is not inside of the scope that's restricted in the `with` block. One way to work around scoping issues is to assign objects to variables that can be accessed without respect to the present scope.
+`Release.Name` is not inside of the scope that's restricted in the `with` block.
+One way to work around scoping issues is to assign objects to variables that can
+be accessed without respect to the present scope.
 
-In Helm templates, a variable is a named reference to another object. It follows the form `$name`. Variables are assigned with a special assignment operator: `:=`. We can rewrite the above to use a variable for `Release.Name`.
+In Helm templates, a variable is a named reference to another object. It follows
+the form `$name`. Variables are assigned with a special assignment operator:
+`:=`. We can rewrite the above to use a variable for `Release.Name`.
 
 ```yaml
 apiVersion: v1
@@ -34,7 +41,9 @@ data:
   {{- end }}
 ```
 
-Notice that before we start the `with` block, we assign `$relname := .Release.Name`. Now inside of the `with` block, the `$relname` variable still points to the release name.
+Notice that before we start the `with` block, we assign `$relname :=
+.Release.Name`. Now inside of the `with` block, the `$relname` variable still
+points to the release name.
 
 Running that will produce this:
 
@@ -51,7 +60,8 @@ data:
   release: viable-badger
 ```
 
-Variables are particularly useful in `range` loops. They can be used on list-like objects to capture both the index and the value:
+Variables are particularly useful in `range` loops. They can be used on
+list-like objects to capture both the index and the value:
 
 ```yaml
   toppings: |-
@@ -61,7 +71,9 @@ Variables are particularly useful in `range` loops. They can be used on list-lik
 
 ```
 
-Note that `range` comes first, then the variables, then the assignment operator, then the list. This will assign the integer index (starting from zero) to `$index` and the value to `$topping`. Running it will produce:
+Note that `range` comes first, then the variables, then the assignment operator,
+then the list. This will assign the integer index (starting from zero) to
+`$index` and the value to `$topping`. Running it will produce:
 
 ```yaml
   toppings: |-
@@ -71,7 +83,8 @@ Note that `range` comes first, then the variables, then the assignment operator,
       3: onions
 ```
 
-For data structures that have both a key and a value, we can use `range` to get both. For example, we can loop through `.Values.favorite` like this:
+For data structures that have both a key and a value, we can use `range` to get
+both. For example, we can loop through `.Values.favorite` like this:
 
 ```yaml
 apiVersion: v1
@@ -85,7 +98,9 @@ data:
   {{- end }}
 ```
 
-Now on the first iteration, `$key` will be `drink` and `$val` will be `coffee`, and on the second, `$key` will be `food` and `$val` will be `pizza`. Running the above will generate this:
+Now on the first iteration, `$key` will be `drink` and `$val` will be `coffee`,
+and on the second, `$key` will be `food` and `$val` will be `pizza`. Running the
+above will generate this:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -99,12 +114,15 @@ data:
   food: "pizza"
 ```
 
-Variables are normally not "global". They are scoped to the block in which they are declared. Earlier, we assigned `$relname` in the top level of the template. That variable will be in scope for the entire template. But in our last example, `$key` and `$val` will only be in scope inside of the `{{ range... }}{{ end }}` block.
+Variables are normally not "global". They are scoped to the block in which they
+are declared. Earlier, we assigned `$relname` in the top level of the template.
+That variable will be in scope for the entire template. But in our last example,
+`$key` and `$val` will only be in scope inside of the `{{ range... }}{{ end }}`
+block.
 
-However, there is one variable that is always global - `$` - this
-variable will always point to the root context.  This can be very
-useful when you are looping in a range need to know the chart's release
-name.
+However, there is one variable that is always global - `$` - this variable will
+always point to the root context.  This can be very useful when you are looping
+in a range need to know the chart's release name.
 
 An example illustrating this:
 ```yaml
@@ -131,4 +149,7 @@ data:
 {{- end }}
 ```
 
-So far we have looked at just one template declared in just one file. But one of the powerful features of the Helm template language is its ability to declare multiple templates and use them together. We'll turn to that in the next section.
+So far we have looked at just one template declared in just one file. But one of
+the powerful features of the Helm template language is its ability to declare
+multiple templates and use them together. We'll turn to that in the next
+section.

--- a/content/docs/topics/chart_template_guide/yaml_techniques.md
+++ b/content/docs/topics/chart_template_guide/yaml_techniques.md
@@ -5,8 +5,8 @@ description: "A closer look at the YAML specification and how it applies to Helm
 
 Most of this guide has been focused on writing the template language. Here,
 we'll look at the YAML format. YAML has some useful features that we, as
-template authors, can use to make our templates less error prone and easier
-to read.
+template authors, can use to make our templates less error prone and easier to
+read.
 
 ## Scalars and Collections
 
@@ -35,8 +35,8 @@ In Helm's dialect of YAML, the scalar data type of a value is determined by a
 complex set of rules, including the Kubernetes schema for resource definitions.
 But when inferring types, the following rules tend to hold true.
 
-If an integer or float is an unquoted bare word, it is typically treated as
-a numeric type:
+If an integer or float is an unquoted bare word, it is typically treated as a
+numeric type:
 
 ```yaml
 count: 1
@@ -59,9 +59,9 @@ answer: "true" # string
 
 The word for an empty value is `null` (not `nil`).
 
-Note that `port: "80"` is valid YAML, and will pass through both the
-template engine and the YAML parser, but will fail if Kubernetes expects
-`port` to be an integer.
+Note that `port: "80"` is valid YAML, and will pass through both the template
+engine and the YAML parser, but will fail if Kubernetes expects `port` to be an
+integer.
 
 In some cases, you can force a particular type inference using YAML node tags:
 
@@ -91,13 +91,13 @@ way3: 'single-quoted strings'
 
 All inline styles must be on one line.
 
-- Bare words are unquoted, and are not escaped. For this reason, you have to
-  be careful what characters you use.
+- Bare words are unquoted, and are not escaped. For this reason, you have to be
+  careful what characters you use.
 - Double-quoted strings can have specific characters escaped with `\`. For
   example `"\"Hello\", she said"`. You can escape line breaks with `\n`.
-- Single-quoted strings are "literal" strings, and do not use the `\` to
-  escape characters. The only escape sequence is `''`, which is decoded as
-  a single `'`.
+- Single-quoted strings are "literal" strings, and do not use the `\` to escape
+  characters. The only escape sequence is `''`, which is decoded as a single
+  `'`.
 
 In addition to the one-line strings, you can declare multi-line strings:
 
@@ -141,15 +141,15 @@ coffee: |
 ```
 
 Note that whatever that first line is, it will be preserved in the output of the
-string. So if you are, for example, using this technique to inject a file's contents
-into a ConfigMap, the comment should be of the type expected by whatever is
-reading that entry.
+string. So if you are, for example, using this technique to inject a file's
+contents into a ConfigMap, the comment should be of the type expected by
+whatever is reading that entry.
 
 ### Controlling Spaces in Multi-line Strings
 
 In the example above, we used `|` to indicate a multi-line string. But notice
-that the content of our string was followed with a trailing `\n`. If we want
-the YAML processor to strip off the trailing newline, we can add a `-` after the
+that the content of our string was followed with a trailing `\n`. If we want the
+YAML processor to strip off the trailing newline, we can add a `-` after the
 `|`:
 
 ```yaml
@@ -189,21 +189,22 @@ coffee: |-
   Espresso
 ```
 
-In the above case, `coffee` will be `Latte\n  12 oz\n  16 oz\nCappuccino\nEspresso`.
+In the above case, `coffee` will be `Latte\n  12 oz\n  16
+oz\nCappuccino\nEspresso`.
 
 ### Indenting and Templates
 
 When writing templates, you may find yourself wanting to inject the contents of
-a file into the template. As we saw in previous chapters, there are two ways
-of doing this:
+a file into the template. As we saw in previous chapters, there are two ways of
+doing this:
 
 - Use `{{ .Files.Get "FILENAME" }}` to get the contents of a file in the chart.
 - Use `{{ include "TEMPLATE" . }}` to render a template and then place its
   contents into the chart.
 
-When inserting files into YAML, it's good to understand the multi-line rules above.
-Often times, the easiest way to insert a static file is to do something like
-this:
+When inserting files into YAML, it's good to understand the multi-line rules
+above. Often times, the easiest way to insert a static file is to do something
+like this:
 
 ```yaml
 myfile: |
@@ -231,8 +232,9 @@ coffee: >
 ```
 
 The value of `coffee` above will be `Latte Cappuccino Espresso\n`. Note that all
-but the last line feed will be converted to spaces. You can combine the whitespace
-controls with the folded text marker, so `>-` will replace or trim all newlines.
+but the last line feed will be converted to spaces. You can combine the
+whitespace controls with the folded text marker, so `>-` will replace or trim
+all newlines.
 
 Note that in the folded syntax, indenting text will cause lines to be preserved.
 
@@ -250,8 +252,8 @@ both the spacing and the newlines are still there.
 
 ## Embedding Multiple Documents in One File
 
-It is possible to place more than one YAML documents into a single file. This
-is done by prefixing a new document with `---` and ending the document with
+It is possible to place more than one YAML documents into a single file. This is
+done by prefixing a new document with `---` and ending the document with
 `...`
 
 ```yaml
@@ -266,14 +268,14 @@ document: 2
 
 In many cases, either the `---` or the `...` may be omitted.
 
-Some files in Helm cannot contain more than one doc. If, for example, more
-than one document is provided inside of a `values.yaml` file, only the first
-will be used.
+Some files in Helm cannot contain more than one doc. If, for example, more than
+one document is provided inside of a `values.yaml` file, only the first will be
+used.
 
-Template files, however, may have more than one document. When this happens,
-the file (and all of its documents) is treated as one object during
-template rendering. But then the resulting YAML is split into multiple
-documents before it is fed to Kubernetes.
+Template files, however, may have more than one document. When this happens, the
+file (and all of its documents) is treated as one object during template
+rendering. But then the resulting YAML is split into multiple documents before
+it is fed to Kubernetes.
 
 We recommend only using multiple documents per file when it is absolutely
 necessary. Having multiple documents in a file can be difficult to debug.
@@ -316,8 +318,8 @@ does not treat the file extension `.json` as a valid suffix.
 
 ## YAML Anchors
 
-The YAML spec provides a way to store a reference to a value, and later
-refer to that value by reference. YAML refers to this as "anchoring":
+The YAML spec provides a way to store a reference to a value, and later refer to
+that value by reference. YAML refers to this as "anchoring":
 
 ```yaml
 coffee: "yes, please"
@@ -329,15 +331,15 @@ coffees:
 ```
 
 In the above, `&favoriteCoffee` sets a reference to `Cappuccino`. Later, that
-reference is used as `*favoriteCoffee`. So `coffees` becomes
-`Latte, Cappuccino, Espresso`.
+reference is used as `*favoriteCoffee`. So `coffees` becomes `Latte, Cappuccino,
+Espresso`.
 
 While there are a few cases where anchors are useful, there is one aspect of
 them that can cause subtle bugs: The first time the YAML is consumed, the
 reference is expanded and then discarded.
 
-So if we were to decode and then re-encode the example above, the resulting
-YAML would be:
+So if we were to decode and then re-encode the example above, the resulting YAML
+would be:
 
 ```yaml
 coffee: yes, please
@@ -348,5 +350,5 @@ coffees:
 - Espresso
 ```
 
-Because Helm and Kubernetes often read, modify, and then rewrite YAML files,
-the anchors will be lost.
+Because Helm and Kubernetes often read, modify, and then rewrite YAML files, the
+anchors will be lost.

--- a/content/docs/topics/chart_tests.md
+++ b/content/docs/topics/chart_tests.md
@@ -3,25 +3,37 @@ title: "Chart Tests"
 description: "Describes how to run and test your charts."
 ---
 
-A chart contains a number of Kubernetes resources and components that work together. As a chart author, you may want to write some tests that validate that your chart works as expected when it is installed. These tests also help the chart consumer understand what your chart is supposed to do.
+A chart contains a number of Kubernetes resources and components that work
+together. As a chart author, you may want to write some tests that validate that
+your chart works as expected when it is installed. These tests also help the
+chart consumer understand what your chart is supposed to do.
 
-A **test** in a helm chart lives under the `templates/` directory and is a pod definition that specifies a container with a given command to run. The container should exit successfully (exit 0) for a test to be considered a success. The pod definition must contain one of the helm test hook annotations: `helm.sh/hook: test-success` or `helm.sh/hook: test-failure`.
+A **test** in a helm chart lives under the `templates/` directory and is a pod
+definition that specifies a container with a given command to run. The container
+should exit successfully (exit 0) for a test to be considered a success. The pod
+definition must contain one of the helm test hook annotations: `helm.sh/hook:
+test-success` or `helm.sh/hook: test-failure`.
 
 Example tests:
-- Validate that your configuration from the values.yaml file was properly injected.
+- Validate that your configuration from the values.yaml file was properly
+  injected.
   - Make sure your username and password work correctly
   - Make sure an incorrect username and password does not work
 - Assert that your services are up and correctly load balancing
 - etc.
 
-You can run the pre-defined tests in Helm on a release using the command `helm test <RELEASE_NAME>`. For a chart consumer, this is a great way to sanity check that their release of a chart (or application) works as expected.
+You can run the pre-defined tests in Helm on a release using the command `helm
+test <RELEASE_NAME>`. For a chart consumer, this is a great way to sanity check
+that their release of a chart (or application) works as expected.
 
 ## A Breakdown of the Helm Test Hooks
 
 In Helm, there are two test hooks: `test-success` and `test-failure`
 
-`test-success` indicates that test pod should complete successfully. In other words, the containers in the pod should exit 0.
-`test-failure` is a way to assert that a test pod should not complete successfully. If the containers in the pod do not exit 0, that indicates success.
+`test-success` indicates that test pod should complete successfully. In other
+words, the containers in the pod should exit 0. `test-failure` is a way to
+assert that a test pod should not complete successfully. If the containers in
+the pod do not exit 0, that indicates success.
 
 ## Example Test
 
@@ -82,5 +94,7 @@ SUCCESS: quirky-walrus-credentials-test
 ```
 
 ## Notes
-- You can define as many tests as you would like in a single yaml file or spread across several yaml files in the `templates/` directory
-- You are welcome to nest your test suite under a `tests/` directory like `<chart-name>/templates/tests/` for more isolation
+- You can define as many tests as you would like in a single yaml file or spread
+  across several yaml files in the `templates/` directory
+- You are welcome to nest your test suite under a `tests/` directory like
+  `<chart-name>/templates/tests/` for more isolation

--- a/content/docs/topics/charts.md
+++ b/content/docs/topics/charts.md
@@ -4,13 +4,12 @@ description: "Explains the chart format, and provides basic guidance for buildin
 ---
 
 Helm uses a packaging format called _charts_. A chart is a collection of files
-that describe a related set of Kubernetes resources. A single chart
-might be used to deploy something simple, like a memcached pod, or
-something complex, like a full web app stack with HTTP servers,
-databases, caches, and so on.
+that describe a related set of Kubernetes resources. A single chart might be
+used to deploy something simple, like a memcached pod, or something complex,
+like a full web app stack with HTTP servers, databases, caches, and so on.
 
-Charts are created as files laid out in a particular directory tree,
-then they can be packaged into versioned archives to be deployed.
+Charts are created as files laid out in a particular directory tree, then they
+can be packaged into versioned archives to be deployed.
 
 This document explains the chart format, and provides basic guidance for
 building charts with Helm.
@@ -37,8 +36,8 @@ wordpress/
   templates/NOTES.txt # OPTIONAL: A plain text file containing short usage notes
 ```
 
-Helm reserves use of the `charts/`, `crds/`, and `templates/` directories, and of
-the listed file names. Other files will be left as they are.
+Helm reserves use of the `charts/`, `crds/`, and `templates/` directories, and
+of the listed file names. Other files will be left as they are.
 
 ## The Chart.yaml File
 
@@ -72,38 +71,38 @@ Other fields will be silently ignored.
 
 ### Charts and Versioning
 
-Every chart must have a version number. A version must follow the
-[SemVer 2](http://semver.org/) standard. Unlike Helm Classic, Kubernetes
-Helm uses version numbers as release markers. Packages in repositories
-are identified by name plus version.
+Every chart must have a version number. A version must follow the [SemVer
+2](http://semver.org/) standard. Unlike Helm Classic, Kubernetes Helm uses
+version numbers as release markers. Packages in repositories are identified by
+name plus version.
 
-For example, an `nginx` chart whose version field is set to `version:
-1.2.3` will be named:
+For example, an `nginx` chart whose version field is set to `version: 1.2.3`
+will be named:
 
 ```
 nginx-1.2.3.tgz
 ```
 
-More complex SemVer 2 names are also supported, such as
-`version: 1.2.3-alpha.1+ef365`. But non-SemVer names are explicitly
-disallowed by the system.
+More complex SemVer 2 names are also supported, such as `version:
+1.2.3-alpha.1+ef365`. But non-SemVer names are explicitly disallowed by the
+system.
 
-**NOTE:** Whereas Helm Classic and Deployment Manager were both
-very GitHub oriented when it came to charts, Kubernetes Helm does not
-rely upon or require GitHub or even Git. Consequently, it does not use
-Git SHAs for versioning at all.
+**NOTE:** Whereas Helm Classic and Deployment Manager were both very GitHub
+oriented when it came to charts, Kubernetes Helm does not rely upon or require
+GitHub or even Git. Consequently, it does not use Git SHAs for versioning at
+all.
 
-The `version` field inside of the `Chart.yaml` is used by many of the
-Helm tools, including the CLI. When generating a
-package, the `helm package` command will use the version that it finds
-in the `Chart.yaml` as a token in the package name. The system assumes
-that the version number in the chart package name matches the version number in
-the `Chart.yaml`. Failure to meet this assumption will cause an error.
+The `version` field inside of the `Chart.yaml` is used by many of the Helm
+tools, including the CLI. When generating a package, the `helm package` command
+will use the version that it finds in the `Chart.yaml` as a token in the package
+name. The system assumes that the version number in the chart package name
+matches the version number in the `Chart.yaml`. Failure to meet this assumption
+will cause an error.
 
 ### The appVersion field
 
-Note that the `appVersion` field is not related to the `version` field. It is
-a way of specifying the version of the application. For example, the `drupal`
+Note that the `appVersion` field is not related to the `version` field. It is a
+way of specifying the version of the application. For example, the `drupal`
 chart may have an `appVersion: 8.2.1`, indicating that the version of Drupal
 included in the chart (by default) is `8.2.1`. This field is informational, and
 has no impact on chart version calculations.
@@ -116,59 +115,66 @@ to mark a chart as deprecated. If the **latest** version of a chart in the
 repository is marked as deprecated, then the chart as a whole is considered to
 be deprecated. The chart name can later be reused by publishing a newer version
 that is not marked as deprecated. The workflow for deprecating charts, as
-followed by the [kubernetes/charts](https://github.com/helm/charts)
-project is:
+followed by the [kubernetes/charts](https://github.com/helm/charts) project is:
   - Update chart's `Chart.yaml` to mark the chart as deprecated, bumping the
-  version
+    version
   - Release the new chart version in the Chart Repository
   - Remove the chart from the source repository (e.g. git)
 
 ### Chart Types
 
-The `type` field defines the type of chart. There are 2 types: `application`
-and `library`.  Application is the default type and it is the standard chart
-which can be operated on fully. The [library or helper chart](https://github.com/helm/charts/tree/master/incubator/common)
-provides utilities or functions for the chart builder. A library chart differs
-from an application chart because it has no resource object and is therefore not
+The `type` field defines the type of chart. There are 2 types: `application` and
+`library`.  Application is the default type and it is the standard chart which
+can be operated on fully. The [library or helper
+chart](https://github.com/helm/charts/tree/master/incubator/common) provides
+utilities or functions for the chart builder. A library chart differs from an
+application chart because it has no resource object and is therefore not
 installable.
 
-**Note:** An application chart can be used as a library chart. This is enabled by setting the
-type to `library`. The chart will then be rendered as a library chart where all utilities and
-functions can be leveraged. All resource objects of the chart will not be rendered.
+**Note:** An application chart can be used as a library chart. This is enabled
+by setting the type to `library`. The chart will then be rendered as a library
+chart where all utilities and functions can be leveraged. All resource objects
+of the chart will not be rendered.
 
 ## Chart LICENSE, README and NOTES
 
-Charts can also contain files that describe the installation, configuration, usage and license of a
-chart.
+Charts can also contain files that describe the installation, configuration,
+usage and license of a chart.
 
-A LICENSE is a plain text file containing the [license](https://en.wikipedia.org/wiki/Software_license)
-for the chart. The chart can contain a license as it may have programming logic in the templates and
-would therefore not be configuration only. There can also be separate license(s) for the application
-installed by the chart, if required.
+A LICENSE is a plain text file containing the
+[license](https://en.wikipedia.org/wiki/Software_license) for the chart. The
+chart can contain a license as it may have programming logic in the templates
+and would therefore not be configuration only. There can also be separate
+license(s) for the application installed by the chart, if required.
 
-A README for a chart should be formatted in Markdown (README.md), and should generally contain:
+A README for a chart should be formatted in Markdown (README.md), and should
+generally contain:
 
 - A description of the application or service the chart provides
 - Any prerequisites or requirements to run the chart
 - Descriptions of options in `values.yaml` and default values
-- Any other information that may be relevant to the installation or configuration of the chart
+- Any other information that may be relevant to the installation or
+  configuration of the chart
 
-The chart can also contain a short plain text `templates/NOTES.txt` file that will be printed out
-after installation, and when viewing the status of a release. This file is evaluated as a
-[template](#templates-and-values), and can be used to display usage notes, next steps, or any other
-information relevant to a release of the chart. For example, instructions could be provided for
-connecting to a database, or accessing a web UI. Since this file is printed to STDOUT when running
-`helm install` or `helm status`, it is recommended to keep the content brief and point to the README
-for greater detail.
+The chart can also contain a short plain text `templates/NOTES.txt` file that
+will be printed out after installation, and when viewing the status of a
+release. This file is evaluated as a [template](#templates-and-values), and can
+be used to display usage notes, next steps, or any other information relevant to
+a release of the chart. For example, instructions could be provided for
+connecting to a database, or accessing a web UI. Since this file is printed to
+STDOUT when running `helm install` or `helm status`, it is recommended to keep
+the content brief and point to the README for greater detail.
 
 ## Chart Dependencies
 
-In Helm, one chart may depend on any number of other charts.
-These dependencies can be dynamically linked using the `dependencies` field in `Chart.yaml` or brought in to the `charts/` directory and managed manually.
+In Helm, one chart may depend on any number of other charts. These dependencies
+can be dynamically linked using the `dependencies` field in `Chart.yaml` or
+brought in to the `charts/` directory and managed manually.
 
 ### Managing Dependencies with the `dependencies` field
 
-The charts required by the current chart are defined as a list in the `dependencies` field.
+The charts required by the current chart are defined as a list in the
+`dependencies` field.
 
 ```yaml
 dependencies:
@@ -182,12 +188,12 @@ dependencies:
 
 - The `name` field is the name of the chart you want.
 - The `version` field is the version of the chart you want.
-- The `repository` field is the full URL to the chart repository. Note
-  that you must also use `helm repo add` to add that repo locally.
+- The `repository` field is the full URL to the chart repository. Note that you
+  must also use `helm repo add` to add that repo locally.
 
-Once you have defined dependencies, you can run `helm dependency update`
-and it will use your dependency file to download all the specified
-charts into your `charts/` directory for you.
+Once you have defined dependencies, you can run `helm dependency update` and it
+will use your dependency file to download all the specified charts into your
+`charts/` directory for you.
 
 ```console
 $ helm dep up foochart
@@ -202,9 +208,9 @@ Downloading apache from repo http://example.com/charts
 Downloading mysql from repo http://another.example.com/charts
 ```
 
-When `helm dependency update` retrieves charts, it will store them as
-chart archives in the `charts/` directory. So for the example above, one
-would expect to see the following files in the charts directory:
+When `helm dependency update` retrieves charts, it will store them as chart
+archives in the `charts/` directory. So for the example above, one would expect
+to see the following files in the charts directory:
 
 ```
 charts/
@@ -214,14 +220,14 @@ charts/
 
 #### Alias field in dependencies
 
-In addition to the other fields above, each requirements entry may contain
-the optional field `alias`.
+In addition to the other fields above, each requirements entry may contain the
+optional field `alias`.
 
-Adding an alias for a dependency chart would put
-a chart in dependencies using alias as name of new dependency.
+Adding an alias for a dependency chart would put a chart in dependencies using
+alias as name of new dependency.
 
-One can use `alias` in cases where they need to access a chart
-with other name(s).
+One can use `alias` in cases where they need to access a chart with other
+name(s).
 
 ```yaml
 # parentchart/Chart.yaml
@@ -251,19 +257,21 @@ The manual way of achieving this is by copy/pasting the same chart in the
 
 #### Tags and Condition fields in dependencies
 
-In addition to the other fields above, each requirements entry may contain
-the optional fields `tags` and `condition`.
+In addition to the other fields above, each requirements entry may contain the
+optional fields `tags` and `condition`.
 
 All charts are loaded by default. If `tags` or `condition` fields are present,
-they will be evaluated and used to control loading for the chart(s) they are applied to.
+they will be evaluated and used to control loading for the chart(s) they are
+applied to.
 
-Condition - The condition field holds one or more YAML paths (delimited by commas).
-If this path exists in the top parent's values and resolves to a boolean value,
-the chart will be enabled or disabled based on that boolean value.  Only the first
-valid path found in the list is evaluated and if no paths exist then the condition has no effect.
+Condition - The condition field holds one or more YAML paths (delimited by
+commas). If this path exists in the top parent's values and resolves to a
+boolean value, the chart will be enabled or disabled based on that boolean
+value.  Only the first valid path found in the list is evaluated and if no paths
+exist then the condition has no effect.
 
-Tags - The tags field is a YAML list of labels to associate with this chart.
-In the top parent's values, all charts with tags can be enabled or disabled by
+Tags - The tags field is a YAML list of labels to associate with this chart. In
+the top parent's values, all charts with tags can be enabled or disabled by
 specifying the tag and a boolean value.
 
 ```yaml
@@ -296,13 +304,14 @@ tags:
   back-end: true
 ```
 
-In the above example all charts with the tag `front-end` would be disabled but since the
-`subchart1.enabled` path evaluates to 'true' in the parent's values, the condition will override the
-`front-end` tag and `subchart1` will be enabled.
+In the above example all charts with the tag `front-end` would be disabled but
+since the `subchart1.enabled` path evaluates to 'true' in the parent's values,
+the condition will override the `front-end` tag and `subchart1` will be enabled.
 
-Since `subchart2` is tagged with `back-end` and that tag evaluates to `true`, `subchart2` will be
-enabled. Also notes that although `subchart2` has a condition specified, there
-is no corresponding path and value in the parent's values so that condition has no effect.
+Since `subchart2` is tagged with `back-end` and that tag evaluates to `true`,
+`subchart2` will be enabled. Also notes that although `subchart2` has a
+condition specified, there is no corresponding path and value in the parent's
+values so that condition has no effect.
 
 ##### Using the CLI with Tags and Conditions
 
@@ -316,29 +325,35 @@ helm install --set tags.front-end=true --set subchart2.enabled=false
 ##### Tags and Condition Resolution
 
 
-  * **Conditions (when set in values) always override tags.** The first condition
-    path that exists wins and subsequent ones for that chart are ignored.
-  * Tags are evaluated as 'if any of the chart's tags are true then enable the chart'.
+  * **Conditions (when set in values) always override tags.** The first
+    condition path that exists wins and subsequent ones for that chart are
+    ignored.
+  * Tags are evaluated as 'if any of the chart's tags are true then enable the
+    chart'.
   * Tags and conditions values must be set in the top parent's values.
-  * The `tags:` key in values must be a top level key. Globals and nested `tags:` tables
-    are not currently supported.
+  * The `tags:` key in values must be a top level key. Globals and nested
+    `tags:` tables are not currently supported.
 
 #### Importing Child Values via dependencies
 
-In some cases it is desirable to allow a child chart's values to propagate to the parent chart and be
-shared as common defaults. An additional benefit of using the `exports` format is that it will enable future
-tooling to introspect user-settable values.
+In some cases it is desirable to allow a child chart's values to propagate to
+the parent chart and be shared as common defaults. An additional benefit of
+using the `exports` format is that it will enable future tooling to introspect
+user-settable values.
 
-The keys containing the values to be imported can be specified in the parent chart's `dependencies` in the field `input-values`
-using a YAML list. Each item in the list is a key which is imported from the child chart's `exports` field.
+The keys containing the values to be imported can be specified in the parent
+chart's `dependencies` in the field `input-values` using a YAML list. Each item
+in the list is a key which is imported from the child chart's `exports` field.
 
-To import values not contained in the `exports` key, use the [child-parent](#using-the-child-parent-format) format.
-Examples of both formats are described below.
+To import values not contained in the `exports` key, use the
+[child-parent](#using-the-child-parent-format) format. Examples of both formats
+are described below.
 
 ##### Using the exports format
 
-If a child chart's `values.yaml` file contains an `exports` field at the root, its contents may be imported
-directly into the parent's values by specifying the keys to import as in the example below:
+If a child chart's `values.yaml` file contains an `exports` field at the root,
+its contents may be imported directly into the parent's values by specifying the
+keys to import as in the example below:
 
 ```yaml
 # parent's Chart.yaml file
@@ -358,8 +373,8 @@ exports:
     myint: 99
 ```
 
-Since we are specifying the key `data` in our import list, Helm looks in the `exports` field of the child
-chart for `data` key and imports its contents.
+Since we are specifying the key `data` in our import list, Helm looks in the
+`exports` field of the child chart for `data` key and imports its contents.
 
 The final parent values would contain our exported field:
 
@@ -370,17 +385,19 @@ myint: 99
 
 ```
 
-Please note the parent key `data` is not contained in the parent's final values. If you need to specify the
-parent key, use the 'child-parent' format.
+Please note the parent key `data` is not contained in the parent's final values.
+If you need to specify the parent key, use the 'child-parent' format.
 
 ##### Using the child-parent format
 
-To access values that are not contained in the `exports` key of the child chart's values, you will need to
-specify the source key of the values to be imported (`child`) and the destination path in the parent chart's
-values (`parent`).
+To access values that are not contained in the `exports` key of the child
+chart's values, you will need to specify the source key of the values to be
+imported (`child`) and the destination path in the parent chart's values
+(`parent`).
 
-The `import-values` in the example below instructs Helm to take any values found at `child:` path and copy them
-to the parent's values at the path specified in `parent:`
+The `import-values` in the example below instructs Helm to take any values found
+at `child:` path and copy them to the parent's values at the path specified in
+`parent:`
 
 ```yaml
 # parent's Chart.yaml file
@@ -393,8 +410,9 @@ dependencies:
       - child: default.data
         parent: myimports
 ```
-In the above example, values found at `default.data` in the subchart1's values will be imported
-to the `myimports` key in the parent chart's values as detailed below:
+In the above example, values found at `default.data` in the subchart1's values
+will be imported to the `myimports` key in the parent chart's values as detailed
+below:
 
 ```yaml
 # parent's values.yaml file
@@ -426,21 +444,22 @@ myimports:
 
 ```
 
-The parent's final values now contains the `myint` and `mybool` fields imported from subchart1.
+The parent's final values now contains the `myint` and `mybool` fields imported
+from subchart1.
 
 ### Managing Dependencies manually via the `charts/` directory
 
-If more control over dependencies is desired, these dependencies can
-be expressed explicitly by copying the dependency charts into the
-`charts/` directory.
+If more control over dependencies is desired, these dependencies can be
+expressed explicitly by copying the dependency charts into the `charts/`
+directory.
 
-A dependency can be either a chart archive (`foo-1.2.3.tgz`) or an
-unpacked chart directory. But its name cannot start with `_` or `.`.
-Such files are ignored by the chart loader.
+A dependency can be either a chart archive (`foo-1.2.3.tgz`) or an unpacked
+chart directory. But its name cannot start with `_` or `.`. Such files are
+ignored by the chart loader.
 
-For example, if the WordPress chart depends on the Apache chart, the
-Apache chart (of the correct version) is supplied in the WordPress
-chart's `charts/` directory:
+For example, if the WordPress chart depends on the Apache chart, the Apache
+chart (of the correct version) is supplied in the WordPress chart's `charts/`
+directory:
 
 ```yaml
 wordpress:
@@ -455,17 +474,16 @@ wordpress:
       # ...
 ```
 
-The example above shows how the WordPress chart expresses its dependency
-on Apache and MySQL by including those charts inside of its `charts/`
-directory.
+The example above shows how the WordPress chart expresses its dependency on
+Apache and MySQL by including those charts inside of its `charts/` directory.
 
-**TIP:** _To drop a dependency into your `charts/` directory, use the
-`helm pull` command_
+**TIP:** _To drop a dependency into your `charts/` directory, use the `helm
+pull` command_
 
 ### Operational aspects of using dependencies
 
-The above sections explain how to specify chart dependencies, but how does this affect
-chart installation using `helm install` and `helm upgrade`?
+The above sections explain how to specify chart dependencies, but how does this
+affect chart installation using `helm install` and `helm upgrade`?
 
 Suppose that a chart named "A" creates the following Kubernetes objects
 
@@ -479,8 +497,9 @@ Furthermore, A is dependent on chart B that creates objects
 - replicaset "B-ReplicaSet"
 - service "B-Service"
 
-After installation/upgrade of chart A a single Helm release is created/modified. The release will
-create/update all of the above Kubernetes objects in the following order:
+After installation/upgrade of chart A a single Helm release is created/modified.
+The release will create/update all of the above Kubernetes objects in the
+following order:
 
 - A-Namespace
 - B-Namespace
@@ -489,46 +508,48 @@ create/update all of the above Kubernetes objects in the following order:
 - A-Service
 - B-Service
 
-This is because when Helm installs/upgrades charts,
-the Kubernetes objects from the charts and all its dependencies are
+This is because when Helm installs/upgrades charts, the Kubernetes objects from
+the charts and all its dependencies are
 
 - aggregrated into a single set; then
 - sorted by type followed by name; and then
 - created/updated in that order.
 
-Hence a single release is created with all the objects for the chart and its dependencies.
+Hence a single release is created with all the objects for the chart and its
+dependencies.
 
-The install order of Kubernetes types is given by the enumeration InstallOrder in kind_sorter.go
-(see [the Helm source file](https://github.com/helm/helm/blob/484d43913f97292648c867b56768775a55e4bba6/pkg/releaseutil/kind_sorter.go)).
+The install order of Kubernetes types is given by the enumeration InstallOrder
+in kind_sorter.go (see [the Helm source
+file](https://github.com/helm/helm/blob/484d43913f97292648c867b56768775a55e4bba6/pkg/releaseutil/kind_sorter.go)).
 
 ## Templates and Values
 
-Helm Chart templates are written in the
-[Go template language](https://golang.org/pkg/text/template/), with the
-addition of 50 or so add-on template
-functions [from the Sprig library](https://github.com/Masterminds/sprig) and a
-few other [specialized functions](charts_tips_and_tricks.md).
+Helm Chart templates are written in the [Go template
+language](https://golang.org/pkg/text/template/), with the addition of 50 or so
+add-on template functions [from the Sprig
+library](https://github.com/Masterminds/sprig) and a few other [specialized
+functions](charts_tips_and_tricks.md).
 
-All template files are stored in a chart's `templates/` folder. When
-Helm renders the charts, it will pass every file in that directory
-through the template engine.
+All template files are stored in a chart's `templates/` folder. When Helm
+renders the charts, it will pass every file in that directory through the
+template engine.
 
 Values for the templates are supplied two ways:
 
-  - Chart developers may supply a file called `values.yaml` inside of a
-    chart. This file can contain default values.
+  - Chart developers may supply a file called `values.yaml` inside of a chart.
+    This file can contain default values.
   - Chart users may supply a YAML file that contains values. This can be
     provided on the command line with `helm install`.
 
-When a user supplies custom values, these values will override the
-values in the chart's `values.yaml` file.
+When a user supplies custom values, these values will override the values in the
+chart's `values.yaml` file.
 
 ### Template Files
 
-Template files follow the standard conventions for writing Go templates
-(see [the text/template Go package documentation](https://golang.org/pkg/text/template/)
-for details).
-An example template file might look something like this:
+Template files follow the standard conventions for writing Go templates (see
+[the text/template Go package
+documentation](https://golang.org/pkg/text/template/) for details). An example
+template file might look something like this:
 
 ```yaml
 apiVersion: v1
@@ -559,59 +580,59 @@ spec:
               value: {{ default "minio" .Values.storage }}
 ```
 
-The above example, based loosely on [https://github.com/deis/charts](https://github.com/deis/charts), is a template for a Kubernetes replication controller.
-It can use the following four template values (usually defined in a
-`values.yaml` file):
+The above example, based loosely on
+[https://github.com/deis/charts](https://github.com/deis/charts), is a template
+for a Kubernetes replication controller. It can use the following four template
+values (usually defined in a `values.yaml` file):
 
 - `imageRegistry`: The source registry for the Docker image.
 - `dockerTag`: The tag for the docker image.
 - `pullPolicy`: The Kubernetes pull policy.
 - `storage`: The storage backend, whose default is set to `"minio"`
 
-All of these values are defined by the template author. Helm does not
-require or dictate parameters.
+All of these values are defined by the template author. Helm does not require or
+dictate parameters.
 
 To see many working charts, check out the [Kubernetes Charts
 project](https://github.com/helm/charts)
 
 ### Predefined Values
 
-Values that are supplied via a `values.yaml` file (or via the `--set`
-flag) are accessible from the `.Values` object in a template. But there
-are other pre-defined pieces of data you can access in your templates.
+Values that are supplied via a `values.yaml` file (or via the `--set` flag) are
+accessible from the `.Values` object in a template. But there are other
+pre-defined pieces of data you can access in your templates.
 
 The following values are pre-defined, are available to every template, and
-cannot be overridden. As with all values, the names are _case
-sensitive_.
+cannot be overridden. As with all values, the names are _case sensitive_.
 
 - `Release.Name`: The name of the release (not the chart)
 - `Release.Namespace`: The namespace the chart was released to.
 - `Release.Service`: The service that conducted the release.
-- `Release.IsUpgrade`: This is set to true if the current operation is an upgrade or rollback.
+- `Release.IsUpgrade`: This is set to true if the current operation is an
+  upgrade or rollback.
 - `Release.IsInstall`: This is set to true if the current operation is an
   install.
 - `Chart`: The contents of the `Chart.yaml`. Thus, the chart version is
-  obtainable as `Chart.Version` and the maintainers are in
-  `Chart.Maintainers`.
+  obtainable as `Chart.Version` and the maintainers are in `Chart.Maintainers`.
 - `Files`: A map-like object containing all non-special files in the chart. This
   will not give you access to templates, but will give you access to additional
-  files that are present (unless they are excluded using `.helmignore`). Files can be
-  accessed using `{{ index .Files "file.name" }}` or using the `{{ .Files.Get name }}` or
-  `{{ .Files.GetString name }}` functions. You can also access the contents of the file
-  as `[]byte` using `{{ .Files.GetBytes }}`
+  files that are present (unless they are excluded using `.helmignore`). Files
+  can be accessed using `{{ index .Files "file.name" }}` or using the `{{
+  .Files.Get name }}` or `{{ .Files.GetString name }}` functions. You can also
+  access the contents of the file as `[]byte` using `{{ .Files.GetBytes }}`
 - `Capabilities`: A map-like object that contains information about the versions
   of Kubernetes (`{{ .Capabilities.KubeVersion }}` and the supported Kubernetes
- API versions (`{{ .Capabilities.APIVersions.Has "batch/v1" }}`)
+  API versions (`{{ .Capabilities.APIVersions.Has "batch/v1" }}`)
 
-**NOTE:** Any unknown Chart.yaml fields will be dropped. They will not
-be accessible inside of the `Chart` object. Thus, Chart.yaml cannot be
-used to pass arbitrarily structured data into the template. The values
-file can be used for that, though.
+**NOTE:** Any unknown Chart.yaml fields will be dropped. They will not be
+accessible inside of the `Chart` object. Thus, Chart.yaml cannot be used to pass
+arbitrarily structured data into the template. The values file can be used for
+that, though.
 
 ### Values files
 
-Considering the template in the previous section, a `values.yaml` file
-that supplies the necessary values would look like this:
+Considering the template in the previous section, a `values.yaml` file that
+supplies the necessary values would look like this:
 
 ```yaml
 imageRegistry: "quay.io/deis"
@@ -620,24 +641,23 @@ pullPolicy: "Always"
 storage: "s3"
 ```
 
-A values file is formatted in YAML. A chart may include a default
-`values.yaml` file. The Helm install command allows a user to override
-values by supplying additional YAML values:
+A values file is formatted in YAML. A chart may include a default `values.yaml`
+file. The Helm install command allows a user to override values by supplying
+additional YAML values:
 
 ```console
 $ helm install --values=myvals.yaml wordpress
 ```
 
-When values are passed in this way, they will be merged into the default
-values file. For example, consider a `myvals.yaml` file that looks like
-this:
+When values are passed in this way, they will be merged into the default values
+file. For example, consider a `myvals.yaml` file that looks like this:
 
 ```yaml
 storage: "gcs"
 ```
 
-When this is merged with the `values.yaml` in the chart, the resulting
-generated content will be:
+When this is merged with the `values.yaml` in the chart, the resulting generated
+content will be:
 
 ```yaml
 imageRegistry: "quay.io/deis"
@@ -649,17 +669,17 @@ storage: "gcs"
 Note that only the last field was overridden.
 
 **NOTE:** The default values file included inside of a chart _must_ be named
-`values.yaml`. But files specified on the command line can be named
-anything.
+`values.yaml`. But files specified on the command line can be named anything.
 
 **NOTE:** If the `--set` flag is used on `helm install` or `helm upgrade`, those
 values are simply converted to YAML on the client side.
 
 **NOTE:** If any required entries in the values file exist, they can be declared
-as required in the chart template by using the ['required' function](charts_tips_and_tricks.md)
+as required in the chart template by using the ['required'
+function](charts_tips_and_tricks.md)
 
-Any of these values are then accessible inside of templates using the
-`.Values` object:
+Any of these values are then accessible inside of templates using the `.Values`
+object:
 
 ```yaml
 apiVersion: v1
@@ -693,13 +713,12 @@ spec:
 
 ### Scope, Dependencies, and Values
 
-Values files can declare values for the top-level chart, as well as for
-any of the charts that are included in that chart's `charts/` directory.
-Or, to phrase it differently, a values file can supply values to the
-chart as well as to any of its dependencies. For example, the
-demonstration WordPress chart above has both `mysql` and `apache` as
-dependencies. The values file could supply values to all of these
-components:
+Values files can declare values for the top-level chart, as well as for any of
+the charts that are included in that chart's `charts/` directory. Or, to phrase
+it differently, a values file can supply values to the chart as well as to any
+of its dependencies. For example, the demonstration WordPress chart above has
+both `mysql` and `apache` as dependencies. The values file could supply values
+to all of these components:
 
 ```yaml
 title: "My WordPress Site" # Sent to the WordPress template
@@ -712,22 +731,21 @@ apache:
   port: 8080 # Passed to Apache
 ```
 
-Charts at a higher level have access to all of the variables defined
-beneath. So the WordPress chart can access the MySQL password as
-`.Values.mysql.password`. But lower level charts cannot access things in
-parent charts, so MySQL will not be able to access the `title` property. Nor,
-for that matter, can it access `apache.port`.
+Charts at a higher level have access to all of the variables defined beneath. So
+the WordPress chart can access the MySQL password as `.Values.mysql.password`.
+But lower level charts cannot access things in parent charts, so MySQL will not
+be able to access the `title` property. Nor, for that matter, can it access
+`apache.port`.
 
-Values are namespaced, but namespaces are pruned. So for the WordPress
-chart, it can access the MySQL password field as `.Values.mysql.password`. But
-for the MySQL chart, the scope of the values has been reduced and the
-namespace prefix removed, so it will see the password field simply as
-`.Values.password`.
+Values are namespaced, but namespaces are pruned. So for the WordPress chart, it
+can access the MySQL password field as `.Values.mysql.password`. But for the
+MySQL chart, the scope of the values has been reduced and the namespace prefix
+removed, so it will see the password field simply as `.Values.password`.
 
 #### Global Values
 
-As of 2.0.0-Alpha.2, Helm supports special "global" value. Consider
-this modified version of the previous example:
+As of 2.0.0-Alpha.2, Helm supports special "global" value. Consider this
+modified version of the previous example:
 
 ```yaml
 title: "My WordPress Site" # Sent to the WordPress template
@@ -743,11 +761,11 @@ apache:
   port: 8080 # Passed to Apache
 ```
 
-The above adds a `global` section with the value `app: MyWordPress`.
-This value is available to _all_ charts as `.Values.global.app`.
+The above adds a `global` section with the value `app: MyWordPress`. This value
+is available to _all_ charts as `.Values.global.app`.
 
-For example, the `mysql` templates may access `app` as `{{ .Values.global.app }}`, and
-so can the `apache` chart. Effectively, the values file above is
+For example, the `mysql` templates may access `app` as `{{ .Values.global.app
+}}`, and so can the `apache` chart. Effectively, the values file above is
 regenerated like this:
 
 ```yaml
@@ -768,23 +786,22 @@ apache:
   port: 8080 # Passed to Apache
 ```
 
-This provides a way of sharing one top-level variable with all
-subcharts, which is useful for things like setting `metadata` properties
-like labels.
+This provides a way of sharing one top-level variable with all subcharts, which
+is useful for things like setting `metadata` properties like labels.
 
-If a subchart declares a global variable, that global will be passed
-_downward_ (to the subchart's subcharts), but not _upward_ to the parent
-chart. There is no way for a subchart to influence the values of the
-parent chart.
+If a subchart declares a global variable, that global will be passed _downward_
+(to the subchart's subcharts), but not _upward_ to the parent chart. There is no
+way for a subchart to influence the values of the parent chart.
 
-Also, global variables of parent charts take precedence over the global variables from subcharts.
+Also, global variables of parent charts take precedence over the global
+variables from subcharts.
 
 ### Schema Files
 
 Sometimes, a chart maintainer might want to define a structure on their values.
-This can be done by defining a schema in the `values.schema.json` file. A
-schema is represented as a [JSON Schema](https://json-schema.org/).
-It might look something like this:
+This can be done by defining a schema in the `values.schema.json` file. A schema
+is represented as a [JSON Schema](https://json-schema.org/). It might look
+something like this:
 
 ```json
 {
@@ -824,17 +841,16 @@ It might look something like this:
 }
 ```
 
-This schema will be applied to the values to validate it. Validation occurs
-when any of the following commands are invoked:
+This schema will be applied to the values to validate it. Validation occurs when
+any of the following commands are invoked:
 
 * `helm install`
 * `helm upgrade`
 * `helm lint`
 * `helm template`
 
-An example of a
-`values.yaml` file that meets the requirements of this schema might look
-something like this:
+An example of a `values.yaml` file that meets the requirements of this schema
+might look something like this:
 
 ```yaml
 name: frontend
@@ -859,8 +875,8 @@ helm install --set port=443
 Furthermore, the final `.Values` object is checked against *all* subchart
 schemas. This means that restrictions on a subchart can't be circumvented by a
 parent chart. This also works backwards - if a subchart has a requirement that
-is not met in the subchart's `values.yaml` file, the parent chart *must*
-satisfy those restrictions in order to be valid.
+is not met in the subchart's `values.yaml` file, the parent chart *must* satisfy
+those restrictions in order to be valid.
 
 ### References
 
@@ -874,17 +890,29 @@ standard references that will help you out.
 
 ## Custom Resource Definitions (CRDs)
 
-Kubernetes provides a mechanism for declaring new types of Kubernetes objects. Using CustomResourceDefinitions (CRDs), Kubernetes developers can declare custom resource types.
+Kubernetes provides a mechanism for declaring new types of Kubernetes objects.
+Using CustomResourceDefinitions (CRDs), Kubernetes developers can declare custom
+resource types.
 
-In Helm 3, CRDs are treated as a special kind of object. They are installed before the rest of the chart, and are subject to some limitations.
+In Helm 3, CRDs are treated as a special kind of object. They are installed
+before the rest of the chart, and are subject to some limitations.
 
-CRD YAML files should be placed in the `crds/` directory inside of a chart. Multiple CRDs (separated by YAML start and end markers) may be placed in the same file. Helm will attempt to load _all_ of the files in the CRD directory into Kubernetes.
+CRD YAML files should be placed in the `crds/` directory inside of a chart.
+Multiple CRDs (separated by YAML start and end markers) may be placed in the
+same file. Helm will attempt to load _all_ of the files in the CRD directory
+into Kubernetes.
 
 CRD files _cannot be templated_. They must be plain YAML documents.
 
-When Helm installs a new chart, it will upload the CRDs, pause until the CRDs are made available by the API server, and then start the template engine, render the rest of the chart, and upload it to Kubernetes. Because of this ordering, CRD information is available in the `.Capabilities` object in Helm templates, and Helm templates may create new instances of objects that were declared in CRDs.
+When Helm installs a new chart, it will upload the CRDs, pause until the CRDs
+are made available by the API server, and then start the template engine, render
+the rest of the chart, and upload it to Kubernetes. Because of this ordering,
+CRD information is available in the `.Capabilities` object in Helm templates,
+and Helm templates may create new instances of objects that were declared in
+CRDs.
 
-For example, if your chart had a CRD for `CronTab` in the `crds/` directory, you may create instances of the `CronTab` kind in the `templates/` directory:
+For example, if your chart had a CRD for `CronTab` in the `crds/` directory, you
+may create instances of the `CronTab` kind in the `templates/` directory:
 
 ```
 crontabs/
@@ -914,7 +942,8 @@ spec:
     kind: CronTab
 ```
 
-Then the template `mycrontab.yaml` may create a new `CronTab` (using templates as usual):
+Then the template `mycrontab.yaml` may create a new `CronTab` (using templates
+as usual):
 
 ```yaml
 apiVersion: stable.example.com
@@ -925,17 +954,27 @@ spec:
    # ...
 ```
 
-Helm will make sure that the `CronTab` kind has been installed and is available from the Kubernetes API server before it proceeds installing the things in `templates/`.
+Helm will make sure that the `CronTab` kind has been installed and is available
+from the Kubernetes API server before it proceeds installing the things in
+`templates/`.
 
 #### Limitations on CRDs
 
-Unlike most objects in Kubernetes, CRDs are installed globally. For that reason, Helm takes a very cautious approach in managing CRDs. CRDs are subject to the following limitations:
+Unlike most objects in Kubernetes, CRDs are installed globally. For that reason,
+Helm takes a very cautious approach in managing CRDs. CRDs are subject to the
+following limitations:
 
-- CRDs are never reinstalled. If Helm determines that the CRDs in the `crds/` directory are already present (regardless of version), Helm will not attempt to install or upgrade.
-- CRDs are never installed on upgrade or rollback. Helm will only create CRDs on installation operations.
-- CRDs are never deleted. Deleting a CRD automatically deletes all of the CRD's contents across all namespaces in the cluster. Consequently, Helm will not delete CRDs.
+- CRDs are never reinstalled. If Helm determines that the CRDs in the `crds/`
+  directory are already present (regardless of version), Helm will not attempt
+  to install or upgrade.
+- CRDs are never installed on upgrade or rollback. Helm will only create CRDs on
+  installation operations.
+- CRDs are never deleted. Deleting a CRD automatically deletes all of the CRD's
+  contents across all namespaces in the cluster. Consequently, Helm will not
+  delete CRDs.
 
-Operators who want to upgrade or delete CRDs are encouraged to do this manually and with great care.
+Operators who want to upgrade or delete CRDs are encouraged to do this manually
+and with great care.
 
 ## Using Helm to Manage Charts
 
@@ -948,16 +987,16 @@ $ helm create mychart
 Created mychart/
 ```
 
-Once you have edited a chart, `helm` can package it into a chart archive
-for you:
+Once you have edited a chart, `helm` can package it into a chart archive for
+you:
 
 ```console
 $ helm package mychart
 Archived mychart-0.1.-.tgz
 ```
 
-You can also use `helm` to help you find issues with your chart's
-formatting or information:
+You can also use `helm` to help you find issues with your chart's formatting or
+information:
 
 ```console
 $ helm lint mychart
@@ -966,45 +1005,42 @@ No issues found
 
 ## Chart Repositories
 
-A _chart repository_ is an HTTP server that houses one or more packaged
-charts. While `helm` can be used to manage local chart directories, when
-it comes to sharing charts, the preferred mechanism is a chart
-repository.
+A _chart repository_ is an HTTP server that houses one or more packaged charts.
+While `helm` can be used to manage local chart directories, when it comes to
+sharing charts, the preferred mechanism is a chart repository.
 
-Any HTTP server that can serve YAML files and tar files and can answer
-GET requests can be used as a repository server.
+Any HTTP server that can serve YAML files and tar files and can answer GET
+requests can be used as a repository server.
 
-Helm comes with built-in package server for developer testing (`helm
-serve`). The Helm team has tested other servers, including Google Cloud
-Storage with website mode enabled, and S3 with website mode enabled.
+Helm comes with built-in package server for developer testing (`helm serve`).
+The Helm team has tested other servers, including Google Cloud Storage with
+website mode enabled, and S3 with website mode enabled.
 
-A repository is characterized primarily by the presence of a special
-file called `index.yaml` that has a list of all of the packages supplied
-by the repository, together with metadata that allows retrieving and
-verifying those packages.
+A repository is characterized primarily by the presence of a special file called
+`index.yaml` that has a list of all of the packages supplied by the repository,
+together with metadata that allows retrieving and verifying those packages.
 
-On the client side, repositories are managed with the `helm repo`
-commands. However, Helm does not provide tools for uploading charts to
-remote repository servers. This is because doing so would add
-substantial requirements to an implementing server, and thus raise the
-barrier for setting up a repository.
+On the client side, repositories are managed with the `helm repo` commands.
+However, Helm does not provide tools for uploading charts to remote repository
+servers. This is because doing so would add substantial requirements to an
+implementing server, and thus raise the barrier for setting up a repository.
 
 ## Chart Starter Packs
 
 The `helm create` command takes an optional `--starter` option that lets you
 specify a "starter chart".
 
-Starters are just regular charts, but are located in `$XDG_DATA_HOME/helm/starters`.
-As a chart developer, you may author charts that are specifically designed
-to be used as starters. Such charts should be designed with the following
-considerations in mind:
+Starters are just regular charts, but are located in
+`$XDG_DATA_HOME/helm/starters`. As a chart developer, you may author charts that
+are specifically designed to be used as starters. Such charts should be designed
+with the following considerations in mind:
 
 - The `Chart.yaml` will be overwritten by the generator.
-- Users will expect to modify such a chart's contents, so documentation
-  should indicate how users can do so.
+- Users will expect to modify such a chart's contents, so documentation should
+  indicate how users can do so.
 - All occurrences of `<CHARTNAME>` will be replaced with the specified chart
   name so that starter charts can be used as templates.
 
-Currently the only way to add a chart to `$XDG_DATA_HOME/helm/starters` is to manually
-copy it there. In your chart's documentation, you may want to explain that
-process.
+Currently the only way to add a chart to `$XDG_DATA_HOME/helm/starters` is to
+manually copy it there. In your chart's documentation, you may want to explain
+that process.

--- a/content/docs/topics/charts_hooks.md
+++ b/content/docs/topics/charts_hooks.md
@@ -3,49 +3,44 @@ title: "Chart Hooks"
 description: "Describes how to work with chart hooks."
 ---
 
-Helm provides a _hook_ mechanism to allow chart developers to intervene
-at certain points in a release's life cycle. For example, you can use
-hooks to:
+Helm provides a _hook_ mechanism to allow chart developers to intervene at
+certain points in a release's life cycle. For example, you can use hooks to:
 
-- Load a ConfigMap or Secret during install before any other charts are
-  loaded.
-- Execute a Job to back up a database before installing a new chart,
-  and then execute a second job after the upgrade in order to restore
-  data.
-- Run a Job before deleting a release to gracefully take a service out
-  of rotation before removing it.
+- Load a ConfigMap or Secret during install before any other charts are loaded.
+- Execute a Job to back up a database before installing a new chart, and then
+  execute a second job after the upgrade in order to restore data.
+- Run a Job before deleting a release to gracefully take a service out of
+  rotation before removing it.
 
-Hooks work like regular templates, but they have special annotations
-that cause Helm to utilize them differently. In this section, we cover
-the basic usage pattern for hooks.
+Hooks work like regular templates, but they have special annotations that cause
+Helm to utilize them differently. In this section, we cover the basic usage
+pattern for hooks.
 
 ## The Available Hooks
 
 The following hooks are defined:
 
-- pre-install: Executes after templates are rendered, but before any
-  resources are created in Kubernetes.
+- pre-install: Executes after templates are rendered, but before any resources
+  are created in Kubernetes.
 - post-install: Executes after all resources are loaded into Kubernetes
-- pre-delete: Executes on a deletion request before any resources are
-  deleted from Kubernetes.
+- pre-delete: Executes on a deletion request before any resources are deleted
+  from Kubernetes.
 - post-delete: Executes on a deletion request after all of the release's
   resources have been deleted.
-- pre-upgrade: Executes on an upgrade request after templates are
-  rendered, but before any resources are loaded into Kubernetes (e.g.
-  before a Kubernetes apply operation).
-- post-upgrade: Executes on an upgrade after all resources have been
-  upgraded.
-- pre-rollback: Executes on a rollback request after templates are
-  rendered, but before any resources have been rolled back.
-- post-rollback: Executes on a rollback request after all resources
-  have been modified.
+- pre-upgrade: Executes on an upgrade request after templates are rendered, but
+  before any resources are loaded into Kubernetes (e.g. before a Kubernetes
+  apply operation).
+- post-upgrade: Executes on an upgrade after all resources have been upgraded.
+- pre-rollback: Executes on a rollback request after templates are rendered, but
+  before any resources have been rolled back.
+- post-rollback: Executes on a rollback request after all resources have been
+  modified.
 
 ## Hooks and the Release Lifecycle
 
-Hooks allow you, the chart developer, an opportunity to perform
-operations at strategic points in a release lifecycle. For example,
-consider the lifecycle for a `helm install`. By default, the lifecycle
-looks like this:
+Hooks allow you, the chart developer, an opportunity to perform operations at
+strategic points in a release lifecycle. For example, consider the lifecycle for
+a `helm install`. By default, the lifecycle looks like this:
 
 1. User runs `helm install foo`
 2. The Helm library install API is called
@@ -55,58 +50,61 @@ looks like this:
 6. The client exits
 
 Helm defines two hooks for the `install` lifecycle: `pre-install` and
-`post-install`. If the developer of the `foo` chart implements both
-hooks, the lifecycle is altered like this:
+`post-install`. If the developer of the `foo` chart implements both hooks, the
+lifecycle is altered like this:
 
 1. User runs `helm install foo`
 2. The Helm library install API is called
 3. After some verification, the library renders the `foo` templates
-4. The library prepares to execute the `pre-install` hooks (loading hook resources into
-   Kubernetes)
-5. The library sorts hooks by weight (assigning a weight of 0 by default) and by name for those hooks with the same weight in ascending order.
-6. The library then loads the hook with the lowest weight first (negative to positive)
+4. The library prepares to execute the `pre-install` hooks (loading hook
+   resources into Kubernetes)
+5. The library sorts hooks by weight (assigning a weight of 0 by default) and by
+   name for those hooks with the same weight in ascending order.
+6. The library then loads the hook with the lowest weight first (negative to
+   positive)
 7. The library waits until the hook is "Ready" (except for CRDs)
-8. The library loads the resulting resources into Kubernetes. Note that if the `--wait`
-flag is set, the library will wait until all resources are in a ready state
-and will not run the `post-install` hook until they are ready.
+8. The library loads the resulting resources into Kubernetes. Note that if the
+   `--wait` flag is set, the library will wait until all resources are in a
+   ready state and will not run the `post-install` hook until they are ready.
 9. The library executes the `post-install` hook (loading hook resources)
 10. The library waits until the hook is "Ready"
 11. The library returns the release object (and other data) to the client
 12. The client exits
 
-What does it mean to wait until a hook is ready? This depends on the
-resource declared in the hook. If the resources is a `Job` kind, the library
- will wait until the job successfully runs to completion. And if the job
-fails, the release will fail. This is a _blocking operation_, so the
-Helm client will pause while the Job is run.
+What does it mean to wait until a hook is ready? This depends on the resource
+declared in the hook. If the resources is a `Job` kind, the library will wait
+until the job successfully runs to completion. And if the job fails, the release
+will fail. This is a _blocking operation_, so the Helm client will pause while
+the Job is run.
 
-For all other kinds, as soon as Kubernetes marks the resource as loaded
-(added or updated), the resource is considered "Ready". When many
-resources are declared in a hook, the resources are executed serially. If they
-have hook weights (see below), they are executed in weighted order. Otherwise,
-ordering is not guaranteed. (In Helm 2.3.0 and after, they are sorted
-alphabetically. That behavior, though, is not considered binding and could change
-in the future.) It is considered good practice to add a hook weight, and set it
-to `0` if weight is not important.
+For all other kinds, as soon as Kubernetes marks the resource as loaded (added
+or updated), the resource is considered "Ready". When many resources are
+declared in a hook, the resources are executed serially. If they have hook
+weights (see below), they are executed in weighted order. Otherwise, ordering is
+not guaranteed. (In Helm 2.3.0 and after, they are sorted alphabetically. That
+behavior, though, is not considered binding and could change in the future.) It
+is considered good practice to add a hook weight, and set it to `0` if weight is
+not important.
 
 
 ### Hook resources are not managed with corresponding releases
 
 The resources that a hook creates are not tracked or managed as part of the
-release. Once Helm verifies that the hook has reached its ready state, it
-will leave the hook resource alone.
+release. Once Helm verifies that the hook has reached its ready state, it will
+leave the hook resource alone.
 
 Practically speaking, this means that if you create resources in a hook, you
 cannot rely upon `helm uninstall` to remove the resources. To destroy such
-resources, you need to either write code to perform this operation in a `pre-delete`
-or `post-delete` hook or add `"helm.sh/hook-delete-policy"` annotation to the hook template file.
+resources, you need to either write code to perform this operation in a
+`pre-delete` or `post-delete` hook or add `"helm.sh/hook-delete-policy"`
+annotation to the hook template file.
 
 ## Writing a Hook
 
 Hooks are just Kubernetes manifest files with special annotations in the
-`metadata` section. Because they are template files, you can use all of
-the normal template features, including reading `.Values`, `.Release`,
-and `.Template`.
+`metadata` section. Because they are template files, you can use all of the
+normal template features, including reading `.Values`, `.Release`, and
+`.Template`.
 
 For example, this template, stored in `templates/post-install-job.yaml`,
 declares a job to be run on `post-install`:
@@ -158,15 +156,16 @@ One resource can implement multiple hooks:
     "helm.sh/hook": post-install,post-upgrade
 ```
 
-Similarly, there is no limit to the number of different resources that
-may implement a given hook. For example, one could declare both a secret
-and a config map as a pre-install hook.
+Similarly, there is no limit to the number of different resources that may
+implement a given hook. For example, one could declare both a secret and a
+config map as a pre-install hook.
 
-When subcharts declare hooks, those are also evaluated. There is no way
-for a top-level chart to disable the hooks declared by subcharts.
+When subcharts declare hooks, those are also evaluated. There is no way for a
+top-level chart to disable the hooks declared by subcharts.
 
 It is possible to define a weight for a hook which will help build a
-deterministic executing order. Weights are defined using the following annotation:
+deterministic executing order. Weights are defined using the following
+annotation:
 
 ```
   annotations:
@@ -177,7 +176,9 @@ Hook weights can be positive or negative numbers but must be represented as
 strings. When Helm starts the execution cycle of hooks of a particular Kind it
 will sort those hooks in ascending order.
 
-It is also possible to define policies that determine when to delete corresponding hook resources. Hook deletion policies are defined using the following annotation:
+It is also possible to define policies that determine when to delete
+corresponding hook resources. Hook deletion policies are defined using the
+following annotation:
 
 ```yaml
   annotations:
@@ -185,18 +186,29 @@ It is also possible to define policies that determine when to delete correspondi
 ```
 
 You can choose one or more defined annotation values:
-* `"hook-succeeded"` specifies Helm should delete the hook after the hook is successfully executed.
-* `"hook-failed"` specifies Helm should delete the hook if the hook failed during execution.
-* `"before-hook-creation"` specifies Helm should delete the previous hook before the new hook is launched.
+* `"hook-succeeded"` specifies Helm should delete the hook after the hook is
+  successfully executed.
+* `"hook-failed"` specifies Helm should delete the hook if the hook failed
+  during execution.
+* `"before-hook-creation"` specifies Helm should delete the previous hook before
+  the new hook is launched.
 
 ### Automatically uninstall hook from previous release
 
-When helm release being updated it is possible, that hook resource already exists in cluster. By default helm will try to create resource and fail with `"... already exists"` error.
+When helm release being updated it is possible, that hook resource already
+exists in cluster. By default helm will try to create resource and fail with
+`"... already exists"` error.
 
-One might choose `"helm.sh/hook-delete-policy": "before-hook-creation"` over `"helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"` because:
+One might choose `"helm.sh/hook-delete-policy": "before-hook-creation"` over
+`"helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"` because:
 
-* It is convenient to keep failed hook job resource in kubernetes for example for manual debug.
-* It may be necessary to keep succeeded hook resource in kubernetes for some reason.
-* At the same time it is not desirable to do manual resource deletion before helm release upgrade.
+* It is convenient to keep failed hook job resource in kubernetes for example
+  for manual debug.
+* It may be necessary to keep succeeded hook resource in kubernetes for some
+  reason.
+* At the same time it is not desirable to do manual resource deletion before
+  helm release upgrade.
 
-`"helm.sh/hook-delete-policy": "before-hook-creation"` annotation on hook causes Helm to remove the hook from previous release if there is one before the new hook is launched and can be used with another policy.
+`"helm.sh/hook-delete-policy": "before-hook-creation"` annotation on hook causes
+Helm to remove the hook from previous release if there is one before the new
+hook is launched and can be used with another policy.

--- a/content/docs/topics/plugins.md
+++ b/content/docs/topics/plugins.md
@@ -7,7 +7,9 @@ Helm 2.1.0 introduced the concept of a client-side Helm _plugin_. A plugin is a
 tool that can be accessed through the `helm` CLI, but which is not part of the
 built-in Helm codebase.
 
-Existing plugins can be found on [related](related.md#helm-plugins) section or by searching [Github](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
+Existing plugins can be found on [related](related.md#helm-plugins) section or
+by searching
+[Github](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
 
 This guide explains how to use and create plugins.
 
@@ -27,20 +29,25 @@ Helm plugins have the following features:
 Helm plugins live in `$(helm home)/plugins`.
 
 The Helm plugin model is partially modeled on Git's plugin model. To that end,
-you may sometimes hear `helm` referred to as the _porcelain_ layer, with
-plugins being the _plumbing_. This is a shorthand way of suggesting that
-Helm provides the user experience and top level processing logic, while the
-plugins do the "detail work" of performing a desired action.
+you may sometimes hear `helm` referred to as the _porcelain_ layer, with plugins
+being the _plumbing_. This is a shorthand way of suggesting that Helm provides
+the user experience and top level processing logic, while the plugins do the
+"detail work" of performing a desired action.
 
 ## Installing a Plugin
 
-Plugins are installed using the `$ helm plugin install <path|url>` command. You can pass in a path to a plugin on your local file system or a url of a remote VCS repo. The `helm plugin install` command clones or copies the plugin at the path/url given into `$ (helm home)/plugins`
+Plugins are installed using the `$ helm plugin install <path|url>` command. You
+can pass in a path to a plugin on your local file system or a url of a remote
+VCS repo. The `helm plugin install` command clones or copies the plugin at the
+path/url given into `$ (helm home)/plugins`
 
 ```console
 $ helm plugin install https://github.com/technosophos/helm-template
 ```
 
-If you have a plugin tar distribution, simply untar the plugin into the `$(helm home)/plugins` directory. You can also install tarball plugins directly from url by issuing `helm plugin install http://domain/path/to/plugin.tar.gz`
+If you have a plugin tar distribution, simply untar the plugin into the `$(helm
+home)/plugins` directory. You can also install tarball plugins directly from url
+by issuing `helm plugin install http://domain/path/to/plugin.tar.gz`
 
 ## Building Plugins
 
@@ -60,8 +67,8 @@ In the example above, the `keybase` plugin is contained inside of a directory
 named `keybase`. It has two files: `plugin.yaml` (required) and an executable
 script, `keybase.sh` (optional).
 
-The core of a plugin is a simple YAML file named `plugin.yaml`.
-Here is a plugin YAML for a plugin that adds support for Keybase operations:
+The core of a plugin is a simple YAML file named `plugin.yaml`. Here is a plugin
+YAML for a plugin that adds support for Keybase operations:
 
 ```yaml
 name: "last"
@@ -93,12 +100,12 @@ Restrictions on `name`:
 - `name` cannot duplicate one of the existing `helm` top-level commands.
 - `name` must be restricted to the characters ASCII a-z, A-Z, 0-9, `_` and `-`.
 
-`version` is the SemVer 2 version of the plugin.
-`usage` and `description` are both used to generate the help text of a command.
+`version` is the SemVer 2 version of the plugin. `usage` and `description` are
+both used to generate the help text of a command.
 
 The `ignoreFlags` switch tells Helm to _not_ pass flags to the plugin. So if a
-plugin is called with `helm myplugin --foo` and `ignoreFlags: true`, then `--foo`
-is silently discarded.
+plugin is called with `helm myplugin --foo` and `ignoreFlags: true`, then
+`--foo` is silently discarded.
 
 Finally, and most importantly, `platformCommand` or `command` is the command
 that this plugin will execute when it is called. The `platformCommand` section
@@ -107,38 +114,40 @@ rules will apply in deciding which command to use:
 
 - If `platformCommand` is present, it will be searched first.
 - If both `os` and `arch` match the current platform, search will stop and the
-command will be used.
-- If `os` matches and there is no more specific `arch` match, the command
-will be used.
+  command will be used.
+- If `os` matches and there is no more specific `arch` match, the command will
+  be used.
 - If no `platformCommand` match is found, the default `command` will be used.
-- If no matches are found in `platformCommand` and no `command` is present,
-Helm will exit with an error.
+- If no matches are found in `platformCommand` and no `command` is present, Helm
+  will exit with an error.
 
 Environment variables are interpolated before the plugin is executed. The
-pattern above illustrates the preferred way to indicate where the plugin
-program lives.
+pattern above illustrates the preferred way to indicate where the plugin program
+lives.
 
 There are some strategies for working with plugin commands:
 
-- If a plugin includes an executable, the executable for a
-`platformCommand:` or a `command:` should be packaged in the plugin directory.
-- The `platformCommand:` or `command:` line will have any environment
-variables expanded before execution. `$HELM_PLUGIN_DIR` will point to the
-plugin directory.
-- The command itself is not executed in a shell. So you can't oneline a shell script.
+- If a plugin includes an executable, the executable for a `platformCommand:` or
+  a `command:` should be packaged in the plugin directory.
+- The `platformCommand:` or `command:` line will have any environment variables
+  expanded before execution. `$HELM_PLUGIN_DIR` will point to the plugin
+  directory.
+- The command itself is not executed in a shell. So you can't oneline a shell
+  script.
 - Helm injects lots of configuration into environment variables. Take a look at
   the environment to see what information is available.
 - Helm makes no assumptions about the language of the plugin. You can write it
   in whatever you prefer.
-- Commands are responsible for implementing specific help text for `-h` and `--help`.
-  Helm will use `usage` and `description` for `helm help` and `helm help myplugin`,
-  but will not handle `helm myplugin --help`.
+- Commands are responsible for implementing specific help text for `-h` and
+  `--help`. Helm will use `usage` and `description` for `helm help` and `helm
+  help myplugin`, but will not handle `helm myplugin --help`.
 
 ## Downloader Plugins
 By default, Helm is able to pull Charts using HTTP/S. As of Helm 2.4.0, plugins
 can have a special capability to download Charts from arbitrary sources.
 
-Plugins shall declare this special capability in the `plugin.yaml` file (top level):
+Plugins shall declare this special capability in the `plugin.yaml` file (top
+level):
 
 ```yaml
 downloaders:
@@ -148,36 +157,36 @@ downloaders:
   - "myprotocols"
 ```
 
-If such plugin is installed, Helm can interact with the repository using the specified
-protocol scheme by invoking the `command`. The special repository shall be added
-similarly to the regular ones: `helm repo add favorite myprotocol://example.com/`
-The rules for the special repos are the same to the regular ones: Helm must be able
-to download the `index.yaml` file in order to discover and cache the list of
-available Charts.
+If such plugin is installed, Helm can interact with the repository using the
+specified protocol scheme by invoking the `command`. The special repository
+shall be added similarly to the regular ones: `helm repo add favorite
+myprotocol://example.com/` The rules for the special repos are the same to the
+regular ones: Helm must be able to download the `index.yaml` file in order to
+discover and cache the list of available Charts.
 
-The defined command will be invoked with the following scheme:
-`command certFile keyFile caFile full-URL`. The SSL credentials are coming from the
-repo definition, stored in `$XDG_DATA_HOME/helm/repositories.yaml`. Downloader
-plugin is expected to dump the raw content to stdout and report errors on stderr.
+The defined command will be invoked with the following scheme: `command certFile
+keyFile caFile full-URL`. The SSL credentials are coming from the repo
+definition, stored in `$XDG_DATA_HOME/helm/repositories.yaml`. Downloader plugin
+is expected to dump the raw content to stdout and report errors on stderr.
 
-The downloader command also supports sub-commands or arguments, allowing you to specify
-for example `bin/mydownloader subcommand -d` in the `plugin.yaml`. This is useful
-if you want to use the same executable for the main plugin command and the downloader
-command, but with a different sub-command for each.
+The downloader command also supports sub-commands or arguments, allowing you to
+specify for example `bin/mydownloader subcommand -d` in the `plugin.yaml`. This
+is useful if you want to use the same executable for the main plugin command and
+the downloader command, but with a different sub-command for each.
 
 ## Environment Variables
 
 When Helm executes a plugin, it passes the outer environment to the plugin, and
 also injects some additional environment variables.
 
-Variables like `KUBECONFIG` are set for the plugin if they are set in the
-outer environment.
+Variables like `KUBECONFIG` are set for the plugin if they are set in the outer
+environment.
 
 The following variables are guaranteed to be set:
 
 - `HELM_PLUGIN`: The path to the plugins directory
-- `HELM_PLUGIN_NAME`: The name of the plugin, as invoked by `helm`. So
-  `helm myplug` will have the short name `myplug`.
+- `HELM_PLUGIN_NAME`: The name of the plugin, as invoked by `helm`. So `helm
+  myplug` will have the short name `myplug`.
 - `HELM_PLUGIN_DIR`: The directory that contains the plugin.
 - `HELM_BIN`: The path to the `helm` command (as executed by the user).
 - `HELM_HOME`: The path to `$XDG_DATA_HOME/helm`.

--- a/content/docs/topics/provenance.md
+++ b/content/docs/topics/provenance.md
@@ -4,8 +4,8 @@ description: "Describes how to verify the integrity and origin of a Chart."
 ---
 
 Helm has provenance tools which help chart users verify the integrity and origin
-of a package. Using industry-standard tools based on PKI, GnuPG, and well-respected
-package managers, Helm can generate and verify signature files.
+of a package. Using industry-standard tools based on PKI, GnuPG, and
+well-respected package managers, Helm can generate and verify signature files.
 
 ## Overview
 
@@ -14,12 +14,13 @@ records are stored in _provenance files_, which are stored alongside a packaged
 chart. For example, if a chart is named `myapp-1.2.3.tgz`, its provenance file
 will be `myapp-1.2.3.tgz.prov`.
 
-Provenance files are generated at packaging time (`helm package --sign ...`), and
-can be checked by multiple commands, notable `helm install --verify`.
+Provenance files are generated at packaging time (`helm package --sign ...`),
+and can be checked by multiple commands, notable `helm install --verify`.
 
 ## The Workflow
 
-This section describes a potential workflow for using provenance data effectively.
+This section describes a potential workflow for using provenance data
+effectively.
 
 Prerequisites:
 
@@ -28,8 +29,8 @@ Prerequisites:
 - GnuPG command line tools (optional)
 - Keybase command line tools (optional)
 
-**NOTE:** If your PGP private key has a passphrase, you will be prompted to enter
-that passphrase for any commands that support the `--sign` option.
+**NOTE:** If your PGP private key has a passphrase, you will be prompted to
+enter that passphrase for any commands that support the `--sign` option.
 
 Creating a new chart is the same as before:
 
@@ -39,23 +40,27 @@ Creating mychart
 ```
 
 Once ready to package, add the `--sign` flag to `helm package`. Also, specify
-the name under which the signing key is known and the keyring containing the corresponding private key:
+the name under which the signing key is known and the keyring containing the
+corresponding private key:
 
 ```console
 $ helm package --sign --key 'helm signing key' --keyring path/to/keyring.secret mychart
 ```
 
-**TIP:** for GnuPG users, your secret keyring is in `~/.gnupg/secring.gpg`. You can
-use `gpg --list-secret-keys` to list the keys you have.
+**TIP:** for GnuPG users, your secret keyring is in `~/.gnupg/secring.gpg`. You
+can use `gpg --list-secret-keys` to list the keys you have.
 
-**Warning:**  the GnuPG v2 store your secret keyring using a new format 'kbx' on the default location  '~/.gnupg/pubring.kbx'. Please use the following command to convert your keyring to the legacy gpg format:
+**Warning:**  the GnuPG v2 store your secret keyring using a new format 'kbx' on
+the default location  '~/.gnupg/pubring.kbx'. Please use the following command
+to convert your keyring to the legacy gpg format:
 
 ```console
 $ gpg --export-secret-keys >~/.gnupg/secring.gpg
 ```
 
-At this point, you should see both `mychart-0.1.0.tgz` and `mychart-0.1.0.tgz.prov`.
-Both files should eventually be uploaded to your desired chart repository.
+At this point, you should see both `mychart-0.1.0.tgz` and
+`mychart-0.1.0.tgz.prov`. Both files should eventually be uploaded to your
+desired chart repository.
 
 You can verify a chart using `helm verify`:
 
@@ -76,16 +81,19 @@ To verify during an install, use the `--verify` flag.
 $ helm install --verify mychart-0.1.0.tgz
 ```
 
-If the keyring (containing the public key associated with the signed chart) is not in the default location, you may need to point to the
-keyring with `--keyring PATH` as in the `helm package` example.
+If the keyring (containing the public key associated with the signed chart) is
+not in the default location, you may need to point to the keyring with
+`--keyring PATH` as in the `helm package` example.
 
-If verification fails, the install will be aborted before the chart is even rendered.
+If verification fails, the install will be aborted before the chart is even
+rendered.
 
 
 ### Using Keybase.io credentials
 
-The [Keybase.io](https://keybase.io) service makes it easy to establish a chain of
-trust for a cryptographic identity. Keybase credentials can be used to sign charts.
+The [Keybase.io](https://keybase.io) service makes it easy to establish a chain
+of trust for a cryptographic identity. Keybase credentials can be used to sign
+charts.
 
 Prerequisites:
 
@@ -130,14 +138,14 @@ least part of that name string in `--key`.
 $ helm package --sign --key technosophos --keyring ~/.gnupg/secring.gpg mychart
 ```
 
-As a result, the `package` command should produce both a `.tgz` file and a `.tgz.prov`
-file.
+As a result, the `package` command should produce both a `.tgz` file and a
+`.tgz.prov` file.
 
 #### Verifying packages
 
 You can also use a similar technique to verify a chart signed by someone else's
-Keybase key. Say you want to verify a package signed by `keybase.io/technosophos`.
-To do this, use the `keybase` tool:
+Keybase key. Say you want to verify a package signed by
+`keybase.io/technosophos`. To do this, use the `keybase` tool:
 
 ```console
 $ keybase follow technosophos
@@ -148,8 +156,8 @@ The first command above tracks the user `technosophos`. Next `keybase pgp pull`
 downloads the OpenPGP keys of all of the accounts you follow, placing them in
 your GnuPG keyring (`~/.gnupg/pubring.gpg`).
 
-At this point, you can now use `helm verify` or any of the commands with a `--verify`
-flag:
+At this point, you can now use `helm verify` or any of the commands with a
+`--verify` flag:
 
 ```console
 $ helm verify somechart-1.2.3.tgz
@@ -159,14 +167,16 @@ $ helm verify somechart-1.2.3.tgz
 
 These are common reasons for failure.
 
-- The prov file is missing or corrupt. This indicates that something is misconfigured
-  or that the original maintainer did not create a provenance file.
+- The prov file is missing or corrupt. This indicates that something is
+  misconfigured or that the original maintainer did not create a provenance
+  file.
 - The key used to sign the file is not in your keyring. This indicate that the
-  entity who signed the chart is not someone you've already signaled that you trust.
-- The verification of the prov file failed. This indicates that something is wrong
-  with either the chart or the provenance data.
-- The file hashes in the provenance file do not match the hash of the archive file. This
-  indicates that the archive has been tampered with.
+  entity who signed the chart is not someone you've already signaled that you
+  trust.
+- The verification of the prov file failed. This indicates that something is
+  wrong with either the chart or the provenance data.
+- The file hashes in the provenance file do not match the hash of the archive
+  file. This indicates that the archive has been tampered with.
 
 If a verification fails, there is reason to distrust the package.
 
@@ -232,10 +242,13 @@ resistance](http://www.rossde.com/PGP/pgp_signatures.html).
 Chart repositories serve as a centralized collection of Helm charts.
 
 Chart repositories must make it possible to serve provenance files over HTTP via
-a specific request, and must make them available at the same URI path as the chart.
+a specific request, and must make them available at the same URI path as the
+chart.
 
-For example, if the base URL for a package is `https://example.com/charts/mychart-1.2.3.tgz`,
-the provenance file, if it exists, MUST be accessible at `https://example.com/charts/mychart-1.2.3.tgz.prov`.
+For example, if the base URL for a package is
+`https://example.com/charts/mychart-1.2.3.tgz`, the provenance file, if it
+exists, MUST be accessible at
+`https://example.com/charts/mychart-1.2.3.tgz.prov`.
 
 From the end user's perspective, `helm install --verify myrepo/mychart-1.2.3`
 should result in the download of both the chart and the provenance file with no
@@ -244,37 +257,36 @@ additional user configuration or action.
 ## Establishing Authority and Authenticity
 
 When dealing with chain-of-trust systems, it is important to be able to
-establish the authority of a signer. Or, to put this plainly, the system
-above hinges on the fact that you trust the person who signed the chart.
-That, in turn, means you need to trust the public key of the signer.
+establish the authority of a signer. Or, to put this plainly, the system above
+hinges on the fact that you trust the person who signed the chart. That, in
+turn, means you need to trust the public key of the signer.
 
-One of the design decisions with Kubernetes Helm has been that the Helm
-project would not insert itself into the chain of trust as a necessary
-party. We don't want to be "the certificate authority" for all chart
-signers. Instead, we strongly favor a decentralized model, which is part
-of the reason we chose OpenPGP as our foundational technology.
-So when it comes to establishing authority, we have left this
-step more-or-less undefined in Helm 2.0.0.
+One of the design decisions with Kubernetes Helm has been that the Helm project
+would not insert itself into the chain of trust as a necessary party. We don't
+want to be "the certificate authority" for all chart signers. Instead, we
+strongly favor a decentralized model, which is part of the reason we chose
+OpenPGP as our foundational technology. So when it comes to establishing
+authority, we have left this step more-or-less undefined in Helm 2.0.0.
 
-However, we have some pointers and recommendations for those interested
-in using the provenance system:
+However, we have some pointers and recommendations for those interested in using
+the provenance system:
 
-- The [Keybase](https://keybase.io) platform provides a public
-  centralized repository for trust information.
+- The [Keybase](https://keybase.io) platform provides a public centralized
+  repository for trust information.
   - You can use Keybase to store your keys or to get the public keys of others.
   - Keybase also has fabulous documentation available
-  - While we haven't tested it, Keybase's "secure website" feature could
-    be used to serve Helm charts.
-- The [official Kubernetes Charts project](https://github.com/helm/charts)
-  is trying to solve this problem for the official chart repository.
-  - There is a long issue there [detailing the current thoughts](https://github.com/helm/charts/issues/23).
-  - The basic idea is that an official "chart reviewer" signs charts with
-    her or his key, and the resulting provenance file is then uploaded
-    to the chart repository.
-  - There has been some work on the idea that a list of valid signing
-    keys may be included in the `index.yaml` file of a repository.
+  - While we haven't tested it, Keybase's "secure website" feature could be used
+    to serve Helm charts.
+- The [official Kubernetes Charts project](https://github.com/helm/charts) is
+  trying to solve this problem for the official chart repository.
+  - There is a long issue there [detailing the current
+    thoughts](https://github.com/helm/charts/issues/23).
+  - The basic idea is that an official "chart reviewer" signs charts with her or
+    his key, and the resulting provenance file is then uploaded to the chart
+    repository.
+  - There has been some work on the idea that a list of valid signing keys may
+    be included in the `index.yaml` file of a repository.
 
-Finally, chain-of-trust is an evolving feature of Helm, and some
-community members have proposed adapting part of the OSI model for
-signatures. This is an open line of inquiry in the Helm team. If you're
-interested, jump on in.
+Finally, chain-of-trust is an evolving feature of Helm, and some community
+members have proposed adapting part of the OSI model for signatures. This is an
+open line of inquiry in the Helm team. If you're interested, jump on in.

--- a/content/docs/topics/registries.md
+++ b/content/docs/topics/registries.md
@@ -3,16 +3,16 @@ title: "Registries"
 description: "Describes how to use OCI for Chart distribution."
 ---
 
-
-Helm 3 supports <a href="https://www.opencontainers.org/" target="_blank">OCI</a> for package distribution.
-Chart packages are able to be stored and shared across OCI-based registries.
+Helm 3 supports <a href="https://www.opencontainers.org/"
+target="_blank">OCI</a> for package distribution. Chart packages are able to be
+stored and shared across OCI-based registries.
 
 ## Enabling OCI Support
 
 Currently OCI support is considered *experimental*.
 
-In order to use the commands described below,
-please set `HELM_EXPERIMENTAL_OCI` in the enironment:
+In order to use the commands described below, please set `HELM_EXPERIMENTAL_OCI`
+in the enironment:
 
 ```console
 export HELM_EXPERIMENTAL_OCI=1
@@ -20,18 +20,22 @@ export HELM_EXPERIMENTAL_OCI=1
 
 ## Running a registry
 
-Starting a registry for test purposes is trivial. As long as you have Docker installed, run the following command:
+Starting a registry for test purposes is trivial. As long as you have Docker
+installed, run the following command:
 ```console
 docker run -dp 5000:5000 --restart=always --name registry registry
 ```
 
 This will start a registry server at `localhost:5000`.
 
-Use `docker logs -f registry` to see the logs and `docker rm -f registry` to stop.
+Use `docker logs -f registry` to see the logs and `docker rm -f registry` to
+stop.
 
-If you wish to persist storage, you can add `-v $(pwd)/registry:/var/lib/registry` to the command above.
+If you wish to persist storage, you can add `-v
+$(pwd)/registry:/var/lib/registry` to the command above.
 
-For more configuration options, please see [the docs](https://docs.docker.com/registry/deploying/).
+For more configuration options, please see [the
+docs](https://docs.docker.com/registry/deploying/).
 
 ### Auth
 
@@ -42,7 +46,8 @@ First, create file `auth.htpasswd` with username and password combo:
 htpasswd -cB -b auth.htpasswd myuser mypass
 ```
 
-Then, start the server, mounting that file and setting the `REGISTRY_AUTH` env var:
+Then, start the server, mounting that file and setting the `REGISTRY_AUTH` env
+var:
 ```console
 docker run -dp 5000:5000 --restart=always --name registry \
   -v $(pwd)/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
@@ -52,7 +57,8 @@ docker run -dp 5000:5000 --restart=always --name registry \
 
 ## Commands for working with registries
 
-Commands are available under both `helm registry` and `helm chart` that allow you to work with registries and local cache.
+Commands are available under both `helm registry` and `helm chart` that allow
+you to work with registries and local cache.
 
 ### The `registry` subcommand
 
@@ -163,7 +169,8 @@ Status: Downloaded newer chart for localhost:5000/myrepo/mychart:2.7.0
 
 Charts stored using the commands above will be cached on the filesystem.
 
-The [OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/master/image-layout.md)
+The [OCI Image Layout
+Specification](https://github.com/opencontainers/image-spec/blob/master/image-layout.md)
 is adhered to strictly for filesystem layout, for example:
 ```console
 $ tree ~/Library/Caches/helm/
@@ -221,4 +228,6 @@ $ cat ~/Library/Caches/helm/registry/cache/blobs/sha256/31fb454efb3c69fafe536725
 
 ## Migrating from chart repos
 
-Migrating from classic [chart repositories](./chart_repository.md) (index.yaml-based repos) is as simple as a `helm fetch` (Helm 2 CLI), `helm chart save`, `helm chart push`.
+Migrating from classic [chart repositories](./chart_repository.md)
+(index.yaml-based repos) is as simple as a `helm fetch` (Helm 2 CLI), `helm
+chart save`, `helm chart push`.


### PR DESCRIPTION
There was a wide variety of wrapping formats from 80 chars all the
way up to never wrapping. This changes the wrapping of all documents
to be at/around 80 chars to make it easier to review and read in text
editors.

I made no other changes to content save for sorting the list of Kubernetes
distros alphabetically to avoid anything that looks like preference for
any given distro.