### PR TITLE
[#553] add prev and next links to docs

### DIFF
--- a/themes/helm/assets/sass/docs-content.scss
+++ b/themes/helm/assets/sass/docs-content.scss
@@ -108,6 +108,18 @@
     }
   }
 
+  .prev-next {
+    border-top: 2px solid lighten($navyl, 33.33%);
+    padding: 1.5rem 0 0;
+    margin-top: 5rem;
+
+    a {
+      display: inline-block;
+      min-width: 66.67%;
+      padding: 1rem 0.5rem;
+    }
+  }
+
   blockquote {
     margin: 2rem 0 2.5rem 4.5vw;
     background-color: rgba(249, 158, 172, 0.125);

--- a/themes/helm/layouts/docs/single.html
+++ b/themes/helm/layouts/docs/single.html
@@ -22,20 +22,21 @@ Helm | {{ .Title }}
         
         {{ .Content }}
 
-        <nav class="level prev-next has-text-left">
+        <nav class="level prev-next">
           <div class="level-left level-item">
-            {{ with .Site.RegularPages.Prev . }}
-            <a class="" href="{{.RelPermalink}}" title="Container">
-              <small class="heading">Previous</small>
-              <p class="title">← {{ .Title }}</p>
+            {{ if .NextInSection }}
+            <a class="" href="{{ .NextInSection.Permalink }}" title="{{ .Title }}">
+              <small class="heading">Prev</small>
+              <p class="title">← {{ .NextInSection.Title }}</p>
             </a>
             {{ end }}
           </div>
+          
           <div class="level-right level-item has-text-right">
-            {{ with .Site.RegularPages.Next . }}
-            <a class="" href="{{.RelPermalink}}" title="Media Object">
+            {{ if .PrevInSection }}
+            <a class="" href="{{ .PrevInSection.Permalink }}" title="{{ .Title }}">
               <small class="heading">Next</small>
-              <p class="title">{{ .Title }} →</p>
+              <p class="title">{{ .PrevInSection.Title }} →</p>
             </a>
             {{ end }}
           </div>

--- a/themes/helm/layouts/docs/single.html
+++ b/themes/helm/layouts/docs/single.html
@@ -21,6 +21,25 @@ Helm | {{ .Title }}
         <h1>{{ .Title }}</h1>
         
         {{ .Content }}
+
+        <nav class="level prev-next has-text-left">
+          <div class="level-left level-item">
+            {{ with .Site.RegularPages.Prev . }}
+            <a class="" href="{{.RelPermalink}}" title="Container">
+              <small class="heading">Previous</small>
+              <p class="title">← {{ .Title }}</p>
+            </a>
+            {{ end }}
+          </div>
+          <div class="level-right level-item has-text-right">
+            {{ with .Site.RegularPages.Next . }}
+            <a class="" href="{{.RelPermalink}}" title="Media Object">
+              <small class="heading">Next</small>
+              <p class="title">{{ .Title }} →</p>
+            </a>
+            {{ end }}
+          </div>
+        </nav>
       </article>
     </section>
   </div>


### PR DESCRIPTION
Adds auto-populated links to the end of each docs page:

![Screen Shot 2020-06-16 at 10 01 12 AM](https://user-images.githubusercontent.com/686194/84804978-60237080-afb8-11ea-9fdf-a71b0ae302bd.png)

---

Closes #553.