### PR TITLE
fix(templates): fix "incorrect" example

### DIFF
--- a/content/docs/topics/chart_best_practices/templates.md
+++ b/content/docs/topics/chart_best_practices/templates.md
@@ -60,9 +60,9 @@ Correct:
 
 Incorrect:
 ```
-{{ .foo }}
-{{ print "foo" }}
-{{- print "bar" -}}
+{{.foo}}
+{{print "foo"}}
+{{-print "bar"-}}
 ```
 
 Templates should chomp whitespace where possible:


### PR DESCRIPTION
The "incorrect" example was demonstrating proper syntax. :1st_place_medal: 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>