### PR TITLE
Add chart alias

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -1,7 +1,10 @@
 ---
 title: "Charts"
 description: "Explains the chart format, and provides basic guidance for building charts with Helm."
-aliases: ["docs/developing_charts/"]
+aliases: [
+  "docs/developing_charts/",
+  "developing_charts"
+]
 weight: 1
 ---
 


### PR DESCRIPTION
Adds an alias to redirect from https://helm.sh/docs/developing_charts/ to https://helm.sh/docs/topics/charts/

---

Fixes #658.