### PR TITLE
Specify more flags to curl

### DIFF
--- a/content/docs/intro/install.md
+++ b/content/docs/intro/install.md
@@ -52,7 +52,7 @@ You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
 
 ```console
-$ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 $ chmod 700 get_helm.sh
 $ ./get_helm.sh
 ```


### PR DESCRIPTION
These flags make it easier to detect if there is an error downloading
the get_helm.sh script.

Signed-off-by: Craig Rodrigues <craig@portworx.com>