### PR TITLE
Specify behavior of lookup function during --dry-run

### DIFF
--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -239,7 +239,7 @@ The `lookup` function uses Helm's existing Kubernetes connection configuration t
 If any error is returned when interacting with calling the API server (for example due to lack of
 permission to access a resource), helm's template processing will fail.
 
-Also keep in mind that Helm is not supposed to contact the Kubernetes API Server during a `helm template`
+Keep in mind that Helm is not supposed to contact the Kubernetes API Server during a `helm template`
 or a `helm install|update|delete|rollback --dry-run`, so the `lookup` function will return `nil` in 
 such a case.
 

--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -239,6 +239,10 @@ The `lookup` function uses Helm's existing Kubernetes connection configuration t
 If any error is returned when interacting with calling the API server (for example due to lack of
 permission to access a resource), helm's template processing will fail.
 
+Also keep in mind that Helm is not supposed to contact the Kubernetes API Server during a `helm template`
+or a `helm install|update|delete|rollback --dry-run`, so the `lookup` function will return `nil` in 
+such a case.
+
 ## Operators are functions
 
 For templates, the operators (`eq`, `ne`, `lt`, `gt`, `and`, `or` and so on) are


### PR DESCRIPTION
As suggested in #635 I tried to detail out the behavior of the lookup function during a --dry-run (or helm template).

Please feel free to add or change.

Best regards,
Alessandro