### PR TITLE
[v2] update gulp task to fix hyphens in environment variables

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ defaultContentLanguage = "en"
   ]
 
 [[params.versions]]
-version = "v3.2.1"
+version = "v3.2.4"
 patch = "stable"
 url = "https://helm.sh/docs"
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -233,7 +233,7 @@ gulp.task('clone', function(cb) {
 
   gulp.task('redirect-underscores', function() {
     return gulp.src('source/docs/helm/*.md')
-    .pipe(replace('_', '-'))
+    .pipe(replace('](../../docs/helm/#helm_', '](../../docs/helm/#helm-'))
     .pipe(gulp.dest('source/docs/helm/'))
   });
 


### PR DESCRIPTION
Updates the how gulp task adapts urls in the helm commands section of the v2 docs.

Fixes #316 