### PR TITLE
Add weights to topics with multiple pages

### DIFF
--- a/content/docs/topics/chart_best_practices/conventions.md
+++ b/content/docs/topics/chart_best_practices/conventions.md
@@ -1,6 +1,7 @@
 ---
 title: "General Conventions"
 description: "general conventions for charts."
+weight: 1
 ---
 
 This part of the Best Practices Guide explains general conventions.

--- a/content/docs/topics/chart_best_practices/custom_resource_definitions.md
+++ b/content/docs/topics/chart_best_practices/custom_resource_definitions.md
@@ -1,6 +1,7 @@
 ---
 title: "Custom Resource Definitions"
 description: "How to handle creating and using CRDs."
+weight: 7
 ---
 
 This section of the Best Practices Guide deals with creating and using Custom

--- a/content/docs/topics/chart_best_practices/dependencies.md
+++ b/content/docs/topics/chart_best_practices/dependencies.md
@@ -1,6 +1,7 @@
 ---
 title: "Dependencies"
 description: "Covers best practices for Chart dependencies."
+weight: 4
 ---
 
 This section of the guide covers best practices for `dependencies` declared in

--- a/content/docs/topics/chart_best_practices/labels.md
+++ b/content/docs/topics/chart_best_practices/labels.md
@@ -1,6 +1,7 @@
 ---
 title: "Labels and Annotations"
 description: "Covers best practices for using labels and annotations in your Chart."
+weight: 5
 ---
 
 This part of the Best Practices Guide discusses the best practices for using

--- a/content/docs/topics/chart_best_practices/pods.md
+++ b/content/docs/topics/chart_best_practices/pods.md
@@ -1,6 +1,7 @@
 ---
 title: "Pods and PodTemplates"
 description: "Discusses formatting the Pod and PodTemplate portions in Chart manifests."
+weight: 6
 ---
 
 This part of the Best Practices Guide discusses formatting the Pod and

--- a/content/docs/topics/chart_best_practices/rbac.md
+++ b/content/docs/topics/chart_best_practices/rbac.md
@@ -1,6 +1,7 @@
 ---
 title: "Role-Based Access Control"
 description: "Discusses the creation and formatting of RBAC resources in Chart manifests."
+weight: 8
 ---
 
 This part of the Best Practices Guide discusses the creation and formatting of

--- a/content/docs/topics/chart_best_practices/templates.md
+++ b/content/docs/topics/chart_best_practices/templates.md
@@ -1,6 +1,7 @@
 ---
 title: "Templates"
 description: "A closer look at best practices surrounding templates."
+weight: 3
 ---
 
 This part of the Best Practices Guide focuses on templates.

--- a/content/docs/topics/chart_best_practices/values.md
+++ b/content/docs/topics/chart_best_practices/values.md
@@ -1,6 +1,7 @@
 ---
 title: "Values"
 description: "Focuses on how you should structure and use your values."
+weight: 2
 ---
 
 This part of the best practices guide covers using values. In this part of the

--- a/content/docs/topics/chart_template_guide/accessing_files.md
+++ b/content/docs/topics/chart_template_guide/accessing_files.md
@@ -1,6 +1,7 @@
 ---
 title: "Accessing Files Inside Templates"
 description: "How to access files from within a template."
+weight: 8
 ---
 
 In the previous section we looked at several ways to create and access named

--- a/content/docs/topics/chart_template_guide/builtin_objects.md
+++ b/content/docs/topics/chart_template_guide/builtin_objects.md
@@ -1,6 +1,7 @@
 ---
 title: "Built-in Objects"
 description: "Built-in objects available to templates."
+weight: 2
 ---
 
 Objects are passed into a template from the template engine. And your code can

--- a/content/docs/topics/chart_template_guide/control_structures.md
+++ b/content/docs/topics/chart_template_guide/control_structures.md
@@ -1,6 +1,7 @@
 ---
 title: "Flow Control"
 description: "A quick overview on the flow structure within templates."
+weight: 5
 ---
 
 Control structures (called "actions" in template parlance) provide you, the

--- a/content/docs/topics/chart_template_guide/data_types.md
+++ b/content/docs/topics/chart_template_guide/data_types.md
@@ -1,6 +1,7 @@
 ---
 title: "Appendix: Go Data Types and Templates"
 description: "A quick overview on variables in templates."
+weight: 13
 ---
 
 The Helm template language is implemented in the strongly typed Go programming

--- a/content/docs/topics/chart_template_guide/debugging.md
+++ b/content/docs/topics/chart_template_guide/debugging.md
@@ -1,6 +1,7 @@
 ---
 title: "Debugging Templates"
 description: "Troubleshooting charts that are failing to deploy."
+weight: 11
 ---
 
 Debugging templates can be tricky because the rendered templates are sent to the

--- a/content/docs/topics/chart_template_guide/functions_and_pipelines.md
+++ b/content/docs/topics/chart_template_guide/functions_and_pipelines.md
@@ -1,6 +1,7 @@
 ---
 title: "Template Functions and Pipelines"
 description: "Using functions in templates."
+weight: 4
 ---
 
 So far, we've seen how to place information into a template. But that

--- a/content/docs/topics/chart_template_guide/named_templates.md
+++ b/content/docs/topics/chart_template_guide/named_templates.md
@@ -1,6 +1,7 @@
 ---
 title: "Named Templates"
 description: "How to define named templates."
+weight: 7
 ---
 
 It is time to move beyond one template, and begin to create others. In this

--- a/content/docs/topics/chart_template_guide/notes_files.md
+++ b/content/docs/topics/chart_template_guide/notes_files.md
@@ -1,6 +1,7 @@
 ---
 title: "Creating a NOTES.txt File"
 description: "How to provide instructions to your Chart users."
+weight: 9
 ---
 
 In this section we are going to look at Helm's tool for providing instructions

--- a/content/docs/topics/chart_template_guide/subcharts_and_globals.md
+++ b/content/docs/topics/chart_template_guide/subcharts_and_globals.md
@@ -1,6 +1,7 @@
 ---
 title: "Subcharts and Global Values"
 description: "Interacting with a subchart's and global values."
+weight: 10
 ---
 
 To this point we have been working only with one chart. But charts can have

--- a/content/docs/topics/chart_template_guide/values_files.md
+++ b/content/docs/topics/chart_template_guide/values_files.md
@@ -1,6 +1,7 @@
 ---
 title: "Values Files"
 description: "Instructions on how to use the --values flag."
+weight: 3
 ---
 
 In the previous section we looked at the built-in objects that Helm templates

--- a/content/docs/topics/chart_template_guide/variables.md
+++ b/content/docs/topics/chart_template_guide/variables.md
@@ -1,6 +1,7 @@
 ---
 title: "Variables"
 description: "Using variables in templates."
+weight: 6
 ---
 
 With functions, pipelines, objects, and control structures under our belts, we

--- a/content/docs/topics/chart_template_guide/yaml_techniques.md
+++ b/content/docs/topics/chart_template_guide/yaml_techniques.md
@@ -1,6 +1,7 @@
 ---
 title: "YAML Techniques"
 description: "A closer look at the YAML specification and how it applies to Helm."
+weight: 12
 ---
 
 Most of this guide has been focused on writing the template language. Here,


### PR DESCRIPTION
Hopefully resolves #405 by adding a `weight:` to each subtopic page and replicating the v2 docs order.


Signed-off-by: Stephen Brown II <Stephen.Brown2@gmail.com>