### PR TITLE
Fix uninstall default behavior

### DIFF
--- a/content/docs/intro/quickstart.md
+++ b/content/docs/intro/quickstart.md
@@ -99,8 +99,11 @@ $ helm uninstall smiling-penguin
 Removed smiling-penguin
 ```
 
-This will uninstall `smiling-penguin` from Kubernetes, but you will still be
-able to request information about that release:
+This will uninstall `smiling-penguin` from Kubernetes, which will remove all
+resources associated with the release as well as the release history.
+
+If the flag `--keep-history` is provided, release history will be kept. You will 
+be able to request information about that release:
 
 ```console
 $ helm status smiling-penguin


### PR DESCRIPTION
By default, all resources and release history will be deleted. Add
flag `--keep-history` while uninstalling to keep the release history.

Reference: https://github.com/helm/helm/blob/release-3.0/cmd/helm/uninstall.go#L70

Signed-off-by: Jeffrey Chu <peihuachu1112@gmail.com>