### PR TITLE
suggest expanding OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,10 @@
 maintainers:
+  - bacongobbler
+  - bridgetkromhout
   - flynnduism
   - hickeyma
+  - jdolitsky
+  - karenhchu
   - mattfarina
-  - bridgetkromhout
-  - bacongobbler
-  - vdice
-  - karenhchu 
+  - technosophos
+  - thomastaylor312


### PR DESCRIPTION
The [`OWNERS.md`](https://github.com/helm/helm-www/blob/master/OWNERS) was shaped around managing the blog and tweaking the website - that is insufficient now that the documentation has moved to this repo from `helm/helm`. 

This PR queue now requires more technical review from the core team, so here I'm adding [maintainers](https://github.com/helm/helm/blob/master/OWNERS) who have been recently active in editing the docs - @jdolitsky @thomastaylor312 @technosophos.