### PR TITLE
Add link checker to site build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ docs.helm.sh/
 
 # JetBrains IDEs (GoLand, IntelliJ, ...) config folder
 .idea
+
+# Link checker artifacts
+bin/
+tmp/

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,4 @@
+DirectoryPath: app
+IgnoreDirectoryMissingTrailingSlash: true
+CheckExternal: false
+IgnoreAltMissing: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+clean:
+	rm -rf app resources
+
+build:
+	hugo --minify
+
+set-up-link-checker:
+	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash
+
+run-link-checker:
+	bin/htmltest
+
+check-links: clean build set-up-link-checker run-link-checker

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ clean:
 build:
 	hugo --minify
 
+build-preview:
+	hugo \
+	--baseURL $(DEPLOY_PRIME_URL) \
+	--buildDrafts \
+	--buildFuture \
+	--minify
+
 set-up-link-checker:
 	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 clean:
 	rm -rf app resources
 
-build:
+build: clean
 	hugo --minify
 
-build-preview:
+	make check-links-ci
+
+build-preview: clean
 	hugo \
 	--baseURL $(DEPLOY_PRIME_URL) \
 	--buildDrafts \
 	--buildFuture \
 	--minify
+
+	make check-links-ci
 
 set-up-link-checker:
 	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash
@@ -17,4 +21,4 @@ set-up-link-checker:
 run-link-checker:
 	bin/htmltest
 
-check-links: clean build set-up-link-checker run-link-checker
+check-links-ci: set-up-link-checker run-link-checker

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,9 @@
 [build]
-  base    = ""
   command = "make build"
   publish = "app"
 
 [build.environment]
-  HUGO_VERSION = "0.55.6"
+  HUGO_VERSION = "0.65.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,14 +1,20 @@
 [build]
   base    = ""
-  command = "hugo --minify"
+  command = "make build"
   publish = "app"
 
 [build.environment]
   HUGO_VERSION = "0.55.6"
+  HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]
   HUGO_ENV = "production"
-  HUGO_ENABLEGITINFO = "true"
+
+[context.deploy-preview]
+  command = "make build-preview"
+
+[context.branch-deploy]
+  command = "make build-preview"
 
 # redirect docs homepage
 [[redirects]]

--- a/themes/helm/layouts/_default/_markup/render-link.html
+++ b/themes/helm/layouts/_default/_markup/render-link.html
@@ -1,0 +1,10 @@
+{{ $link := .Destination }}
+{{ $isRemote := strings.HasPrefix $link "http" }}
+{{- if not $isRemote -}}
+{{ $url := urls.Parse .Destination }}
+{{- if $url.Path -}}
+{{ $fragment := "" }}
+{{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+{{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end }}{{ end -}}
+{{- end -}}
+<a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}</a>


### PR DESCRIPTION
This PR does a few things:

1. Adds link checking, provided by [htmltest](https://github.com/wjdp/htmltest), to the site build
2. Adds a Hugo [render hook](https://gohugo.io/getting-started/configuration-markup/#render-hook-templates) for links in Markdown files. This hook will automatically convert Markdown links à la `/foo/bar.md` into `/foo/bar`, so we won't need to convert these anymore. In fact, if someone wants to convert those *back* to Markdown links, go for it.
3. Puts all of the site's build logic into a `Makefile`.

This will resolve issues like the one addressed in #501.