### PR TITLE
Add script to sync generated docs from helm#master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ docs.helm.sh/
 
 # JetBrains IDEs (GoLand, IntelliJ, ...) config folder
 .idea
+
+scripts/update-docs/.tmp.docs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "helm"]
 	path = scripts/update-docs/helm
-	url = git@github.com:helm/helm.git
+	url = https://github.com/helm/helm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "helm"]
+	path = scripts/update-docs/helm
+	url = git@github.com:helm/helm.git

--- a/README.md
+++ b/README.md
@@ -43,14 +43,7 @@ For earlier versions, see the dev-v2 branch of the main Helm repo [here](https:/
 
 The documentation for the list of Helm CLI Commands are [exported](https://github.com/helm/helm/blob/a6b2c9e2126753f6f94df231e89b2153c2862764/cmd/helm/root.go#L169) from the main helm project repo and rendered [here on the website](https://helm.sh/docs/helm) as a reference.
 
-To update these docs, you'll need to:
-
-1. Go to the `helm/helm` repo and fetch the latest master.
-2. Run `helm docs --type markdown` to generate the markdown docs files
-3. Copy the generated files (helm.md, helm_create.md, etc)
-4. Return to the `helm/helm-www` repo and navigate to `content/en/docs/helm/`
-5. Paste the latest CLI command docs here, replacing any prior markdown files
-6. Commit the changes and create a PR to update the website.
+To update these docs simply run `yarn update-docs`.
 
 
 ### How to Write a Blog Post

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "last 2 versions",
     "Firefox ESR",
     "not dead"
-  ]
+  ],
+  "scripts": {
+    "update-docs": "./scripts/update-docs/update-docs.sh"
+  }
 }

--- a/scripts/update-docs/update-docs.sh
+++ b/scripts/update-docs/update-docs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Abort if anything messes up, namely to avoid `git reset --hard` in our working repo
+# or `rsync --delete`ing valid doc templates
+set -e
+
+# Init submodules
+git submodule update --init --recursive
+
+pushd scripts/update-docs/
+
+# Ensure we've created our temp doc directory, but don't fail if we have already
+mkdir .tmp.docs || :
+
+# Make sure the submodule is pointing at master; note this may introduce pending changes 
+pushd helm
+git fetch
+git reset --hard origin/master
+helm docs --type=markdown --dir ../.tmp.docs
+popd
+rsync --recursive --delete ./.tmp.docs/ ../../content/en/docs/helm/
+popd 
+
+echo Docs updated.


### PR DESCRIPTION
Signed-off-by: Zachary Brown <z@charybrown.com>

 - Adds `yarn update-docs` command
 - Adds a git submodule pointing to `github.com:helm/helm.git` for the purpose of pulling the latest docs
 - Uses rsync to delete extraneous files, resolving an issue which has led to staleness e.g. as documented here https://github.com/helm/helm/issues/6996#issuecomment-582065733

To take it for a spin, pull down this branch and run `yarn update-docs`

Admittedly an opinionated approach: assumes presence of `bash` and `rsync`, willingness to use `git submodule`s, and `rsync` — but perhaps suitable for maintainers.  Feel free to use, modify, or discard.