### PR TITLE
Provide go package lookup metadata for individual packages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,3 +28,14 @@
 [[redirects]]
   from = "/docs/developing_charts/"
   to = "https://v2.helm.sh/docs/developing_charts/"
+
+# redirect Go package lookups
+[[redirects]]
+  from = "/helm/v3/*"
+  to = "/helm/v3"
+  status = 200
+
+[[redirects]]
+  from = "/helm/v2/*"
+  to = "/helm/v2"
+  status = 200


### PR DESCRIPTION
This takes advantage of [Netlify's redirects](https://docs.netlify.com/routing/redirects/) to [rewrite](https://docs.netlify.com/routing/redirects/rewrites-proxies/) requests so that the go metadata appears on any page under the /helm/v2 or /helm/v3 paths.

Fixes: https://github.com/helm/helm/issues/7195
Fixes: #721