### PR TITLE
[docs] Resort and reorganize the chart_template_guide

### DIFF
--- a/content/docs/chart_template_guide/_index.md
+++ b/content/docs/chart_template_guide/_index.md
@@ -1,8 +1,7 @@
 ---
-title: "Developing Templates"
-sidebar: true
+title: "Chart Template Guide"
 weight: 5
-aliases: ["/docs/chart_template_guide/"]
+aliases: ["/topics/chart_template_guide/"]
 ---
 
 # The Chart Template Developer's Guide

--- a/content/docs/chart_template_guide/accessing_files.md
+++ b/content/docs/chart_template_guide/accessing_files.md
@@ -1,7 +1,7 @@
 ---
 title: "Accessing Files Inside Templates"
 description: "How to access files from within a template."
-weight: 8
+weight: 9
 ---
 
 In the previous section we looked at several ways to create and access named

--- a/content/docs/chart_template_guide/builtin_objects.md
+++ b/content/docs/chart_template_guide/builtin_objects.md
@@ -1,7 +1,7 @@
 ---
 title: "Built-in Objects"
 description: "Built-in objects available to templates."
-weight: 2
+weight: 3
 ---
 
 Objects are passed into a template from the template engine. And your code can

--- a/content/docs/chart_template_guide/control_structures.md
+++ b/content/docs/chart_template_guide/control_structures.md
@@ -1,7 +1,7 @@
 ---
 title: "Flow Control"
 description: "A quick overview on the flow structure within templates."
-weight: 5
+weight: 6
 ---
 
 Control structures (called "actions" in template parlance) provide you, the

--- a/content/docs/chart_template_guide/data_types.md
+++ b/content/docs/chart_template_guide/data_types.md
@@ -1,7 +1,7 @@
 ---
 title: "Appendix: Go Data Types and Templates"
 description: "A quick overview on variables in templates."
-weight: 13
+weight: 16
 ---
 
 The Helm template language is implemented in the strongly typed Go programming

--- a/content/docs/chart_template_guide/debugging.md
+++ b/content/docs/chart_template_guide/debugging.md
@@ -1,7 +1,7 @@
 ---
 title: "Debugging Templates"
 description: "Troubleshooting charts that are failing to deploy."
-weight: 11
+weight: 13
 ---
 
 Debugging templates can be tricky because the rendered templates are sent to the

--- a/content/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/docs/chart_template_guide/functions_and_pipelines.md
@@ -1,7 +1,7 @@
 ---
 title: "Template Functions and Pipelines"
 description: "Using functions in templates."
-weight: 4
+weight: 5
 ---
 
 So far, we've seen how to place information into a template. But that

--- a/content/docs/chart_template_guide/getting_started.md
+++ b/content/docs/chart_template_guide/getting_started.md
@@ -1,7 +1,9 @@
 ---
-title: "Getting Started with a Chart Template"
+title: "Getting Started"
+weight: 2
 description: "A quick guide on Chart templates."
-aliases: ["/docs/getting_started/"]
+aliases: ["/intro/getting_started/"]
+
 ---
 
 In this section of the guide, we'll create a chart and then add a first

--- a/content/docs/chart_template_guide/helm_ignore_file.md
+++ b/content/docs/chart_template_guide/helm_ignore_file.md
@@ -1,0 +1,27 @@
+---
+title: "The .helmignore file"
+description: "The `.helmignore` file is used to specify files you don't want to include in your helm chart."
+weight: 12
+---
+
+The `.helmignore` file is used to specify files you don't want to include in your helm chart.
+
+If this file exists, the `helm package` command will ignore all the files that match the pattern specified in the `.helmignore` file while packaging your application.
+
+This can help in avoiding unnecessary or sensitive files or directories from being added in your helm chart.
+
+The `.helmignore` file supports Unix shell glob matching, relative path matching, and negation (prefixed with !). Only one pattern per line is considered.
+
+Here is an example `.helmignore` file:
+
+```
+# comment
+.git
+*/temp*
+*/*/temp*
+temp?
+```
+
+**We'd love your help** making this document better. To add, correct, or remove
+information, [file an issue](https://github.com/helm/helm/issues) or
+send us a pull request.

--- a/content/docs/chart_template_guide/named_templates.md
+++ b/content/docs/chart_template_guide/named_templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Named Templates"
 description: "How to define named templates."
-weight: 7
+weight: 8
 ---
 
 It is time to move beyond one template, and begin to create others. In this

--- a/content/docs/chart_template_guide/notes_files.md
+++ b/content/docs/chart_template_guide/notes_files.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating a NOTES.txt File"
 description: "How to provide instructions to your Chart users."
-weight: 9
+weight: 10
 ---
 
 In this section we are going to look at Helm's tool for providing instructions

--- a/content/docs/chart_template_guide/subcharts_and_globals.md
+++ b/content/docs/chart_template_guide/subcharts_and_globals.md
@@ -1,7 +1,7 @@
 ---
 title: "Subcharts and Global Values"
 description: "Interacting with a subchart's and global values."
-weight: 10
+weight: 11
 ---
 
 To this point we have been working only with one chart. But charts can have
@@ -35,7 +35,7 @@ $ rm -rf mysubchart/templates/*.*
 
 Notice that just as before, we deleted all of the base templates so that we can
 start from scratch. In this guide, we are focused on how templates work, not on
-managing dependencies. But the [Charts Guide]({{< ref "../charts.md" >}}) has more information
+managing dependencies. But the [Charts Guide]({{< ref "../topics/charts.md" >}}) has more information
 on how subcharts work.
 
 ## Adding Values and a Template to the Subchart

--- a/content/docs/chart_template_guide/values_files.md
+++ b/content/docs/chart_template_guide/values_files.md
@@ -1,7 +1,7 @@
 ---
 title: "Values Files"
 description: "Instructions on how to use the --values flag."
-weight: 3
+weight: 4
 ---
 
 In the previous section we looked at the built-in objects that Helm templates

--- a/content/docs/chart_template_guide/variables.md
+++ b/content/docs/chart_template_guide/variables.md
@@ -1,7 +1,7 @@
 ---
 title: "Variables"
 description: "Using variables in templates."
-weight: 6
+weight: 7
 ---
 
 With functions, pipelines, objects, and control structures under our belts, we

--- a/content/docs/chart_template_guide/wrapping_up.md
+++ b/content/docs/chart_template_guide/wrapping_up.md
@@ -1,0 +1,26 @@
+---
+title: "Next Steps"
+description: "Wrapping up - some useful pointers to other documentation that will help you."
+weight: 14
+---
+
+This guide is intended to give you, the chart developer, a strong understanding of how to use Helm's template language. The guide focuses on the technical aspects of template development.
+
+But there are many things this guide has not covered when it comes to the practical day-to-day development of charts. Here are some useful pointers to other documentation that will help you as you create new charts:
+
+- The [Helm Charts project](https://github.com/helm/charts) is an indispensable source of charts. That project is also sets the standard for best practices in chart development.
+- The Kubernetes [Documentation](https://kubernetes.io/docs/home/) provides detailed examples of the various resource kinds that you can use, from ConfigMaps and Secrets to DaemonSets and Deployments.
+- The Helm [Charts Guide](../charts.md) explains the workflow of using charts.
+- The Helm [Chart Hooks Guide](../charts_hooks.md) explains how to create lifecycle hooks.
+- The Helm [Charts Tips and Tricks](../charts_tips_and_tricks.md) article provides some useful tips for writing charts.
+- The [Sprig documentation](https://github.com/Masterminds/sprig) documents more than sixty of the template functions.
+- The [Go template docs](https://godoc.org/text/template) explain the template syntax in detail.
+- The [Schelm tool](https://github.com/databus23/schelm) is a nice helper utility for debugging charts.
+
+Sometimes it's easier to ask a few questions and get answers from experienced developers. The best place to do this is in the [Kubernetes Slack](https://kubernetes.slack.com) Helm channels:
+
+- [#helm-users](https://kubernetes.slack.com/messages/helm-users)
+- [#helm-dev](https://kubernetes.slack.com/messages/helm-dev)
+- [#charts](https://kubernetes.slack.com/messages/charts)
+
+Finally, if you find errors or omissions in this document, want to suggest some new content, or would like to contribute, visit [The Helm Project](https://github.com/helm/helm).

--- a/content/docs/chart_template_guide/yaml_techniques.md
+++ b/content/docs/chart_template_guide/yaml_techniques.md
@@ -1,7 +1,7 @@
 ---
-title: "YAML Techniques"
+title: "Appendix: YAML Techniques"
 description: "A closer look at the YAML specification and how it applies to Helm."
-weight: 12
+weight: 15
 ---
 
 Most of this guide has been focused on writing the template language. Here,


### PR DESCRIPTION
In this PR I've added weight to the `chart_template_guide` section of the docs, to restore the correct sort order as per the v2 docs:

<img width="280" alt="Screen Shot 2019-12-11 at 10 54 50 AM" src="https://user-images.githubusercontent.com/686194/70651569-ecb63600-1c05-11ea-884a-49e1bc908f6a.png">

Fixes #434.

---

Notes:

* **Regrouping Section** - when the v3 docs [were reorganized](https://github.com/helm/helm-www/commit/7f4422d8f13f57f3f27fd612f3c3c24f597f59ee#diff-1c03d9f049788a11e0339e13c7146d6b) into `intro` and `topics` subfolders, somehow the Chart Template Guide files were spread across these different directories and any navigational flow was lost. Here I have regrouped them as best I can.
* **Menu Label** - I changed _Developing Templates_ to _Chart Template Guide_ to better match the content therein.
* **Missing Files!** - the **[.helmignore File](https://v2.helm.sh/docs/chart_template_guide/#the-helmignore-file)** and **[Next Steps](https://v2.helm.sh/docs/chart_template_guide/#wrapping-up)** docs are missing from v3. Here's the v2 one. **Is this accidental or intentional**? If we're not sure we should reinstate these. 

Signed-off-by: flynnduism <flynnduism@gmail.com>