### PR TITLE
add notes for depricated commands

### DIFF
--- a/content/en/docs/helm/helm_delete.md
+++ b/content/en/docs/helm/helm_delete.md
@@ -1,7 +1,7 @@
 ---
-section: depreciated
+section: deprecated
 ---
 
 ## helm delete
 
-This command has been depricated. Please refer instead to [helm uninstall](../helm_uninstall/).
+This command has been renamed. Please refer instead to [helm uninstall](../helm_uninstall/).

--- a/content/en/docs/helm/helm_delete.md
+++ b/content/en/docs/helm/helm_delete.md
@@ -1,0 +1,7 @@
+---
+section: depreciated
+---
+
+## helm delete
+
+This command has been depricated. Please refer instead to [helm uninstall](../helm_uninstall/).

--- a/content/en/docs/helm/helm_inspect.md
+++ b/content/en/docs/helm/helm_inspect.md
@@ -1,0 +1,7 @@
+---
+section: depreciated
+---
+
+## helm inspect
+
+This command has been depricated. Please refer instead to [helm show](../helm_show/).

--- a/content/en/docs/helm/helm_inspect.md
+++ b/content/en/docs/helm/helm_inspect.md
@@ -1,7 +1,7 @@
 ---
-section: depreciated
+section: deprecated
 ---
 
 ## helm inspect
 
-This command has been depricated. Please refer instead to [helm show](../helm_show/).
+This command has been renamed. Please refer instead to [helm show](../helm_show/).


### PR DESCRIPTION
Some older v2 commands have been deleted and/or renamed, and the CLI docs were causing confusion... @bacongobbler has cleaned this up in #485 👏👏👏 

This PR is a follow-up to add some deprecation notes to the docs.

---

`helm inspect` is now `helm show` and `helm delete` is `helm uninstall`.

![Screen Shot 2020-02-04 at 12 09 29 PM](https://user-images.githubusercontent.com/686194/73795985-e0aba800-4760-11ea-80d5-32343d2888fe.png)

These commands see a fair amount of search activity. We could add Hugo Aliases or to the Netlify config to simply redirect the user to the new command, but I think it's worthwhile to clarify the change that took place, even if it takes the user one more click to get to the result. 

![Screen Shot 2020-02-04 at 3 17 43 PM](https://user-images.githubusercontent.com/686194/73796214-85c68080-4761-11ea-8bd7-0654a800071c.png)

_Example stub page._

Note these _"stub"_ doc pages for the old commands are **excluded from appearing in the main left menu**, they are accessible only via searching or directly typing out the old command url. We don't want to present them in the top-level list of _actual_ commands.

Signed-off-by: flynnduism <dev@ronan.design>