### PR TITLE
add idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ app/*
 resources/
 helm.sh/
 docs.helm.sh/
+
+# JetBrains IDEs (GoLand, IntelliJ, ...) config folder
+.idea


### PR DESCRIPTION
The idea folder contains config files for JetBrains IDEs like GoLand, IntelliJ and others.

Signed-off-by: Daniel Strobusch <1847260+dastrobu@users.noreply.github.com>