### PR TITLE
add hugo alias redirects for applicable v2 urls

### DIFF
--- a/content/docs/community/developers.md
+++ b/content/docs/community/developers.md
@@ -2,6 +2,7 @@
 title: "Developer Guide"
 description: "Instructions for setting up your environment for developing Helm."
 weight: 1
+aliases: ["/docs/developers/"]
 ---
 
 This guide explains how to set up your environment for developing on Helm.

--- a/content/docs/community/history.md
+++ b/content/docs/community/history.md
@@ -1,6 +1,7 @@
 ---
 title: "The History of the Project"
 description: "Provides a high-level overview of the project's history."
+aliases: ["/docs/history/"]
 ---
 
 Helm 3 is a [CNCF project](https://www.cncf.io/projects/) in the [final stages of incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc).

--- a/content/docs/community/related.md
+++ b/content/docs/community/related.md
@@ -2,6 +2,7 @@
 title: "Related Projects and Documentation"
 description: "third-party tools, plugins and documentation provided by the community!"
 weight: 3
+aliases: ["/docs/related/"]
 ---
 
 The Helm community has produced many extra tools, plugins, and documentation

--- a/content/docs/howto/chart_repository_sync_example.md
+++ b/content/docs/howto/chart_repository_sync_example.md
@@ -2,6 +2,7 @@
 title: "Syncing Your Chart Repository"
 description: "Describes how to synchronize your local and remote chart repositories."
 weight: 2
+aliases: ["/docs/chart_repository_sync_example/"]
 ---
 
 *Note: This example is specifically for a Google Cloud Storage (GCS) bucket

--- a/content/docs/howto/charts_tips_and_tricks.md
+++ b/content/docs/howto/charts_tips_and_tricks.md
@@ -2,6 +2,7 @@
 title: "Chart Development Tips and Tricks"
 description: "Covers some of the tips and tricks Helm chart developers have learned while building production-quality charts."
 weight: 1
+aliases: ["/docs/charts_tips_and_tricks/"]
 ---
 
 This guide covers some of the tips and tricks Helm chart developers have learned

--- a/content/docs/intro/_index.md
+++ b/content/docs/intro/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Introduction"
 weight: 1
+aliases: ["/docs/using_helm/"]
 ---
 
 # Introduction to Helm

--- a/content/docs/intro/getting_started.md
+++ b/content/docs/intro/getting_started.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started with a Chart Template"
 description: "A quick guide on Chart templates."
-aliases: ["/docs/chart_template_guide/#getting-started-with-a-chart-template"]
+aliases: ["/docs/getting_started/"]
 ---
 
 In this section of the guide, we'll create a chart and then add a first

--- a/content/docs/intro/getting_started.md
+++ b/content/docs/intro/getting_started.md
@@ -1,6 +1,7 @@
 ---
 title: "Getting Started with a Chart Template"
 description: "A quick guide on Chart templates."
+aliases: ["/docs/chart_template_guide/#getting-started-with-a-chart-template"]
 ---
 
 In this section of the guide, we'll create a chart and then add a first

--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -2,7 +2,7 @@
 title: "Installing Helm"
 description: "Learn how to install and get running with Helm."
 weight: 2
-aliases: ["/docs/using_helm/#installing-helm"]
+aliases: ["/docs/install/"]
 ---
 
 This guide shows how to install the Helm CLI. Helm can be installed either from

--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -2,6 +2,7 @@
 title: "Installing Helm"
 description: "Learn how to install and get running with Helm."
 weight: 2
+aliases: ["/docs/using_helm/#installing-helm"]
 ---
 
 This guide shows how to install the Helm CLI. Helm can be installed either from

--- a/content/docs/intro/quickstart.md
+++ b/content/docs/intro/quickstart.md
@@ -2,7 +2,7 @@
 title: "Quickstart Guide"
 description: "How to install and get started with Helm including instructions for distros, FAQs, and plugins."
 weight: 1
-aliases: ["/docs/using_helm/#quickstart-guide"]
+aliases: ["/docs/quickstart/"]
 ---
 
 This guide covers how you can quickly get started using Helm.

--- a/content/docs/intro/quickstart.md
+++ b/content/docs/intro/quickstart.md
@@ -2,6 +2,7 @@
 title: "Quickstart Guide"
 description: "How to install and get started with Helm including instructions for distros, FAQs, and plugins."
 weight: 1
+aliases: ["/docs/using_helm/#quickstart-guide"]
 ---
 
 This guide covers how you can quickly get started using Helm.

--- a/content/docs/intro/using_helm.md
+++ b/content/docs/intro/using_helm.md
@@ -2,6 +2,7 @@
 title: "Using Helm"
 description: "Explains the basics of Helm."
 weight: 3
+aliases: ["/docs/using_helm/#using-helm"]
 ---
 
 This guide explains the basics of using Helm to manage packages on your

--- a/content/docs/intro/using_helm.md
+++ b/content/docs/intro/using_helm.md
@@ -2,7 +2,6 @@
 title: "Using Helm"
 description: "Explains the basics of Helm."
 weight: 3
-aliases: ["/docs/using_helm/#using-helm"]
 ---
 
 This guide explains the basics of using Helm to manage packages on your

--- a/content/docs/topics/architecture.md
+++ b/content/docs/topics/architecture.md
@@ -1,6 +1,7 @@
 ---
 title: "Helm Architecture"
 description: "Describes the Helm architecture at a high level."
+aliases: ["/docs/architecture/"]
 ---
 
 # The Kubernetes Helm Architecture

--- a/content/docs/topics/chart_best_practices/_index.md
+++ b/content/docs/topics/chart_best_practices/_index.md
@@ -2,6 +2,7 @@
 title: "Best Practices"
 sidebar: true
 weight: 4
+aliases: ["/docs/chart_best_practices/"]
 ---
 
 # The Chart Best Practices Guide

--- a/content/docs/topics/chart_repository.md
+++ b/content/docs/topics/chart_repository.md
@@ -1,6 +1,7 @@
 ---
 title: "The Chart Repository Guide"
 description: "How to create and work with Helm chart repositories."
+aliases: ["/docs/chart_repository/"]
 ---
 
 # The Chart Repository Guide

--- a/content/docs/topics/chart_template_guide/_index.md
+++ b/content/docs/topics/chart_template_guide/_index.md
@@ -2,6 +2,7 @@
 title: "Developing Templates"
 sidebar: true
 weight: 5
+aliases: ["/docs/chart_template_guide/"]
 ---
 
 # The Chart Template Developer's Guide

--- a/content/docs/topics/chart_tests.md
+++ b/content/docs/topics/chart_tests.md
@@ -1,6 +1,7 @@
 ---
 title: "Chart Tests"
 description: "Describes how to run and test your charts."
+aliases: ["/docs/chart_tests/"]
 ---
 
 A chart contains a number of Kubernetes resources and components that work

--- a/content/docs/topics/charts.md
+++ b/content/docs/topics/charts.md
@@ -1,6 +1,7 @@
 ---
 title: "Charts"
 description: "Explains the chart format, and provides basic guidance for building charts with Helm."
+aliases: ["docs/developing_charts/"]
 ---
 
 Helm uses a packaging format called _charts_. A chart is a collection of files

--- a/content/docs/topics/charts_hooks.md
+++ b/content/docs/topics/charts_hooks.md
@@ -1,6 +1,7 @@
 ---
 title: "Chart Hooks"
 description: "Describes how to work with chart hooks."
+aliases: ["/docs/charts_hooks/"]
 ---
 
 Helm provides a _hook_ mechanism to allow chart developers to intervene at

--- a/content/docs/topics/kubernetes_distros.md
+++ b/content/docs/topics/kubernetes_distros.md
@@ -1,6 +1,7 @@
 ---
 title: "Kubernetes Distribution Guide"
 description: "captures information about using Helm in specific Kubernetes environments."
+aliases: ["/docs/kubernetes_distros/"]
 ---
 
 This document captures information about using Helm in specific Kubernetes

--- a/content/docs/topics/plugins.md
+++ b/content/docs/topics/plugins.md
@@ -1,6 +1,7 @@
 ---
 title: "The Helm Plugins Guide"
 description: "Introduces how to use and create plugins to extend Helm's functionality."
+aliases: ["/docs/plugins/"]
 ---
 
 A Helm plugin is a tool that can be accessed through the `helm` CLI, but which

--- a/content/docs/topics/provenance.md
+++ b/content/docs/topics/provenance.md
@@ -1,6 +1,7 @@
 ---
 title: "Helm Provenance and Integrity"
 description: "Describes how to verify the integrity and origin of a Chart."
+aliases: ["/docs/provenance/"]
 ---
 
 Helm has provenance tools which help chart users verify the integrity and origin

--- a/content/docs/topics/rbac.md
+++ b/content/docs/topics/rbac.md
@@ -1,6 +1,7 @@
 ---
 title: "Role-based Access Control"
 description: "Explains how Helm interacts with Kubernetes' Role-Based Access Control."
+aliases: ["/docs/rbac/"]
 ---
 
 In Kubernetes, granting roles to a user or an application-specific service

--- a/content/docs/topics/registries.md
+++ b/content/docs/topics/registries.md
@@ -1,6 +1,7 @@
 ---
 title: "Registries"
 description: "Describes how to use OCI for Chart distribution."
+aliases: ["/docs/registries/"]
 ---
 
 Helm 3 supports <a href="https://www.opencontainers.org/"


### PR DESCRIPTION
Adds [hugo aliases](v) to pages that have been relocated in v3 docs.

The v3 docs have a different structure with some new directories (mostly `/intro` and `/topics`) and reorganization of content. These redirects are to try and catch as many of the old urls as possible (esp useful for things like links from external sources) and send users to a suitable destination.

e.g.

```
https://helm.sh/docs/using_helm/#quickstart-guide -> https://helm.sh/docs/intro/

https://helm.sh/docs/chart_best_practices/        -> https://helm.sh/docs/topics/chart_best_practices/