### PR TITLE
Add note about tested release

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -21,6 +21,10 @@ and installed.
 
 From there, you should be able to run the client and [add the stable repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository): `helm help`.
 
+**Note:** Helm automated tests are performed for Linux AMD64 only during CircleCi
+builds and releases. Testing of other OSes are the responsibility of the community
+requesting Helm for the OS in question. 
+
 ### From Homebrew (macOS)
 
 Members of the Kubernetes community have contributed a Helm formula build to


### PR DESCRIPTION
This note was recommended when discussing the addition of tests for s390x platform (https://github.com/helm/helm/pull/7096).

It was decided at the meeting that Helm community would continue to accommodate builds  for different platforms and allow tests for those platforms but would be performing automated tests for the Linux AMD64 platform only (as previously). The responsibility however for the testing and validation of Helm for the other platforms is the responsibility of the community which requests Helm for that platform. 