### PR TITLE
fix broken links on wrapping_up

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
   ]
 
 [[params.versions]]
-version = "v3.0.0"
+version = "v3.0.2"
 patch = "stable"
 url = "https://helm.sh/docs"
 primary = true

--- a/content/en/docs/chart_template_guide/wrapping_up.md
+++ b/content/en/docs/chart_template_guide/wrapping_up.md
@@ -10,9 +10,9 @@ But there are many things this guide has not covered when it comes to the practi
 
 - The [Helm Charts project](https://github.com/helm/charts) is an indispensable source of charts. That project is also sets the standard for best practices in chart development.
 - The Kubernetes [Documentation](https://kubernetes.io/docs/home/) provides detailed examples of the various resource kinds that you can use, from ConfigMaps and Secrets to DaemonSets and Deployments.
-- The Helm [Charts Guide](../charts.md) explains the workflow of using charts.
-- The Helm [Chart Hooks Guide](../charts_hooks.md) explains how to create lifecycle hooks.
-- The Helm [Charts Tips and Tricks](../charts_tips_and_tricks.md) article provides some useful tips for writing charts.
+- The Helm [Charts Guide](../../topics/charts/) explains the workflow of using charts.
+- The Helm [Chart Hooks Guide](../../topics/charts_hooks/) explains how to create lifecycle hooks.
+- The Helm [Charts Tips and Tricks](../../howto/charts_tips_and_tricks/) article provides some useful tips for writing charts.
 - The [Sprig documentation](https://github.com/Masterminds/sprig) documents more than sixty of the template functions.
 - The [Go template docs](https://godoc.org/text/template) explain the template syntax in detail.
 - The [Schelm tool](https://github.com/databus23/schelm) is a nice helper utility for debugging charts.


### PR DESCRIPTION
Preview of fixed links [here](https://5e2898b7297c4f0008ddfa8c--helm-merge.netlify.com/docs/chart_template_guide/wrapping_up/).

Closes #473 and [#7454](https://github.com/helm/helm/issues/7454)