### PR TITLE
Fix GitHub spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
     - Any PR with the `size/large` label requires 2 review approvals from maintainers before it can be
     merged. Those with `size/medium` or `size/small` are per the judgement of the maintainers.
 4. Reviewing/Discussion
-    - All reviews will be completed using Github review tool.
+    - All reviews will be completed using GitHub review tool.
     - A "Comment" review should be used when there are questions about the code that should be
     answered, but that don't involve code changes. This type of review does not count as approval.
     - A "Changes Requested" review indicates that changes to the code need to be made before they will be merged.

--- a/content/en/blog/2018-12-11-helm-hub.md
+++ b/content/en/blog/2018-12-11-helm-hub.md
@@ -13,7 +13,7 @@ With this in mind, we are delighted to announce the launch of the [Helm Hub](htt
 
 ![Helm Hub](https://helm.sh/img/blog/helm-hub.png)
 
-Helm repositories can be hosted in many ways including as GitHub or Gitlab pages, in object storage, using [Chartmuseum](https://github.com/helm/chartmuseum), and via a service provider.
+Helm repositories can be hosted in many ways including as GitHub or GitLab pages, in object storage, using [Chartmuseum](https://github.com/helm/chartmuseum), and via a service provider.
 
 If you have a chart repository you would like listed please head over to the [hub repository on GitHub](https://github.com/helm/hub) and follow the directions. The process is as simple as a pull request.
 

--- a/content/en/blog/2019-06-10-get-helm-sh.md
+++ b/content/en/blog/2019-06-10-get-helm-sh.md
@@ -27,7 +27,7 @@ If you're using the old URL in your CI pipeline, you can replace <https://kubern
 
 If you're using [the get script](https://helm.sh/docs/using_helm/#from-script), it is now [pulling from the new URL](https://github.com/helm/helm/blob/2ca025d48222d6fa188653e2ca5eda6ed799145c/scripts/get#L114), so no changes on your end are required.
 
-All the download URLs in our [Github releases](https://github.com/helm/helm/releases) have also been changed to use the new URL.
+All the download URLs in our [GitHub releases](https://github.com/helm/helm/releases) have also been changed to use the new URL.
 
 ## What's under the hood?
 

--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -73,7 +73,7 @@ request](https://github.com/helm/helm-www/pulls).
 - [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories
   on Google Cloud Storage
 - [helm-github](https://github.com/sagansystems/helm-github) - Plugin to install
-  Helm Charts from Github repositories
+  Helm Charts from GitHub repositories
 - [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - Plugin to
   monitor a release and rollback based on Prometheus/ElasticSearch query
 - [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm

--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -31,7 +31,7 @@ progress](https://github.com/helm/helm/issues/1038) in GitHub.
 Because a chart repository can be any HTTP server that can serve YAML and tar
 files and can answer GET requests, you have a plethora of options when it comes
 down to hosting your own chart repository. For example, you can use a Google
-Cloud Storage (GCS) bucket, Amazon S3 bucket, Github Pages, or even create your
+Cloud Storage (GCS) bucket, Amazon S3 bucket, GitHub Pages, or even create your
 own web server.
 
 ### The chart repository structure
@@ -145,7 +145,7 @@ You can also set up chart repositories using JFrog Artifactory. Read more about
 chart repositories with JFrog Artifactory
 [here](https://www.jfrog.com/confluence/display/RTF/Helm+Chart+Repositories)
 
-### Github Pages example
+### GitHub Pages example
 
 In a similar way you can create charts repository using GitHub Pages.
 
@@ -163,15 +163,15 @@ locally as.
 $ git checkout -b gh-pages
 ```
 
-Or via web browser using **Branch** button on your Github repository:
+Or via web browser using **Branch** button on your GitHub repository:
 
-![Create Github Pages branch](https://helm.sh/img/create-a-gh-page-button.png)
+![Create GitHub Pages branch](https://helm.sh/img/create-a-gh-page-button.png)
 
-Next, you'll want to make sure your **gh-pages branch** is set as Github Pages,
-click on your repo **Settings** and scroll down to **Github pages** section and
+Next, you'll want to make sure your **gh-pages branch** is set as GitHub Pages,
+click on your repo **Settings** and scroll down to **GitHub pages** section and
 set as per below:
 
-![Create Github Pages branch](https://helm.sh/img/set-a-gh-page.png)
+![Create GitHub Pages branch](https://helm.sh/img/set-a-gh-page.png)
 
 By default **Source** usually gets set to **gh-pages branch**. If this is not
 set by default, then select it.

--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -9,7 +9,7 @@ is not part of the built-in Helm codebase.
 
 Existing plugins can be found on [related]({{< ref "related.md#helm-plugins" >}}) section or
 by searching
-[Github](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
+[GitHub](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
 
 This guide explains how to use and create plugins.
 

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -124,7 +124,7 @@ Helm Docs | Helm
 
           <div class="small-12 medium-12 large-7 get-helm columns">
             <h2>Get Helm!</h2>
-            <p>The Helm project can be found <a href="https://github.com/helm/helm">here on Github</a>:</p>
+            <p>The Helm project can be found <a href="https://github.com/helm/helm">here on GitHub</a>:</p>
 
             <p><a href="https://github.com/helm/helm"><img src="/img/btn-get-helm.png" alt="Get Helm"></a></p>
 
@@ -156,7 +156,7 @@ Helm Docs | Helm
                 <ul>
                   <li><i class="fa fa-book"></i> <a href="/docs">Read the Docs</a></li>
                   <li><i class="fa fa-tags"></i> <a href="https://github.com/helm/helm/releases">Releases</a></li>
-                  <li><i class="fa fa-github"></i> <a href="https://github.com/helm/helm">Helm on Github</a></li>
+                  <li><i class="fa fa-github"></i> <a href="https://github.com/helm/helm">Helm on GitHub</a></li>
                   <li><i class="fa fa-comments"></i> <a href="http://slack.k8s.io/">Chat #helm-users on Slack</a></li>
                 </ul>
               </div>

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -23,7 +23,7 @@
 -->
 
 <li><a href="https://twitter.com/helmpack" target="_blank" class="hide-for-small-only" title="Helm on Twitter"><img src="/img/twitter.svg" alt="Helm on twitter" /></a></li>
-<li><a href="https://github.com/helm/helm" target="_blank" class="hide-for-small-only" title="Helm on Github"><img src="/img/github.svg" alt="Github" /></a></li>
+<li><a href="https://github.com/helm/helm" target="_blank" class="hide-for-small-only" title="Helm on GitHub"><img src="/img/github.svg" alt="GitHub" /></a></li>
 
 <li class="nav-dropdown">
   {{ with $primary }}


### PR DESCRIPTION
Just a few minor typo fixes: `Github` -> `GitHub`.