### PR TITLE
Remove reference to `helm home` command on plugins page

### DIFF
--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -27,7 +27,7 @@ Helm plugins have the following features:
 - They can be written in any programming language.
 - They integrate with Helm, and will show up in `helm help` and other places.
 
-Helm plugins live in `$XDG_DATA_HOME/plugins`.
+Helm plugins live in `$XDG_DATA_HOME/helm/plugins`.
 
 The Helm plugin model is partially modeled on Git's plugin model. To that end,
 you may sometimes hear `helm` referred to as the _porcelain_ layer, with plugins
@@ -40,15 +40,16 @@ the user experience and top level processing logic, while the plugins do the
 Plugins are installed using the `$ helm plugin install <path|url>` command. You
 can pass in a path to a plugin on your local file system or a url of a remote
 VCS repo. The `helm plugin install` command clones or copies the plugin at the
-path/url given into `$XDG_DATA_HOME/plugins`
+path/url given into `$XDG_DATA_HOME/helm/plugins`
 
 ```console
 $ helm plugin install https://github.com/adamreese/helm-env
 ```
 
-If you have a plugin tar distribution, simply untar the plugin into the `$(helm
-home)/plugins` directory. You can also install tarball plugins directly from url
-by issuing `helm plugin install https://domain/path/to/plugin.tar.gz`
+If you have a plugin tar distribution, simply untar the plugin into the
+`$XDG_DATA_HOME/helm/plugins` directory. You can also install tarball plugins
+directly from url by issuing `helm plugin install
+https://domain/path/to/plugin.tar.gz`
 
 ## Building Plugins
 
@@ -56,7 +57,7 @@ In many ways, a plugin is similar to a chart. Each plugin has a top-level
 directory, and then a `plugin.yaml` file.
 
 ```
-$XDG_DATA_HOME/plugins/
+$XDG_DATA_HOME/helm/plugins/
   |- keybase/
       |
       |- plugin.yaml


### PR DESCRIPTION
The `home` command was removed in helm v3.

This commit also updates the location of the plugin directory to
`$XDG_DATA_HOME/helm/plugins` which is the location the helm CLI lists
as the default path:

```
$ helm --help
[...]
Helm stores configuration based on the XDG base directory specification, so

- cached files are stored in $XDG_CACHE_HOME/helm
- configuration is stored in $XDG_CONFIG_HOME/helm
- data is stored in $XDG_DATA_HOME/helm
[...]
```