### PR TITLE
Fix replacement of `--` with – (en dash)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,12 @@ guessSyntax = true
 [Permalinks]
 code = "/:filename/"
 
+[blackfriday]
+smartypants = false
+smartDashes = false
+angledQuotes = false
+latexDashes = false
+
 [params]
 title = "Helm"
 description = "Helm - The Kubernetes Package Manager."


### PR DESCRIPTION
Disable the smartypants and smartDashes rendering of markdown files.

In some sections `--set-files` or other instructions are replaced with `–set-files`. Which leads to copy/paste errors.