### PR TITLE
Moving explanation to where it makes sense.

### DIFF
--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -200,10 +200,10 @@ REVISION: 1
 TEST SUITE: None
 ```
 
+You can run `helm get manifest clunky-serval` to see the entire generated YAML.
+
 Note that the config map inside kubernetes name is
 `clunky-serval-configmap` instead of `mychart-configmap` previously.
-
-You can run `helm get manifest clunky-serval` to see the entire generated YAML.
 
 At this point, we've seen templates at their most basic: YAML files that have
 template directives embedded in `{{` and `}}`. In the next part, we'll take a


### PR DESCRIPTION
The explanation tells the reader what they will see in the generated YAML. So I think it would be more clear to first show the output of the `helm get manifest` command, and then give an explanation of what the reader is looking at.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>