### PR TITLE
Adding the CVE id assigned to this vulnerability

### DIFF
--- a/content/blog/2019-10-30-helm-symlink-security-notice.md
+++ b/content/blog/2019-10-30-helm-symlink-security-notice.md
@@ -1,5 +1,5 @@
 ---
-title: "Helm Vulnerability: Client Loading and Packaging Chart Directory Containing Malicious Symlinked Content"
+title: "Helm Vulnerability: Client Loading and Packaging Chart Directory Containing Malicious Symlinked Content [CVE-2019-18658]"
 authorname: "Matt Farina"
 author: "@mattfarina"
 authorlink: "https://mattfarina.com"


### PR DESCRIPTION
The CVE assigned to this can be found at
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18658

Adding the CVE id this was follows the method previously done.
In the future we made (should?) use the new system provided by
GitHub. This is an update to a post from prior to that system.