### PR TITLE
[#499] [#522] fix code block styling issues

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -133,3 +133,8 @@ weight = 4
 
 [languages.zh.params]
 language_alternatives = ["en"]
+
+[markup]
+  [markup.highlight]
+    style = "manni"
+    guessSyntax = true

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -53,7 +53,7 @@ description: A single-sentence description of this project (optional)
 type: It is the type of chart (optional)
 keywords:
   - A list of keywords about this project (optional)
-home: The URL of this project's home page (optional)
+home: The URL of this projects home page (optional)
 sources:
   - A list of URLs to source code for this project (optional)
 dependencies: # A list of the chart requirements (optional)
@@ -68,8 +68,8 @@ dependencies: # A list of the chart requirements (optional)
       - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
     alias: (optional) Alias usable alias to be used for the chart. Useful when you have to add the same chart multiple times
 maintainers: # (optional)
-  - name: The maintainer's name (required for each maintainer)
-    email: The maintainer's email (optional for each maintainer)
+  - name: The maintainers name (required for each maintainer)
+    email: The maintainers email (optional for each maintainer)
     url: A URL for the maintainer (optional for each maintainer)
 icon: A URL to an SVG or PNG image to be used as an icon (optional).
 appVersion: The version of the app that this contains (optional). This needn't be SemVer.

--- a/themes/helm/assets/sass/docs-content.scss
+++ b/themes/helm/assets/sass/docs-content.scss
@@ -126,8 +126,6 @@
 
   &.markdown pre,
   pre {
-    background-color: #e4f3f9;
-    color: black;
     border: none;
     padding: 0.75em 1em;
     margin: 0.25em 0 2.5em;
@@ -135,7 +133,7 @@
 
     code {
       padding: 0;
-      background-color: #e4f3f9;
+      background: transparent;
       font-size: 1rem;
     }
   }
@@ -144,7 +142,6 @@
     margin: 0px;
     width: 100%;
     height: 220px;
-    border-bottom: 3px solid $grey1;
     overflow: auto;
   }
 
@@ -153,9 +150,7 @@
   }
 
   code {
-    color: black;
     padding: 0.5em 0.5em;
-    background-color: #e4f3f9;
     border: none;
     font-size: 1rem;
   }


### PR DESCRIPTION
Code blocks on the site are having style issues, due to differences in the version of Hugo being used between local dev and  production. More recent version of Hugo apply code syntax highlighting to all blocks during the site build, which is causing conflicts with the site stylesheet.

Example:

<img width="721" alt="Screen Shot 2020-03-02 at 8 49 22 PM" src="https://user-images.githubusercontent.com/686194/75743883-71759500-5cc7-11ea-8b65-c27154472e93.png">

This PR cleans up the conflict in styles, and adds [config options](https://gohugo.io/getting-started/configuration-markup#highlight) to specify a light [code theme](https://xyproto.github.io/splash/docs/manni.html) which will suit the site.

With the changes:

<img width="868" alt="Screen Shot 2020-03-02 at 8 48 50 PM" src="https://user-images.githubusercontent.com/686194/75743832-3e330600-5cc7-11ea-87bf-f0e43d34a389.png">

---

Closes #499 and #205 
