### PR TITLE
Fix --timeout flag

### DIFF
--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -371,7 +371,7 @@ not a full list of cli flags. To see a description of all flags, just run `helm
 <command> --help`.
 
 - `--timeout`: A value in seconds to wait for Kubernetes commands to complete
-  This defaults to 300 (5 minutes)
+  This defaults to `5m0s`
 - `--wait`: Waits until all Pods are in a ready state, PVCs are bound,
   Deployments have minimum (`Desired` minus `maxUnavailable`) Pods in ready
   state and Services have an IP address (and Ingress if a `LoadBalancer`) before


### PR DESCRIPTION
This PR fixes the documentation regarding the usage of the `--timeout` flag.
Using `--timeout` without a time unit results in error in helm 3.

Somehow related with https://github.com/helm/helm/issues/7375