### PR TITLE
docs(helm): Clarify GPG key selection for `package --sign`

### DIFF
--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -45,8 +45,10 @@ the name under which the signing key is known and the keyring containing the
 corresponding private key:
 
 ```console
-$ helm package --sign --key 'helm signing key' --keyring path/to/keyring.secret mychart
+$ helm package --sign --key 'John Smith' --keyring path/to/keyring.secret mychart
 ```
+
+**Note:** The value of the `--key` argument must be a substring of the desired key's `uid` (in the output of `gpg --list-keys`), for example the name or email. **The fingerprint _cannot_ be used.**
 
 **TIP:** for GnuPG users, your secret keyring is in `~/.gnupg/secring.gpg`. You
 can use `gpg --list-secret-keys` to list the keys you have.


### PR DESCRIPTION
I was confused by this piece of documentation because I thought `helm signing key` meant "the fingerprint of the desired key". However, [that doesn't work](https://github.com/helm/helm/issues/7631).