### PR TITLE
Added that CNCF funded sec audit to the blog post

### DIFF
--- a/content/blog/2019-11-04-helm-security-audit-results.md
+++ b/content/blog/2019-11-04-helm-security-audit-results.md
@@ -12,7 +12,7 @@ A security audit is part of the graduation criteria for CNCF projects. Specifica
 
 > Have completed an independent and third party security audit with results published of similar scope and quality as the following example (including critical vulnerabilities addressed): https://github.com/envoyproxy/envoy#security-audit and all critical vulnerabilities need to be addressed before graduation.
 
-During October, [Cure53](https://cure53.de/) performed a security audit of Helm version 3. Cure53 has performed audits of other CNCF projects including Prometheus, Envoy, Jaeger, Notary, and others.
+During October, the CNCF funded [Cure53](https://cure53.de/) to perform a security audit of Helm version 3. Cure53 has performed audits of other CNCF projects including Prometheus, Envoy, Jaeger, Notary, and others.
 
 A [report from the security audit is available in the Helm community repo](https://github.com/helm/community/blob/master/security-audit/HLM-01-report.pdf). We recommend that you take a look at it for the details. The report covers their process, what they reviewed, and what they found. Their review included, but was not limited to:
 


### PR DESCRIPTION
To clear up some ambiguite that arose, it was specifically noted
that the CNCF funded the 3rd party security audit.