### PR TITLE
update the docs quicklinks with some common question topics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,13 +56,16 @@ description = "Practical steps for building Helm charts—how to structure, sign
 url = "/docs/topics/charts"
 
 [[params.quicklinks]]
-title = "Deploying to Kubernetes"
-description = "Helm can deploy apps to Kubernetes, with release and rollback versioning"
-url = "https://daemonza.github.io/2017/02/20/using-helm-to-deploy-to-kubernetes"
-via = "daemonza"
+title = "Video: Intro to Helm"
+description = "Watch Matt Farina and Josh Dolitsky present an introduction to Helm at KubeCon 2019."
+url = "https://www.youtube.com/watch?v=Zzwq9FmZdsU"
 
 [[params.quicklinks]]
-title = "CI/CD for Kubernetes"
-description = "Instructions on using Helm as the missing CI/CD Kubernetes component"
-url = "https://medium.com/@gajus/the-missing-ci-cd-kubernetes-component-helm-package-manager-1fe002aac680"
-via = "hackernoon"
+title = "Migrating from v2 to v3"
+description = "Read our blog post on how to migrate from Helm v2 to Helm v3."
+url = "/blog/migrate-from-helm-v2-to-helm-v3/"
+
+[[params.quicklinks]]
+title = "Helm Security Audit"
+description = "Helm has been audited and deemed as recommended for public deployment  during a third-party security audit funded by the CNCF."
+url = "/blog/2019-11-04-helm-security-audit-results/"


### PR DESCRIPTION
The 'quicklink' section should ideally highlight current and interesting topics, but they haven't changed in a long time. This PR changes the ones found on helm.sh/docs to address some of the common questions asked at KubeCon

- what is helm? -> link to the _Intro to Helm_ KubeCon 2019 talk
- what do I do to upgrade to helm 3?  -> link to the migration blog post
- is helm secure? -> link to the announcement about the security audit results

![Screen Shot 2019-11-22 at 1 21 04 PM](https://user-images.githubusercontent.com/686194/69461281-095bfe00-0d2b-11ea-8039-ca991a1e1148.png)
