### PR TITLE
[#726] add a note about helm init

### DIFF
--- a/content/en/docs/helm/helm_init.md
+++ b/content/en/docs/helm/helm_init.md
@@ -4,6 +4,6 @@ section: deprecated
 
 ## helm init
 
-This command does not exist in Helm 3, following the [removal of Tiller](https://helm.sh/docs/faq/#removal-of-tiller). You no longer need to install Tiller in the cluster and set up a Helm state before in order to use Helm.
+This command does not exist in Helm 3, following the [removal of Tiller](https://helm.sh/docs/faq/#removal-of-tiller). You no longer need to install Tiller in your cluster in order to use Helm.
 
-If you are using Helm 2, go to [v2.helm.sh](https://v2.helm.sh/) to view the [Helm Init documentation](https://v2.helm.sh/docs/helm/#helm-init).
+If you are using Helm 2, go to [v2.helm.sh](https://v2.helm.sh/docs/helm/#helm-init) to view the [Helm Init documentation](https://v2.helm.sh/docs/helm/#helm-init).

--- a/content/en/docs/helm/helm_init.md
+++ b/content/en/docs/helm/helm_init.md
@@ -1,0 +1,9 @@
+---
+section: deprecated
+---
+
+## helm init
+
+This command does not exist in Helm 3, following the [removal of Tiller](https://helm.sh/docs/faq/#removal-of-tiller). You no longer need to install Tiller in the cluster and set up a Helm state before in order to use Helm.
+
+If you are using Helm 2, go to [v2.helm.sh](https://v2.helm.sh/) to view the [Helm Init documentation](https://v2.helm.sh/docs/helm/#helm-init).


### PR DESCRIPTION
I noticed the issue #726, seeking clarification around `helm init`. There still seems to be frequent confusion around Tiller (see search data below).

![Screen Shot 2020-06-24 at 11 55 46 AM](https://user-images.githubusercontent.com/686194/85616963-4f57a800-b613-11ea-9586-6d9b9946bae7.png)


This PR adds a _stub_ page explaining the depreciation, so if someone searches for `init` or `tiller` they will see this note rather than find nothing.