### PR TITLE
Clarify path for template directory

### DIFF
--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -50,8 +50,6 @@ $ helm create mychart
 Creating mychart
 ```
 
-From here on, we'll be working in the `mychart` directory.
-
 ### A Quick Glimpse of `mychart/templates/`
 
 If you take a look at the `mychart/templates/` directory, you'll notice a few
@@ -101,10 +99,10 @@ data:
 recommend using the suffix `.yaml` for YAML files and `.tpl` for helpers.
 
 The YAML file above is a bare-bones ConfigMap, having the minimal necessary
-fields. In virtue of the fact that this file is in the `templates/` directory,
+fields. In virtue of the fact that this file is in the `mychart/templates/` directory,
 it will be sent through the template engine.
 
-It is just fine to put a plain YAML file like this in the `templates/`
+It is just fine to put a plain YAML file like this in the `mychart/templates/`
 directory. When Helm reads this template, it will simply send it to Kubernetes
 as-is.
 

--- a/content/ko/docs/chart_template_guide/getting_started.md
+++ b/content/ko/docs/chart_template_guide/getting_started.md
@@ -50,8 +50,6 @@ $ helm create mychart
 Creating mychart
 ```
 
-From here on, we'll be working in the `mychart` directory.
-
 ### `mychart/templates/` 훑어보기
 
 If you take a look at the `mychart/templates/` directory, you'll notice a few
@@ -101,10 +99,10 @@ data:
 recommend using the suffix `.yaml` for YAML files and `.tpl` for helpers.
 
 The YAML file above is a bare-bones ConfigMap, having the minimal necessary
-fields. In virtue of the fact that this file is in the `templates/` directory,
+fields. In virtue of the fact that this file is in the `mychart/templates/` directory,
 it will be sent through the template engine.
 
-It is just fine to put a plain YAML file like this in the `templates/`
+It is just fine to put a plain YAML file like this in the `mychart/templates/`
 directory. When Helm reads this template, it will simply send it to Kubernetes
 as-is.
 


### PR DESCRIPTION
Fixes https://github.com/helm/helm-www/issues/443

The text in this guide introduces potential confusion by ambiguously implying that all commands are run from the `mychart` directory, which they are not. In this PR, I attempt to clear up that confusion.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>