### PR TITLE
Add warning for lookup with dry-run flag

### DIFF
--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -235,6 +235,9 @@ field:
 When no object is found, an empty value is returned. This can be used to check for the existence of
 an object.
 
+Note that the `lookup` function will also return an empty map when using `helm template`, `helm lint` or
+`helm install` with the `--dry-run` flag.
+
 The `lookup` function uses Helm's existing Kubernetes connection configuration to query Kubernetes.
 If any error is returned when interacting with calling the API server (for example due to lack of
 permission to access a resource), helm's template processing will fail.


### PR DESCRIPTION
Add a note about using the lookup function returning an empty value with template, lint and install with --dry-run flags.

Feel free up update the styling or wording. Just hope that other people don't trip over this.

https://github.com/helm/helm-www/issues/635