### PR TITLE
Update hook and test documentation for Helm 3

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -174,7 +174,7 @@ somewhere. In Helm 2, this was stored in the same namespace as Tiller. In
 practice, this meant that once a name was used by a release, no other release
 could use that same name, even if it was deployed in a different namespace.
 
-In Helm 3, release information about a particular release is now stored in the
+In Helm 3, information about a particular release is now stored in the
 same namespace as the release itself. This means that users can now `helm
 install wordpress stable/wordpress` in two separate namespaces, and each can be
 referred with `helm list` by changing the current namespace context (e.g. `helm

--- a/content/docs/topics/chart_tests.md
+++ b/content/docs/topics/chart_tests.md
@@ -9,32 +9,20 @@ together. As a chart author, you may want to write some tests that validate that
 your chart works as expected when it is installed. These tests also help the
 chart consumer understand what your chart is supposed to do.
 
-A **test** in a helm chart lives under the `templates/` directory and is a pod
+A **test** in a helm chart lives under the `templates/` directory and is a job
 definition that specifies a container with a given command to run. The container
-should exit successfully (exit 0) for a test to be considered a success. The pod
-definition must contain one of the helm test hook annotations: `helm.sh/hook:
-test-success` or `helm.sh/hook: test-failure`.
+should exit successfully (exit 0) for a test to be considered a success. The job
+definition must contain the helm test hook annotation: `helm.sh/hook: test`.
 
 Example tests:
-- Validate that your configuration from the values.yaml file was properly
-  injected.
+
+- Validate that your configuration from the values.yaml file was properly injected.
   - Make sure your username and password work correctly
   - Make sure an incorrect username and password does not work
 - Assert that your services are up and correctly load balancing
 - etc.
 
-You can run the pre-defined tests in Helm on a release using the command `helm
-test <RELEASE_NAME>`. For a chart consumer, this is a great way to sanity check
-that their release of a chart (or application) works as expected.
-
-## A Breakdown of the Helm Test Hooks
-
-In Helm, there are two test hooks: `test-success` and `test-failure`
-
-`test-success` indicates that test pod should complete successfully. In other
-words, the containers in the pod should exit 0. `test-failure` is a way to
-assert that a test pod should not complete successfully. If the containers in
-the pod do not exit 0, that indicates success.
+You can run the pre-defined tests in Helm on a release using the command `helm test <RELEASE_NAME>`. For a chart consumer, this is a great way to sanity check that their release of a chart (or application) works as expected.
 
 ## Example Test
 
@@ -49,53 +37,62 @@ mariadb/
   templates/
   templates/tests/test-mariadb-connection.yaml
 ```
+
 In `wordpress/templates/tests/test-mariadb-connection.yaml`:
+
 ```yaml
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: "{{ .Release.Name }}-credentials-test"
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
-  containers:
-  - name: {{ .Release.Name }}-credentials-test
-    image: {{ .Values.image }}
-    env:
-      - name: MARIADB_HOST
-        value: {{ template "mariadb.fullname" . }}
-      - name: MARIADB_PORT
-        value: "3306"
-      - name: WORDPRESS_DATABASE_NAME
-        value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
-      - name: WORDPRESS_DATABASE_USER
-        value: {{ default "" .Values.mariadb.mariadbUser | quote }}
-      - name: WORDPRESS_DATABASE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ template "mariadb.fullname" . }}
-            key: mariadb-password
-    command: ["sh", "-c", "mysql --host=$MARIADB_HOST --port=$MARIADB_PORT --user=$WORDPRESS_DATABASE_USER --password=$WORDPRESS_DATABASE_PASSWORD"]
-  restartPolicy: Never
+  template:
+    spec:
+      containers:
+      - name: main
+        image: {{ .Values.image }}
+        env:
+        - name: MARIADB_HOST
+          value: {{ template "mariadb.fullname" . }}
+        - name: MARIADB_PORT
+          value: "3306"
+        - name: WORDPRESS_DATABASE_NAME
+          value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
+        - name: WORDPRESS_DATABASE_USER
+          value: {{ default "" .Values.mariadb.mariadbUser | quote }}
+        - name: WORDPRESS_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mariadb.fullname" . }}
+              key: mariadb-password
+        command: ["sh", "-c", "mysql --host=$MARIADB_HOST --port=$MARIADB_PORT --user=$WORDPRESS_DATABASE_USER --password=$WORDPRESS_DATABASE_PASSWORD"]
+      restartPolicy: Never
 ```
 
 ## Steps to Run a Test Suite on a Release
-1. `$ helm install mariadb`
-```
-NAME:   quirky-walrus
-LAST DEPLOYED: Mon Feb 13 13:50:43 2017
-NAMESPACE: default
-STATUS: DEPLOYED
-```
 
+1. `$ helm install mariadb --name quirky-walrus --namespace default`
 2. `$ helm test quirky-walrus`
-```
-RUNNING: quirky-walrus-credentials-test
-SUCCESS: quirky-walrus-credentials-test
+
+```cli
+NAME: quirky-walrus
+LAST DEPLOYED: Mon Feb 13 13:50:43 2019
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+TEST SUITE:     quirky-walrus-credentials-test
+Last Started:   Mon Feb 13 13:51:07 2019
+Last Completed: Mon Feb 13 13:51:18 2019
+Phase:          Succeeded
 ```
 
 ## Notes
+
 - You can define as many tests as you would like in a single yaml file or spread
-  across several yaml files in the `templates/` directory
+  across several yaml files in the `templates/` directory.
 - You are welcome to nest your test suite under a `tests/` directory like
-  `<chart-name>/templates/tests/` for more isolation
+  `<chart-name>/templates/tests/` for more isolation.
+- A test is a [Helm hook](/docs/charts_hooks/), so annotations like `helm.sh/hook-weight`
+  and `helm.sh/hook-delete-policy` may be used with test resources.

--- a/content/docs/topics/chart_tests.md
+++ b/content/docs/topics/chart_tests.md
@@ -73,7 +73,7 @@ spec:
 
 ## Steps to Run a Test Suite on a Release
 
-1. `$ helm install mariadb --name quirky-walrus --namespace default`
+1. `$ helm install quirky-walrus mariadb --namespace default`
 2. `$ helm test quirky-walrus`
 
 ```cli

--- a/content/docs/topics/v2_v3_migration.md
+++ b/content/docs/topics/v2_v3_migration.md
@@ -47,7 +47,7 @@ during migration:
    - `crd-install` hook removed and replaced with `crds` directory in chart
      where all CRDs defined in it will be installed before any rendering of the
      chart
-   - `test-failure` target removed. Use `test-success` instead
+   - `test-failure` hook annotation value removed, and `test-success` deprecated. Use `test` instead
    - Commands removed/replaced/added:
        - delete --> uninstall : removes all release history by default
          (previously needed `--purge`)


### PR DESCRIPTION
This PR brings Helm docs up to date with the changes from https://github.com/helm/helm/pull/6054 and https://github.com/helm/helm/pull/6639.

- Note that `test-success` and `test-failure` hooks are deprecated in favor of `test`
- Update Helm test example to use a `Job` resource instead of a `Pod`
- Indicate that `crd-install` is no longer supported in Helm 3
- Suggest using [TTL controller](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) to clean up Job hooks
- Note that `before-hook-creation` is now the default hook deletion policy
- Warn that garbage collection behavior is subject to change and `helm.sh/resource-policy: keep` should be applied in situations where this is undesirable (see also https://github.com/helm/helm/issues/6364)

View rendered pages:
- https://deploy-preview-395--helm-merge.netlify.com/docs/topics/charts_hooks/
- https://deploy-preview-395--helm-merge.netlify.com/docs/topics/chart_tests/