### PR TITLE
[#424] remove duplicate javascript

### DIFF
--- a/themes/helm/assets/js/app.js
+++ b/themes/helm/assets/js/app.js
@@ -42,12 +42,3 @@ $(function() {
     }
   });
 });
-
-{{ if $isDoc }}
-<script async src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
-  apiKey: '8bca76b0664b04581dc9f9854e844a90',
-  indexName: 'helm',
-  inputSelector: '#q',
-  debug: false // Set debug to true if you want to inspect the dropdown
-  })"></script>
-{{ end }}


### PR DESCRIPTION
This PR solves #424 and resolves a javascript error on the docs site, which was caused by the search tool code being included a second time. 😊

Signed-off-by: flynnduism <flynnduism@gmail.com>