### PR TITLE
Add helm-secrets

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -29,6 +29,7 @@ request](https://github.com/helm/helm-www/pulls).
   [private] chart repository
 - [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) - Helm Plugin that generates
   values yaml schema for your Helm 3 charts
+- [helm-secrets](https://github.com/jkroepke/helm-secrets) - Plugin to manage and store secrets safely (based on [sops](https://github.com/mozilla/sops)) 
 
 We also encourage GitHub authors to use the
 [helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories) tag on their plugin


### PR DESCRIPTION
Hi,

as in https://github.com/helm/helm-www/pull/567 mentioned correctly the helm-secrets project gets inactive.

helm-secrets is a great plugin because with you want to store secret in an encrypted format. encryption on rest is default compliance rule in a lot of companies in germany.

Since is this mandatory for us I will continue to maintain it.

URL to project: https://github.com/jkroepke/helm-secrets