### PR TITLE
[v3] fix /blog redirect loop

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,39 +19,3 @@
 [[redirects]]
   from = "https://docs.helm.sh/*"
   to = "https://helm.sh/docs/:splat"
-
-[[redirects]] # from v3 to latest
-  from = "/blog/"
-  to = "https://helm.sh/blog"
-  status = 301
-  force = true
-
-[[redirects]] # from v3 to latest
-  from = "/blog/*"
-  to = "https://helm.sh/blog/:splat"
-  status = 301
-  force = true
-
-[[redirects]] # from v3 to latest
-  from = "https://helm-v3-dev.netlify.com/blog/"
-  to = "https://helm.sh/blog"
-  status = 301
-  force = true
-
-[[redirects]] # from v3 to latest
-  from = "https://helm-v3-dev.netlify.com/blog/*"
-  to = "https://helm.sh/blog/:splat"
-  status = 301
-  force = true
-
-[[redirects]] # from v3 to latest
-  from = "https://v3.helm.sh/blog/"
-  to = "https://helm.sh/blog"
-  status = 301
-  force = true
-
-[[redirects]] # from v3 to latest
-  from = "https://v3.helm.sh/blog/*"
-  to = "https://helm.sh/blog/:splat"
-  status = 301
-  force = true


### PR DESCRIPTION
Following the site version changes, the `/blog` pages are inaccessible due to a redirect loop caused by [this code](https://github.com/helm/helm-www/blob/master/netlify.toml#L23-L57).