### PR TITLE
Multiple service accounts example correction

### DIFF
--- a/content/docs/topics/chart_best_practices/rbac.md
+++ b/content/docs/topics/chart_best_practices/rbac.md
@@ -11,7 +11,7 @@ RBAC resources are:
 
 - ServiceAccount (namespaced)
 - Role (namespaced)
-- ClusterRole 
+- ClusterRole
 - RoleBinding (namespaced)
 - ClusterRoleBinding
 
@@ -38,11 +38,12 @@ This structure can be extended for more complex charts that require multiple
 ServiceAccounts.
 
 ```yaml
-serviceAccounts:
-  client:
+someComponent:
+  serviceAccount:
     create: true
     name:
-  server: 
+anotherComponent:
+  serviceAccount:
     create: true
     name:
 ```


### PR DESCRIPTION
It makes more sense to have a component's service account values under itself in the values file.