### PR TITLE
fix(docs): remove section "Understanding your Security Context"

### DIFF
--- a/content/docs/intro/quickstart.md
+++ b/content/docs/intro/quickstart.md
@@ -15,7 +15,6 @@ use of Helm.
 2. Deciding what security configurations to apply to your installation, if any
 3. Installing and configuring Helm.
 
-
 ### Install Kubernetes or have access to a cluster
 
 - You must have Kubernetes installed. For the latest release of Helm, we
@@ -25,28 +24,6 @@ use of Helm.
 
 NOTE: Kubernetes versions prior to 1.6 have limited or no support for role-based
 access controls (RBAC).
-
-
-### Understand your Security Context
-
-As with all powerful tools, ensure you are installing it correctly for your
-scenario.
-
-If you're using Helm on a cluster that you completely control, like minikube or
-a cluster on a private network in which sharing is not a concern, the default
-installation -- which applies no security configuration -- is fine, and it's
-definitely the easiest. To install Helm without additional security steps,
-[install Helm](#Install-Helm) and then [initialize Helm](#initialize-helm).
-
-However, if your cluster is exposed to a larger network or if you share your
-cluster with others -- production clusters fall into this category -- you must
-take extra steps to secure your installation to prevent careless or malicious
-actors from damaging the cluster or its data. To apply configurations that
-secure Helm for use in production environments and other multi-tenant scenarios,
-see [Securing a Helm installation](securing_installation.md)
-
-If your cluster has Role-Based Access Control (RBAC) enabled, you may want to
-[configure a service account and rules](rbac.md) before proceeding.
 
 ## Install Helm
 


### PR DESCRIPTION
This section has been removed now that Tiller is no longer a part of Helm 3. More advanced configuration of thei user's Roles and RoleBindings are covered in the topic guide for Role-based Access Control (see #337), but this is no longer a mandatory part of the quickstart guide. This is now an implementation detail based on how Kubernetes was configured.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>