### PR TITLE
Chart doc fixes

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -690,7 +690,7 @@ cannot be overridden. As with all values, the names are _case sensitive_.
   will not give you access to templates, but will give you access to additional
   files that are present (unless they are excluded using `.helmignore`). Files
   can be accessed using `{{ index .Files "file.name" }}` or using the `{{
-  .Files.Get name }}` or `{{ .Files.GetString name }}` functions. You can also
+  .Files.Get name }}` function. You can also
   access the contents of the file as `[]byte` using `{{ .Files.GetBytes }}`
 - `Capabilities`: A map-like object that contains information about the versions
   of Kubernetes (`{{ .Capabilities.KubeVersion }}` and the supported Kubernetes

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -75,6 +75,8 @@ maintainers: # (optional)
 icon: A URL to an SVG or PNG image to be used as an icon (optional).
 appVersion: The version of the app that this contains (optional). This needn't be SemVer.
 deprecated: Whether this chart is deprecated (optional, boolean)
+annotations:
+  example: A list of annotations keyed by name (optional).
 ```
 
 Other fields will be silently ignored.


### PR DESCRIPTION
Two chart documentation files...

1. Removing the `GetString` function which does not exist
2. Documenting `annotations` which can be listed in a `Chart.yaml` file