### PR TITLE
Clarify available doc versions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,12 +45,8 @@ url = "https://helm.sh/docs"
 primary = true
 
 [[params.versions]]
-version = "v2.16.3"
+version = "v2.16.6"
 url = "https://v2.helm.sh/docs"
-
-[[params.versions]]
-version = "v2.14.0"
-url = "https://v2-14-0.helm.sh/docs"
 
 [[params.quicklinks]]
 title = "Quickstart Guide"


### PR DESCRIPTION
I think the most sustainable path forward for https://github.com/helm/helm-www/issues/497 (in terms of what we can realistically accomplish right now) is "most current v2 docs" and "most current v3 docs". Trying to maintain docs pinned to minor versions does not look like it is going to happen.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>