### PR TITLE
[#658] add netlify redirect for developing_charts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,7 +20,7 @@
   from = "https://docs.helm.sh/"
   to = "https://helm.sh/docs/"
 
-# redirect docs subpages 
+# redirect docs subpages
 [[redirects]]
   from = "https://docs.helm.sh/*"
   to = "https://helm.sh/docs/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,3 +24,7 @@
 [[redirects]]
   from = "https://docs.helm.sh/*"
   to = "https://helm.sh/docs/:splat"
+
+[[redirects]]
+  from = "/docs/developing_charts/"
+  to = "https://v2.helm.sh/docs/developing_charts/"


### PR DESCRIPTION
The previous commit to add a page-level redirect ([here](https://github.com/helm/helm-www/blame/master/content/en/docs/topics/charts.md#L4L7)) did not resolve the issue. 

Adding a proxy redirect to the netlify config to fix #658.