### PR TITLE
docs(theme): fix the v3 docs landing pages

### DIFF
--- a/themes/helm/assets/sass/docs-content.scss
+++ b/themes/helm/assets/sass/docs-content.scss
@@ -13,6 +13,7 @@
     letter-spacing: 0.03em;
     margin-top: 1em;
     padding-top: 2.5em;
+    padding-bottom: 1.5rem;
   }
 
   article {
@@ -65,6 +66,57 @@
     a {
       padding-left: 0.25em;
       padding-right: 0.25em;
+    }
+  }
+
+  .quick-links {
+    padding-top: 5rem;
+
+    h3 {
+      color: $blue;
+
+      &:hover {
+        color: $blue;
+      }
+    }
+    
+    .quick-item {
+      position: relative;
+      display: block;
+      clear: both;
+      padding: 1rem 1rem 1.5rem;
+      background: transparent;
+
+      &:hover {
+        color: $blue4;
+        border-bottom: none;
+      }
+
+      &:after {
+        height: 2px;
+        background: desaturate(lighten($blue1, 35%), 20%);
+        width: 100%;
+        display: block;
+        content: " ";
+        position: absolute;
+        top: 1px;
+      }
+
+      h4 {
+        display: inline-block;
+        float: left;
+        clear: both;
+        color: $blue4;
+        font-size: 1.125em;
+        width: 30%;
+      }
+      p {
+        display: inline-block;
+        float: right;
+        text-align: left;
+        width: 58%;
+
+      }
     }
   }
 

--- a/themes/helm/assets/sass/docs-footer.scss
+++ b/themes/helm/assets/sass/docs-footer.scss
@@ -215,7 +215,7 @@
 }
 
 .cncf {
-  background: desaturate($light2, 50%);
+  background: lighten(desaturate($light2, 50%), 7.5%);
   min-height: 2rem;
   text-align: center;
   padding-left: 300px;

--- a/themes/helm/assets/sass/docs-layout.scss
+++ b/themes/helm/assets/sass/docs-layout.scss
@@ -37,3 +37,53 @@ body {
   width: 25%;
   width: 300px;
 }
+
+
+.main .content-wrap {
+  .quick-links {
+    padding-top: 5rem;
+
+    h3 {
+      color: $blue;
+    }
+    .quick-item {
+      position: relative;
+      display: block;
+      clear: both;
+      padding: 1rem 1rem 1.5rem;
+      background: transparent;
+
+      &:hover {
+        color: $blue4;
+        border-bottom: none;
+      }
+
+      &:after {
+        height: 2px;
+        background: desaturate(lighten($blue1, 35%), 20%);
+        width: 100%;
+        display: block;
+        content: " ";
+        position: absolute;
+        top: 1px;
+      }
+
+      h4 {
+        display: inline-block;
+        float: left;
+        clear: both;
+        color: $blue4;
+        font-size: 1.125em;
+        width: 30%;
+      }
+      p {
+        display: inline-block;
+        float: right;
+        text-align: left;
+        width: 58%;
+
+      }
+
+    }
+  }
+}

--- a/themes/helm/assets/sass/docs-responsive.scss
+++ b/themes/helm/assets/sass/docs-responsive.scss
@@ -183,21 +183,20 @@
     display: none;
   }
 
-  .cncf-wrap {
-    .cncf {
-      padding-top: 2rem;
-      padding-bottom: 2rem;
+  .cncf {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
 
-      img,
-      p {
-        float: none;
-        min-width: 80%;
-        margin: 1.5rem auto;
-      }
+    img,
+    p {
+      float: none;
+      min-width: 80%;
+      margin: 1.5rem auto;
+    }
 
-      img {
-        max-width: 51%;
-      }
+    img {
+      min-width: 10%;
+      max-width: 40vw;
     }
   }
 }

--- a/themes/helm/assets/sass/docs-sidebar.scss
+++ b/themes/helm/assets/sass/docs-sidebar.scss
@@ -203,8 +203,14 @@
       display: block;
       padding-top: .5rem;
       padding-bottom: .575rem;
-      background-color: $light2;
+      background-color: desaturate(lighten($blue1, 35%), 20%);
+      border: 2px solid lighten($blue1, 17.5%);
       color: $blue3;
+
+      &:hover {
+        background-color: $blue;
+        color: white;
+      }
 
       i {
         margin: -0.05em 0.5em 0 -0.667em;

--- a/themes/helm/layouts/docs/list.html
+++ b/themes/helm/layouts/docs/list.html
@@ -10,75 +10,62 @@ Helm | Docs
   <div class="main home page" id="scrollpane">
 
     <nav class="top-bar">
-
       {{ partial "banner.html" . }}
-        
       <ul class="inline right text-right">
         {{ partial "nav.html" . }}
       </ul>
     </nav>
 
-    <div class="row collapse" id="helm">
-      <div class="small-12 columns home-intro-wrap">
+    <div class="row">
+      <div class="small-1 columns">&nbsp;</div>
+      <div class="small-10 columns content-wrap">
+        {{ .Content }}
 
-        <section class="billboard">
-          <div class="container">
-            {{ .Content }}
-          </div>
-        </section>
-
-        <div class="row home-featured">
-          <div class="small-12 medium-10 small-centered medium-centered columns panels">
-            <h3 class="text-center">Quicklinks</h3>
-            <div class="row">
-              {{ if $isDocsRoot }}
-              {{ $quicklinks := site.Params.quicklinks }}
-              {{ range $quicklinks }}
-              <div class="small-12 large-4 columns">
-                <div class="panel">
-                  <a href="{{ .url }}">
-                    <h3>
-                      {{ .title }}
-                      {{ with .via }}
-                      &nbsp;<small><i class="fa fa-external-link"></i></small>
-                      {{ end }}
-                    </h3>
-                    <p>
-                      {{ .description }}
-                      {{ with .via }}
-                      - <small>
-                        (via {{ . }})
-                      </small>
-                      {{ end }}
-                    </p>
-                  </a>
-                </div>
-              </div>
+        <div class="quick-links">
+          <h3 class="text-center">Quicklinks</h3>
+          
+          {{ if $isDocsRoot }}
+          {{ $quicklinks := site.Params.quicklinks }}
+          {{ range $quicklinks }}
+          <a href="{{ .url }}" class="quick-item"> 
+            <h4>
+              {{ .title }}
+              {{ with .via }}
+              &nbsp;<small><i class="fa fa-external-link"></i></small>
               {{ end }}
-              {{ else }}
-              {{ range .Pages }}
-              <div class="small-12 large-4 columns">
-                <div class="panel">
-                  <a href="{{ .RelPermalink }}">
-                    <h3>
-                      {{ .Title }}
-                    </h3>
-                    <p>
-                      {{ .Description }}
-                    </p>
-                  </a>
-                </div>
-              </div>
+            </h4>
+            <p>
+              {{ .description }}
+              {{ with .via }}
+              - <small>
+                (via {{ . }})
+              </small>
               {{ end }}
-              {{ end }}
-            </div>
-          </div>
+            </p>
+          </a>
+          {{ end }}
+          
+          {{ else }}
+          
+          {{ range .Pages }}
+          <a href="{{ .RelPermalink }}" class="quick-item">
+            <h4>
+              {{ .Title }}
+            </h4>
+            <p>
+              {{ .Description }}
+            </p>
+          </a>
+          {{ end }}
+          {{ end }}
         </div>
 
-        {{ partial "cncf.html" . }}
-
       </div>
-    </div>  
+      <div class="small-1 columns">&nbsp;</div>
+    </div>
   </div>
+
+  {{ partial "cncf.html" . }}
 </div>
+
 {{ end }}

--- a/themes/helm/layouts/docs/single.html
+++ b/themes/helm/layouts/docs/single.html
@@ -34,9 +34,10 @@ Helm | {{ .Title }}
       <div class="small-1 columns">&nbsp;</div>
     </div>
   </div>
-</div>
-{{ end }}
 
-{{ define "footer" }}
-{{ partial "cncf.html" . }}
+  {{ end }}
+
+  {{ define "footer" }}
+  {{ partial "cncf.html" . }}
+</div>
 {{ end }}

--- a/themes/helm/layouts/partials/offcanvas.html
+++ b/themes/helm/layouts/partials/offcanvas.html
@@ -1,3 +1,5 @@
+{{ $docsHome      := .FirstSection }}
+{{ $docsSections  := where site.Sections "Section" "docs" }}
 <aside class="left-off-canvas-menu" id="off-canvas-navigation" data-topbar>
   <div class="drawer-wrap">
 
@@ -7,23 +9,20 @@
           <span class="ripple">Docs Home <span></span></span>
         </a>
       </li>
-      {{ range site.Menus.main }}
-      <li class="sidebar-nav-item toctree-l1 {{if $.IsMenuCurrent "main" . }} active {{end}}">
-        <a class="reference internal" href="{{ .URL | safeHTMLAttr }}" state="">
-          <span class="ripple">{{ .Name }} <span></span></span>
-        </a>
-        {{ if .HasChildren }}
-        <ul class="current">
-          {{ range .Children.ByWeight }}
-          <li class="toctree-l2 {{if $.IsMenuCurrent "main" . }} active {{end}}">
-            <a href="/docs/{{ .Parent | safeHTMLAttr }}/#{{ .URL | safeHTMLAttr }}" title="Switch to {{ .Name }}">
-              {{ .Name }}
-            </a>
-          </li>
-          {{ end }}
-        </ul>
-        {{end}}
-      </li>
+      {{ range $docsSections }}
+      {{ range .Sections }}
+      {{ .Render "section-link" }}
+
+      {{ range .Sections }}
+      {{ .Render "section-link" }}
+      {{ end }}
+      {{ end }}
+
+      {{ range .Pages }}
+      {{ if .Title }}
+      {{ .Render "section-link" }}
+      {{ end }}
+      {{ end }}
       {{ end }}
     </ul>
 


### PR DESCRIPTION
This PR adds a bunch of CSS fixes to the current `v3.helm.sh` docs theme, to fix these issues: #247 #248 #249 #297 #327

### Simpler Section Template
Documentation landing pages no longer use the home page template that was applied in #230 

The homepage design (waves, boat etc) shouldn't appear on pages that prioritize information. These pages display dark text on a clear background, and Quicklinks are now displayed as a tabular list of links rather than the square panels which were going askew.

### Layout Tweaks 

* grid layout fixed for mobile no longer askew 
* mobile menu content updated to render the new menu 
* CNCF footer alignment is visible once again

---

Screenshot:

![helm-quicklinks-fix](https://user-images.githubusercontent.com/686194/68151873-623c3180-fef7-11e9-8756-f1a67ceb52c5.gif)

---

Signed-off-by: flynnduism <flynnduism@gmail.com>