### PR TITLE
Add Apt (Deb/Ubuntu) installation instructions

### DIFF
--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -421,7 +421,7 @@ an error if the namespace does not exist.
 
 ## Installing
 
-### Why aren't there Debian/Fedora/... native packages of Helm?
+### Why aren't there native packages of Helm for Fedora and other Linux distros?
 
 We'd love to provide these or point you toward a trusted provider. If you're
 interested in helping, we'd love it. This is how the Homebrew formula was

--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -46,6 +46,19 @@ package](https://chocolatey.org/packages/kubernetes-helm) build to
 choco install kubernetes-helm
 ```
 
+### From Apt (Debian/Ubuntu)
+
+Members of the Kubernetes community have contributed a [Helm
+package](https://helm.baltorepo.com/stable/debian/) for Apt. This package is generally up to date.
+
+```console
+curl https://helm.baltorepo.com/organization/signing.asc | sudo apt-key add -
+sudo apt-get install apt-transport-https --yes
+echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+sudo apt-get update
+sudo apt-get install helm
+```
+
 ### From Snap (Linux)                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                      
 The [Snapcrafters](https://github.com/snapcrafters) community maintains the


### PR DESCRIPTION
refs https://github.com/helm/helm/issues/7003

This points Debian/Ubuntu users of Helm to a native repo that makes it easy to install and upgrade Helm.

Signed-off-by: Matthew Fox <matt@getbalto.com>