### PR TITLE
fix(index): fix docs link

### DIFF
--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -6,7 +6,7 @@ Helm Docs | Helm
 {{ $home := site.BaseURL }}
 <nav class="top-bar home-nav">
   {{ partial "banner.html" . }}
-    
+
   <h1>
     <a href="{{ $home }}" title="Helm.sh">
       {{ partial "logo.html" . }}
@@ -19,7 +19,7 @@ Helm Docs | Helm
 </nav>
 
 <section class="main-section">
-  
+
   <div id="helm" class="home">
 
     <section class="billboard">
@@ -96,7 +96,7 @@ Helm Docs | Helm
 
             <p><a href="https://github.com/helm/helm"><img src="/img/btn-get-helm.png" alt="Get Helm"></a></p>
 
-            <p>For documentation, see <a href="https://docs.helm.sh/">docs.helm.sh</a></p>
+            <p>The documentation can be found <a href="/docs">here</a>.</p>
 
             <p>The previous version — <a href="https://github.com/deis/helm">Helm Classic</a> — can be found <a href="https://github.com/deis/helm">here</a>.</p>
           </div>
@@ -122,7 +122,7 @@ Helm Docs | Helm
             <div class="row">
               <div class="small-12 medium-12 large-5 helm-community-links columns">
                 <ul>
-                  <li><i class="fa fa-book"></i> <a href="https://docs.helm.sh/">Read the Docs</a></li>
+                  <li><i class="fa fa-book"></i> <a href="/docs">Read the Docs</a></li>
                   <li><i class="fa fa-tags"></i> <a href="https://github.com/helm/helm/releases">Releases</a></li>
                   <li><i class="fa fa-github"></i> <a href="https://github.com/helm/helm">Helm on Github</a></li>
                   <li><i class="fa fa-comments"></i> <a href="http://slack.k8s.io/">Chat #helm-users on Slack</a></li>
@@ -153,7 +153,7 @@ Helm Docs | Helm
 
         </div>
       </div>
-    </div>  
+    </div>
   </div> <!-- / #helm -->
 
 </section>


### PR DESCRIPTION
Several links were hardcoded to `helm.sh` when they should've linked to `/docs`. This way, each version of the landing page will refer to its own documentation.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>