### PR TITLE
[v2] site versioning adjustments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,3 +18,39 @@
 [[redirects]]
   from = "https://docs.helm.sh/*"
   to = "https://helm.sh/docs/:splat"
+
+[[redirects]] # from v3 to latest
+  from = "/blog/"
+  to = "https://helm.sh/blog"
+  status = 301
+  force = true
+
+[[redirects]] # from v3 to latest
+  from = "/blog/*"
+  to = "https://helm.sh/blog/:splat"
+  status = 301
+  force = true
+
+[[redirects]] # from v3 to latest
+  from = "https://v2-helm.netlify.com/blog/"
+  to = "https://helm.sh/blog"
+  status = 301
+  force = true
+
+[[redirects]] # from v3 to latest
+  from = "https://v2-helm.netlify.com/blog/*"
+  to = "https://helm.sh/blog/:splat"
+  status = 301
+  force = true
+
+[[redirects]] # from v3 to latest
+  from = "https://v2.helm.sh/blog/"
+  to = "https://helm.sh/blog"
+  status = 301
+  force = true
+
+[[redirects]] # from v3 to latest
+  from = "https://v2.helm.sh/blog/*"
+  to = "https://helm.sh/blog/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
Some small adjustments for the `v2.helm.sh` site.

* update references to different versions
* redirect v2.helm.sh/blog traffic to helm.sh/blog, to ensure users are presented with the latest content