### PR TITLE
remove numerical value for top-level objects

### DIFF
--- a/content/en/docs/chart_template_guide/values_files.md
+++ b/content/en/docs/chart_template_guide/values_files.md
@@ -5,8 +5,8 @@ weight: 4
 ---
 
 In the previous section we looked at the built-in objects that Helm templates
-offer. One of the four built-in objects is `Values`. This object provides access
-to values passed into the chart. Its contents come from four sources:
+offer. One of the built-in objects is `Values`. This object provides access
+to values passed into the chart. Its contents come from multiple sources:
 
 - The `values.yaml` file in the chart
 - If this is a subchart, the `values.yaml` file of a parent chart


### PR DESCRIPTION
more may be added as time goes on, so we should remove this from the documentation to prevent updating the value.

follow-up from #437

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>