### PR TITLE
Add list of tests to update as part of releasing a new version

### DIFF
--- a/content/en/docs/community/release_checklist.md
+++ b/content/en/docs/community/release_checklist.md
@@ -145,6 +145,16 @@ index 2109a0a..6f5a1a4 100644
         BuildMetadata = "unreleased"
 ```
 
+In addition to updating the version within the `version.go` file, you will also
+need to update corresponding tests that are using that version number.
+
+* `cmd/helm/testdata/output/version.txt`
+* `cmd/helm/testdata/output/version-client.txt`
+* `cmd/helm/testdata/output/version-client-shorthand.txt`
+* `cmd/helm/testdata/output/version-short.txt`
+* `cmd/helm/testdata/output/version-template.txt`
+* `pkg/chartutil/capabilities_test.go`
+
 ```shell
 git add .
 git commit -m "bump version to $RELEASE_CANDIDATE_NAME"


### PR DESCRIPTION
As part of https://github.com/helm/helm/pull/7005, @bacongobbler requested that I also update the release checklist to include the tests, as to avoid breaking tests on the next release.

The list of test files to update I retrieved from [the last commit that changed the version](https://github.com/helm/helm/commit/8316a403ed16c76c35ce673e163c0ee30b1e8871), plus the test I was adding in my other pr.

Let me know if the wording can be improved, or if I missed any other steps.