### PR TITLE
change references to v2 (older version) and v3 (stable)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://v3.helm.sh/"
+baseurl = "https://helm.sh/"
 languageCode = "en-us"
 title = "Helm"
 theme = "helm"
@@ -14,7 +14,6 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [params]
   title = "Helm"
-  author = "Ronan Flynn-Curran"
   description = "Helm - The Kubernetes Package Manager."
   googleAnalyticsId = "UA-42867143-2"
   googleSiteVerification = "dCa3wS47cErhx0IpaxbB85NfcOP-vFxevknVk6fzf5I"
@@ -31,14 +30,13 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [[params.versions]]
 version = "v3.0.0"
-patch = "unreleased"
-url = "https://v3.helm.sh/docs"
+patch = "stable"
+url = "https://helm.sh/docs"
 primary = true
 
 [[params.versions]]
-version = "v2.14.3"
-patch = "stable"
-url = "https://helm.sh/docs"
+version = "v2.16.1"
+url = "https://v2.helm.sh/docs"
 
 [[params.versions]]
 version = "v2.14.0"

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -8,9 +8,9 @@
     <!-- <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">You are viewing Helm 2 (latest). &nbsp; Helm 3 is here - <a href="https://v3.helm.sh" target="_blank"><strong>Docs</strong></a> | <a href="https://helm.sh/blog/" target="_blank"><strong>Blog</strong></a></small></a></p> -->
 
     <!-- viewing helm 3 version of site (desktop) -->
-    <p class="center text-center show-for-medium-up">You are viewing info for Helm 3 - check the <a href="https://v3.helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://helm.sh"><strong>return to Helm 2</strong></a> for latest stable version.</p>
+    <p class="center text-center show-for-medium-up">You are viewing info for Helm 3 - check the <a href="https://helm.sh/docs/faq/"><strong>version FAQs</strong></a> or <a href="https://v2.helm.sh"><strong>return to Helm 2</strong></a> for prior versions.</p>
 
     <!-- viewing helm 3 version of site (mobile) -->
-    <p class="center show-for-small-only"><a href="https://helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm <strong>3</strong> release. For latest <strong>Helm 2</strong> go here.</small></a></p>
+    <p class="center show-for-small-only"><a href="https://v2.helm.sh/docs"><small style="font-size: 0.9rem;">Viewing Helm <strong>3</strong> release. For <strong>Helm 2</strong> go here.</small></a></p>
   </div>
 </div>


### PR DESCRIPTION
Moves the `stable` label from v2 to v3.
Points v2 references at v2.helm.sh
Points v3 references at helm.sh  