### PR TITLE
Adding helm description and links

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -3,6 +3,12 @@ title: "Docs Home"
 description: "Everything you need to know about how the documentation is organized."
 ---
 
+# Welcome
+
+Welcome to the [Helm](https://helm.sh/) documentation. Helm is the package
+manager for Kubernetes, and you can read detailed background information in
+the [CNCF Helm Project Journey report](https://www.cncf.io/cncf-helm-project-journey/).
+
 # How the documentation is organized
 
 Helm has a lot of documentation. A high-level overview of how it’s organized


### PR DESCRIPTION
Fixes #512 

Instead of adding a long "what is helm" section to the helm docs, I link to the front page of the site (which has a short explanation) and the CNCF project journey (which has a much longer and more detailed explanation).

Tagging @mattfarina for review as he commented on the issue I am attempting to resolve.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>