### PR TITLE
Snapcraft installation instructions added

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -46,6 +46,15 @@ package](https://chocolatey.org/packages/kubernetes-helm) build to
 choco install kubernetes-helm
 ```
 
+### From Snap (Linux)                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                     
+The [Snapcrafters](https://github.com/snapcrafters) community maintains the
+Snap version of the [Helm package](https://snapcraft.io/helm):
+
+```console
+sudo snap install helm --classic
+```
+
 ## From Script
 
 Helm now has an installer script that will automatically grab the latest version

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -89,6 +89,7 @@ Helm
           <li id="tablinks"><a href="#Chocolatey">Chocolatey</a></li>
           <li id="tablinks"><a href="#Scoop">Scoop</a></li>
           <li id="tablinks"><a href="#Gofish">GoFish</a></li>
+          <li id="tablinks"><a href="#Snap">Snap</a></li>
         </ul>
         <div class="tabgroup">
           <div class="tabcontent" id="Homebrew">
@@ -106,6 +107,10 @@ Helm
           <div class="tabcontent" id="Gofish">
             <input id="copyfish" value="gofish install helm" />
             <button data-clipboard-target="#copyfish" class="button">{{ T "action_copy" }}</button>
+          </div>
+          <div class="tabcontent" id="Snap">
+            <input id="copysnap" value="sudo snap install helm --classic" />
+            <button data-clipboard-target="#copysnap" class="button">{{ T "action_copy" }}</button>
           </div>
         </div>
 


### PR DESCRIPTION
Helm is available as a snap - https://snapcraft.io/helm; added this to the installation options.

Also, this PR is an addition to https://github.com/helm/helm/pull/7827

Signed-off-by: Ihor Dvoretskyi <ihor@linux.com>