### PR TITLE
Noting that README is displaed on hubs

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -212,6 +212,9 @@ generally contain:
 - Any other information that may be relevant to the installation or
   configuration of the chart
 
+When hubs and other user interfaces display details about a chart that detail
+is pulled from the content in the `README.md` file.
+
 The chart can also contain a short plain text `templates/NOTES.txt` file that
 will be printed out after installation, and when viewing the status of a
 release. This file is evaluated as a [template](#templates-and-values), and can


### PR DESCRIPTION
On hubs, like the Helm Hub, there are charts that do not display
content and the authors are unsure of why. Hubs pull that info
from README files. This has not been explicitly stated thus far.
Adding to the docs to make people aware