### PR TITLE
Fixing navigation greating links that go to nowhere

### DIFF
--- a/themes/helm/layouts/partials/nav-fixed.html
+++ b/themes/helm/layouts/partials/nav-fixed.html
@@ -15,7 +15,7 @@
     <div class="navbar-menu is-centered" id="navMenuDocumentation">
       {{ range $menu }}
         {{ if in (print .URL) "http"}}
-          <a href="{{ .URL | relLangURL }}" class
+          <a href="{{ .URL }}" class
           ="navbar-item external" target="_blank">
             {{ .Name }} <span class="icon"><i class="mdi mdi-open-in-new"></i></span>
           </a>

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -14,7 +14,7 @@
     <div class="navbar-menu is-centered" id="navMenuDocumentation">
       {{ range $menu }}
         {{ if in (print .URL) "http"}}
-          <a href="{{ .URL | relLangURL }}" class="navbar-item external" target="_blank">
+          <a href="{{ .URL }}" class="navbar-item external" target="_blank">
             {{ .Name }} <span class="icon"><i class="mdi mdi-open-in-new"></i></span>
           </a>
         {{ else }}


### PR DESCRIPTION
There is a difference between building a preview/serging localling
and deploying to production. Building a preview uses make build-preview
which has different options from the make build used for produciton.
Something in the hugo options ended up changing the handling of URLs.
The preview step works the same as `hugo serve` making it difficult
to notice in dev.

The issue here was that external URLs were passed through the
relLangURL template function. This is only to be used for relative
URLs. In some modes it was passing through the full URL and in others
it was taking the path, internationalizing it, and passing that along.
When it mangled the full URL we had the issue.

Since these URLs are for full URLs where we want the full thing passed
through, this change removes the use of relLangURL for absolute URLs.

Closes #704