### PR TITLE
Disable typographer extension in markup parsing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,9 @@ plainIdAnchors = "true"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [markup]
+[markup.goldmark]
+[markup.goldmark.extensions]
+typographer = false
 [markup.highlight]
 style = "manni"
 guessSyntax = true


### PR DESCRIPTION
The documentation of command line arguments often inclucde `--` double
dashes. If the typographer extension is enabled this dashes are replaced
by an 'em dash'. This leads to copy/paste errors from the doc to the
desired script/console.

E.g.

`--set-files foobar` will be converted to `—set-files foobar`