### PR TITLE
improve language switching

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -138,6 +138,11 @@ weight = 3
 external = "yes"
 
 [[languages.ko.menus.main]]
+name = "Blog"
+url = "https://helm.sh/blog"
+weight = 4
+
+[[languages.ko.menus.main]]
 name = "Community"
 url = "https://github.com/helm/community"
 weight = 5

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -4,6 +4,15 @@
 [action_get_started]
 other = "Get Started"
 
+[action_get_started_link]
+other = "/docs/intro/quickstart"
+
+[action_translate]
+other = "Translate this page"
+
+[action_translate_link]
+other = "https://github.com/helm/helm-www#internationalization--translation"
+
 [action_copy]
 other = "Copy"
 

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -4,6 +4,15 @@
 [action_get_started]
 other = "시작"
 
+[action_get_started_link]
+other = "/ko/docs/intro/quickstart"
+
+[action_translate]
+other = "이 페이지 번역"
+
+[action_translate_link]
+other = "https://github.com/helm/helm-www#internationalization--translation"
+
 [action_copy]
 other = "복사"
 

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -103,6 +103,14 @@
         min-width: auto;
         padding-right: 2.25rem;
       }
+
+      .l18n-prompt a {
+        background-color: $light1;
+        display: block;
+        text-align: center;
+        line-height: 1.75;
+        margin: 0.5rem auto;
+      }
     }
     
     a.versioner-trigger {

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -196,6 +196,11 @@
     .versioner {
       display: none;
     }
+
+    li.versioner.l18ner {
+      display: block;
+      right: 17vw;
+    }
   }
 
   body.ko {

--- a/themes/helm/layouts/partials/nav-fixed.html
+++ b/themes/helm/layouts/partials/nav-fixed.html
@@ -55,7 +55,7 @@
                   {{ else }}
                 {{ end }}
             {{ end }}
-            <li class="navbar-item l18n-prompt"><a href="https://github.com/helm/helm-www#internationalization--translation"><small>Translate this page</small></a></li>
+            <li class="navbar-item l18n-prompt"><a href="{{ T "action_translate_link" }}"><small>{{ T "action_translate" }}</small></a></li>
           </ul>
         </li>
         {{ else }}
@@ -79,7 +79,7 @@
           </ul>
         </li>
         <li>
-          <a class="button is-outlined" href="/docs/intro/quickstart/">{{ T "action_get_started" }}</a>
+          <a class="button not-fixed is-outlined" href="{{ T "action_get_started_link" }}">{{ T "action_get_started" }}</a>
         </li>
       </ul>
     </div>

--- a/themes/helm/layouts/partials/nav-fixed.html
+++ b/themes/helm/layouts/partials/nav-fixed.html
@@ -1,7 +1,5 @@
 {{ $versions  := site.Params.versions }}
 {{ $primary   := index (where $versions ".primary" true) 0 }}
-{{ $lang      := .Lang }}
-{{ $isEnglish := eq $lang "en" }}
 {{ $menu      := site.Menus.main }}
 
 <nav class="navbar navbar-top navbar-top-fixed" role="navigation" aria-label="main navigation">
@@ -33,19 +31,35 @@
       <ul class="is-pulled-right">
         
         <!-- l18n -->
+        {{ if .Site.IsMultiLingual }}
         <li class="versioner l18ner navbar-item has-dropdown is-hoverable">
           <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger navbar-link">
             {{ .Language.LanguageName }} <i class="fa fa-caret-down"></i>
           </a>
 
           <ul id="drop1" class="navbar-dropdown dropdown-menu f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1">
-            {{ range $.Site.Home.AllTranslations }}
-            <li>
-              <a href="{{ .Permalink }}" class="navbar-item">{{ .Language.LanguageName }}</a>
-            </li>
+            {{ $siteLanguages := .Site.Languages}}
+            {{ $pageLang := .Page.Lang}}
+            {{ range .Page.AllTranslations }}
+                {{ $translation := .}}
+                {{ range $siteLanguages }}
+                    {{ if eq $translation.Lang .Lang }}
+                      {{ $selected := false }}
+                      {{ if eq $pageLang .Lang}}
+                          <li class="navbar-item"><a href="{{ $translation.URL }}" class="active">{{ .LanguageName }}</a></li>
+                      {{ else }}
+                          <li class="navbar-item"><a href="{{ $translation.URL }}">{{ .LanguageName }}</a></li>
+                      {{ end }}
+                    {{ end }}
+
+                  {{ else }}
+                {{ end }}
             {{ end }}
+            <li class="navbar-item l18n-prompt"><a href="https://github.com/helm/helm-www#internationalization--translation"><small>Translate this page</small></a></li>
           </ul>
         </li>
+        {{ else }}
+        {{ end }}
         
         <li class="versioner navbar-item has-dropdown is-hoverable">
           {{ with $primary }}

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -1,7 +1,5 @@
 {{ $versions  := site.Params.versions }}
 {{ $primary   := index (where $versions ".primary" true) 0 }}
-{{ $lang      := .Lang }}
-{{ $isEnglish := eq $lang "en" }}
 {{ $menu      := site.Menus.main }}
 
 <nav class="navbar navbar-top" role="navigation" aria-label="main navigation">
@@ -31,19 +29,35 @@
       <ul class="is-pulled-right">
         
         <!-- l18n -->
+        {{ if .Site.IsMultiLingual }}
         <li class="versioner l18ner navbar-item has-dropdown is-hoverable">
           <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger navbar-link">
             {{ .Language.LanguageName }} <i class="fa fa-caret-down"></i>
           </a>
 
           <ul id="drop1" class="navbar-dropdown dropdown-menu f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1">
-            {{ range $.Site.Home.AllTranslations }}
-            <li>
-              <a href="{{ .Permalink }}" class="navbar-item">{{ .Language.LanguageName }}</a>
-            </li>
+            {{ $siteLanguages := .Site.Languages}}
+            {{ $pageLang := .Page.Lang}}
+            {{ range .Page.AllTranslations }}
+                {{ $translation := .}}
+                {{ range $siteLanguages }}
+                    {{ if eq $translation.Lang .Lang }}
+                      {{ $selected := false }}
+                      {{ if eq $pageLang .Lang}}
+                          <li class="navbar-item"><a href="{{ $translation.URL }}" class="active">{{ .LanguageName }}</a></li>
+                      {{ else }}
+                          <li class="navbar-item"><a href="{{ $translation.URL }}">{{ .LanguageName }}</a></li>
+                      {{ end }}
+                    {{ end }}
+
+                  {{ else }}
+                {{ end }}
             {{ end }}
+            <li class="navbar-item l18n-prompt"><a href="https://github.com/helm/helm-www#internationalization--translation"><small>Translate this page</small></a></li>
           </ul>
         </li>
+        {{ else }}
+        {{ end }}
         
         <!-- versioning-->
         <li class="versioner navbar-item has-dropdown is-hoverable">

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -53,7 +53,7 @@
                   {{ else }}
                 {{ end }}
             {{ end }}
-            <li class="navbar-item l18n-prompt"><a href="https://github.com/helm/helm-www#internationalization--translation"><small>Translate this page</small></a></li>
+            <li class="navbar-item l18n-prompt"><a href="{{ T "action_translate_link" }}"><small>{{ T "action_translate" }}</small></a></li>
           </ul>
         </li>
         {{ else }}
@@ -78,7 +78,7 @@
           </ul>
         </li>
         <li>
-          <a class="button not-fixed is-outlined" href="/docs/intro/quickstart/">{{ T "action_get_started" }}</a>
+          <a class="button not-fixed is-outlined" href="{{ T "action_get_started_link" }}">{{ T "action_get_started" }}</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
* show the language switcher on all pages
* link directly to the translated page (rather than homepage)
* conditionally hide links when translations do not exist
* include a prompt to encourage further translation

Closes #687.