### PR TITLE
Update homebrew formula name

### DIFF
--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -27,7 +27,7 @@ Members of the Kubernetes community have contributed a Helm formula build to
 Homebrew. This formula is generally up to date.
 
 ```console
-brew install kubernetes-helm
+brew install helm
 ```
 
 (Note: There is also a formula for emacs-helm, which is a different project.)


### PR DESCRIPTION
The homebrew formula name was changed from `kubernetes-helm` to just `helm` with the helm 3 release: Homebrew/homebrew-core#46708
