### PR TITLE
Specifies the order of the topics

### DIFF
--- a/content/en/docs/topics/advanced.md
+++ b/content/en/docs/topics/advanced.md
@@ -2,6 +2,7 @@
 title: "Advanced Helm Techniques"
 description: "Explains various advanced features for Helm power users"
 aliases: ["/docs/advanced_helm_techniques"]
+weight: 9
 ---
 
 This section explains various advanced features and techniques for using Helm.

--- a/content/en/docs/topics/architecture.md
+++ b/content/en/docs/topics/architecture.md
@@ -2,6 +2,7 @@
 title: "Helm Architecture"
 description: "Describes the Helm architecture at a high level."
 aliases: ["/docs/architecture/"]
+weight: 8
 ---
 
 # The Kubernetes Helm Architecture

--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -2,6 +2,7 @@
 title: "The Chart Repository Guide"
 description: "How to create and work with Helm chart repositories."
 aliases: ["/docs/chart_repository/"]
+weight: 6
 ---
 
 This section explains how to create and work with Helm chart repositories. At a

--- a/content/en/docs/topics/chart_tests.md
+++ b/content/en/docs/topics/chart_tests.md
@@ -2,6 +2,7 @@
 title: "Chart Tests"
 description: "Describes how to run and test your charts."
 aliases: ["/docs/chart_tests/"]
+weight: 3
 ---
 
 A chart contains a number of Kubernetes resources and components that work

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -2,6 +2,7 @@
 title: "Charts"
 description: "Explains the chart format, and provides basic guidance for building charts with Helm."
 aliases: ["docs/developing_charts/"]
+weight: 1
 ---
 
 Helm uses a packaging format called _charts_. A chart is a collection of files

--- a/content/en/docs/topics/charts_hooks.md
+++ b/content/en/docs/topics/charts_hooks.md
@@ -2,6 +2,7 @@
 title: "Chart Hooks"
 description: "Describes how to work with chart hooks."
 aliases: ["/docs/charts_hooks/"]
+weight: 2
 ---
 
 Helm provides a _hook_ mechanism to allow chart developers to intervene at

--- a/content/en/docs/topics/kubernetes_distros.md
+++ b/content/en/docs/topics/kubernetes_distros.md
@@ -2,6 +2,7 @@
 title: "Kubernetes Distribution Guide"
 description: "Captures information about using Helm in specific Kubernetes environments."
 aliases: ["/docs/kubernetes_distros/"]
+weight: 10
 ---
 
 This document captures information about using Helm in specific Kubernetes

--- a/content/en/docs/topics/library_charts.md
+++ b/content/en/docs/topics/library_charts.md
@@ -2,6 +2,7 @@
 title: "Library Charts"
 description: "Explains library chars and examples of usage"
 aliases: ["docs/library_charts/"]
+weight: 4
 ---
 
 A library chart is a type of [Helm chart]({{< ref "/docs/topics/charts.md" >}}) that defines chart primitives or definitions which can be shared by Helm templates in other charts. This allows users to share snippets of code that can be re-used across charts, avoiding repetition and keeping charts [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).

--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -2,6 +2,7 @@
 title: "The Helm Plugins Guide"
 description: "Introduces how to use and create plugins to extend Helm's functionality."
 aliases: ["/docs/plugins/"]
+weight: 12
 ---
 
 A Helm plugin is a tool that can be accessed through the `helm` CLI, but which

--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -2,6 +2,7 @@
 title: "Helm Provenance and Integrity"
 description: "Describes how to verify the integrity and origin of a Chart."
 aliases: ["/docs/provenance/"]
+weight: 5
 ---
 
 Helm has provenance tools which help chart users verify the integrity and origin

--- a/content/en/docs/topics/rbac.md
+++ b/content/en/docs/topics/rbac.md
@@ -2,6 +2,7 @@
 title: "Role-based Access Control"
 description: "Explains how Helm interacts with Kubernetes' Role-Based Access Control."
 aliases: ["/docs/rbac/"]
+weight: 11
 ---
 
 In Kubernetes, granting roles to a user or an application-specific service

--- a/content/en/docs/topics/registries.md
+++ b/content/en/docs/topics/registries.md
@@ -2,6 +2,7 @@
 title: "Registries"
 description: "Describes how to use OCI for Chart distribution."
 aliases: ["/docs/registries/"]
+weight: 7
 ---
 
 Helm 3 supports <a href="https://www.opencontainers.org/"

--- a/content/en/docs/topics/v2_v3_migration.md
+++ b/content/en/docs/topics/v2_v3_migration.md
@@ -1,6 +1,7 @@
 ---
 title: "Migrating Helm v2 to v3"
 description: "Learn how to migrate Helm v2 to v3."
+weight: 13
 ---
 
 This guide shows how to migrate  Helm v2 to v3. Helm v2 needs to be installed


### PR DESCRIPTION
The topics were in no particular order. Sometimes this did not
flow well. For example, the sections on chart hooks and chart
tests came before the material on charts.

This change specifies an order to the documents which shows up
in the navigation.