### PR TITLE
[#524] fix left nav duplicated links

### DIFF
--- a/content/en/docs/chart_best_practices/_index.md
+++ b/content/en/docs/chart_best_practices/_index.md
@@ -2,7 +2,7 @@
 title: "Best Practices"
 sidebar: true
 weight: 4
-aliases: ["/docs/chart_best_practices/"]
+aliases: ["/docs/topics/chart_best_practices/"]
 ---
 
 # The Chart Best Practices Guide

--- a/content/en/docs/chart_best_practices/conventions.md
+++ b/content/en/docs/chart_best_practices/conventions.md
@@ -2,6 +2,7 @@
 title: "General Conventions"
 description: "General conventions for charts."
 weight: 1
+aliases: ["/docs/topics/chart_best_practices/conventions/"]
 ---
 
 This part of the Best Practices Guide explains general conventions.

--- a/content/en/docs/chart_best_practices/custom_resource_definitions.md
+++ b/content/en/docs/chart_best_practices/custom_resource_definitions.md
@@ -2,6 +2,7 @@
 title: "Custom Resource Definitions"
 description: "How to handle creating and using CRDs."
 weight: 7
+aliases: ["/docs/topics/chart_best_practices/custom_resource_definitions/"]
 ---
 
 This section of the Best Practices Guide deals with creating and using Custom

--- a/content/en/docs/chart_best_practices/dependencies.md
+++ b/content/en/docs/chart_best_practices/dependencies.md
@@ -2,6 +2,7 @@
 title: "Dependencies"
 description: "Covers best practices for Chart dependencies."
 weight: 4
+aliases: ["/docs/topics/chart_best_practices/dependencies/"]
 ---
 
 This section of the guide covers best practices for `dependencies` declared in

--- a/content/en/docs/chart_best_practices/labels.md
+++ b/content/en/docs/chart_best_practices/labels.md
@@ -2,6 +2,7 @@
 title: "Labels and Annotations"
 description: "Covers best practices for using labels and annotations in your Chart."
 weight: 5
+aliases: ["/docs/topics/chart_best_practices/labels/"]
 ---
 
 This part of the Best Practices Guide discusses the best practices for using

--- a/content/en/docs/chart_best_practices/pods.md
+++ b/content/en/docs/chart_best_practices/pods.md
@@ -2,6 +2,7 @@
 title: "Pods and PodTemplates"
 description: "Discusses formatting the Pod and PodTemplate portions in Chart manifests."
 weight: 6
+aliases: ["/docs/topics/chart_best_practices/pods/"]
 ---
 
 This part of the Best Practices Guide discusses formatting the Pod and

--- a/content/en/docs/chart_best_practices/rbac.md
+++ b/content/en/docs/chart_best_practices/rbac.md
@@ -2,6 +2,7 @@
 title: "Role-Based Access Control"
 description: "Discusses the creation and formatting of RBAC resources in Chart manifests."
 weight: 8
+aliases: ["/docs/topics/chart_best_practices/rbac/"]
 ---
 
 This part of the Best Practices Guide discusses the creation and formatting of

--- a/content/en/docs/chart_best_practices/templates.md
+++ b/content/en/docs/chart_best_practices/templates.md
@@ -2,6 +2,7 @@
 title: "Templates"
 description: "A closer look at best practices surrounding templates."
 weight: 3
+aliases: ["/docs/topics/chart_best_practices/templates/"]
 ---
 
 This part of the Best Practices Guide focuses on templates.

--- a/content/en/docs/chart_best_practices/values.md
+++ b/content/en/docs/chart_best_practices/values.md
@@ -2,6 +2,7 @@
 title: "Values"
 description: "Focuses on how you should structure and use your values."
 weight: 2
+aliases: ["/docs/topics/chart_best_practices/values/"]
 ---
 
 This part of the best practices guide covers using values. In this part of the

--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -1,10 +1,16 @@
 ---
 title: "Frequently Asked Questions"
-description: "What are the key differences between Helm 2 and Helm 3? Visit the FAQs for insights."
 weight: 8
+aliases: [
+  "/docs/topics/faq/",
+  "/docs/faq/"
+]
 ---
 
-This page provides help with the most common questions about Helm.
+# Frequently Asked Questions
+
+> What are the key differences between Helm 2 and Helm 3?  
+> This page provides help with the most common questions.
 
 **We'd love your help** making this document better. To add, correct, or remove
 information, [file an issue](https://github.com/helm/helm-www/issues) or send us

--- a/content/en/docs/glossary/_index.md
+++ b/content/en/docs/glossary/_index.md
@@ -4,6 +4,8 @@ description: "Terms used to describe components of Helm's architecture."
 weight: 9
 ---
 
+# Glossary
+
 ## Chart
 
 A Helm package that contains information sufficient for installing a set of

--- a/themes/helm/layouts/partials/sidebar.html
+++ b/themes/helm/layouts/partials/sidebar.html
@@ -22,19 +22,15 @@
         </li>
 
         {{ range $docsSections }}
-        {{ range .Sections }}
-        {{ .Render "section-link" }}
+          {{ range .Sections }}
+            
+            {{ .Render "section-link" }}
 
-        {{ range .Sections }}
-        {{ .Render "section-link" }}
-        {{ end }}
-        {{ end }}
-
-        {{ range .Pages }}
-        {{ if .Title }}
-        {{ .Render "section-link" }}
-        {{ end }}
-        {{ end }}
+            {{ range .Sections }}
+              {{ .Render "section-link" }}
+            {{ end }}
+          
+          {{ end }}
         {{ end }}
       </ul>
     </nav>

--- a/themes/helm/layouts/partials/sidebar.html
+++ b/themes/helm/layouts/partials/sidebar.html
@@ -22,14 +22,18 @@
         </li>
 
         {{ range $docsSections }}
-          {{ range .Sections }}
-            
+          <!-- {{ range .Sections }}
             {{ .Render "section-link" }}
 
             {{ range .Sections }}
               {{ .Render "section-link" }}
             {{ end }}
-          
+          {{ end }} -->
+
+          {{ range .Pages }}
+            {{ if .Title }}
+              {{ .Render "section-link" }}
+            {{ end }}
           {{ end }}
         {{ end }}
       </ul>

--- a/themes/helm/layouts/partials/sidebar.html
+++ b/themes/helm/layouts/partials/sidebar.html
@@ -1,5 +1,4 @@
 {{ $docsHome      := .FirstSection }}
-{{ $docsSections  := where site.Sections "Section" "docs" }}
 <div class="sidebar">
   <div class="is-visible-mobile" id="sidebar-toggle">Browse Docs <span class="icon"><i class="mdi mdi-arrow-down"></i></span></div>
 

--- a/themes/helm/layouts/partials/sidebar.html
+++ b/themes/helm/layouts/partials/sidebar.html
@@ -21,19 +21,9 @@
           </a>
         </li>
 
-        {{ range $docsSections }}
-          <!-- {{ range .Sections }}
+        {{ range .Pages }}
+          {{ if .Title }}
             {{ .Render "section-link" }}
-
-            {{ range .Sections }}
-              {{ .Render "section-link" }}
-            {{ end }}
-          {{ end }} -->
-
-          {{ range .Pages }}
-            {{ if .Title }}
-              {{ .Render "section-link" }}
-            {{ end }}
           {{ end }}
         {{ end }}
       </ul>

--- a/themes/helm/layouts/partials/sidebar.html
+++ b/themes/helm/layouts/partials/sidebar.html
@@ -1,6 +1,6 @@
 {{ $docsHome      := .FirstSection }}
 <div class="sidebar">
-  <div class="is-visible-mobile" id="sidebar-toggle">Browse Docs <span class="icon"><i class="mdi mdi-arrow-down"></i></span></div>
+  <div class="is-visible-mobile is-hidden-desktop" id="sidebar-toggle">Browse Docs <span class="icon"><i class="mdi mdi-arrow-down"></i></span></div>
 
   <div class="sidebar-content-wrapper">
     <div class="search-container">
@@ -20,11 +20,14 @@
           </a>
         </li>
 
-        {{ range .Pages }}
-          {{ if .Title }}
-            {{ .Render "section-link" }}
+        {{ range (where .Site.Pages "Section" "docs") }}
+          {{ range .Sections }}
+            {{ if .Title }}
+              {{ .Render "section-link" }}
+            {{ end }}
           {{ end }}
         {{ end }}
+
       </ul>
     </nav>
 


### PR DESCRIPTION
This PR fixes #524. Thanks @hickeyma for spotting that glitch.

---

### Sidebar Duplication

This issue is resolved by changing the range of content shown in the left sidebar.

![compare](https://user-images.githubusercontent.com/686194/76018684-55474300-5ed5-11ea-9c7c-efd48893ee55.png)


### Dir change for Best Practices

In changing how the sidebar is generated, the _Chart Best Practices_ section disappeared from the menu, as it sat as a child of the Topics directory. To restore it to the side menu, I moved this directory to the docs root, and added aliases to redirect anyone who uses the prior url structure.