### PR TITLE
Removing aliases to ko docs

### DIFF
--- a/content/ko/docs/chart_best_practices/conventions.md
+++ b/content/ko/docs/chart_best_practices/conventions.md
@@ -2,7 +2,6 @@
 title: "일반적인 관례"
 description: "차트에 대한 일반적인 관례"
 weight: 1
-aliases: ["/docs/topics/chart_best_practices/conventions/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 일반적인 관례를 설명한다.

--- a/content/ko/docs/chart_best_practices/custom_resource_definitions.md
+++ b/content/ko/docs/chart_best_practices/custom_resource_definitions.md
@@ -2,7 +2,6 @@
 title: "커스텀 리소스 데피니션(CRD)"
 description: "CRD를 생성하고 사용하는 방법"
 weight: 7
-aliases: ["/docs/topics/chart_best_practices/custom_resource_definitions/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 커스텀 리소스 데피니션 객체를 생성하고 사용하는 것을 다룬다.

--- a/content/ko/docs/chart_best_practices/dependencies.md
+++ b/content/ko/docs/chart_best_practices/dependencies.md
@@ -2,7 +2,6 @@
 title: "의존성"
 description: "차트 의존성에 관한 모범사례를 다룬다."
 weight: 4
-aliases: ["/docs/topics/chart_best_practices/dependencies/"]
 ---
 
 이 부분은 가이드의 일부로서 `Chart.yaml`에서 선언되는 `dependencies`에 과한 모범사례를 다룬다.

--- a/content/ko/docs/chart_best_practices/labels.md
+++ b/content/ko/docs/chart_best_practices/labels.md
@@ -2,7 +2,6 @@
 title: "레이블과 어노테이션"
 description: "차트 내에서 레이블과 어노테이션을 사용하는 모범사례를 다룬다."
 weight: 5
-aliases: ["/docs/topics/chart_best_practices/labels/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 차트 내에서 레이블과 어노테이션을 사용하는 모범사례에 대해 논한다.

--- a/content/ko/docs/chart_best_practices/pods.md
+++ b/content/ko/docs/chart_best_practices/pods.md
@@ -2,7 +2,6 @@
 title: "파드와 파드템플릿"
 description: "차트 매니페스트에 있는 파드와 파드템플릿 부분의 형식을 논한다."
 weight: 6
-aliases: ["/docs/topics/chart_best_practices/pods/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 차트 매니페스트에 있는 파드와 파드템플릿 부분의 형식을 논한다.

--- a/content/ko/docs/chart_best_practices/rbac.md
+++ b/content/ko/docs/chart_best_practices/rbac.md
@@ -2,7 +2,6 @@
 title: "역할 기반 접근 제어"
 description: "차트 매니페스트에 있는 RBAC 리소스의 생성과 형식을 논한다."
 weight: 8
-aliases: ["/docs/topics/chart_best_practices/rbac/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 차트 매니페스트에 있는 RBAC 리소스의 생성과 형식을 논한다.

--- a/content/ko/docs/chart_best_practices/templates.md
+++ b/content/ko/docs/chart_best_practices/templates.md
@@ -2,7 +2,6 @@
 title: "템플릿"
 description: "템플릿에 관한 모범사례 들여다보기"
 weight: 3
-aliases: ["/docs/topics/chart_best_practices/templates/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 템플릿을 자세히 알아본다.

--- a/content/ko/docs/chart_best_practices/values.md
+++ b/content/ko/docs/chart_best_practices/values.md
@@ -2,7 +2,6 @@
 title: "값"
 description: "값을 구성하고 사용하는 방법을 집중적으로 다룬다."
 weight: 2
-aliases: ["/docs/topics/chart_best_practices/values/"]
 ---
 
 이 부분은 모범사례 가이드의 일부로서 값(values)을 사용하는 방법을 다룬다.

--- a/content/ko/docs/chart_template_guide/getting_started.md
+++ b/content/ko/docs/chart_template_guide/getting_started.md
@@ -2,7 +2,6 @@
 title: "시작하기"
 weight: 2
 description: "차트 템플릿에 관한 퀵가이드"
-aliases: ["/intro/getting_started/"]
 
 ---
 

--- a/content/ko/docs/community/history.md
+++ b/content/ko/docs/community/history.md
@@ -1,7 +1,6 @@
 ---
 title: "프로젝트 연혁"
 description: "프로젝트의 연혁에 대한 개요를 설명한다."
-aliases: ["/docs/history/"]
 weight: 4
 ---
 

--- a/content/ko/docs/intro/install.md
+++ b/content/ko/docs/intro/install.md
@@ -2,7 +2,6 @@
 title: "헬름 설치하기"
 description: "헬름 설치하고 작동하는 방법 배우기."
 weight: 2
-aliases: ["/docs/install/"]
 ---
 
 이 가이드는 헬름 CLI를 설치하는 방법을 설명한다. 헬름은 소스 또는 미리-빌드된(pre-built) 바이너리 릴리스로 설치할 수 있다.

--- a/content/ko/docs/intro/quickstart.md
+++ b/content/ko/docs/intro/quickstart.md
@@ -2,7 +2,6 @@
 title: "퀵스타트 가이드"
 description: "배포판, FAQ, 플러그인의 설명을 포함한 헬름 설치 및 시작 방법"
 weight: 1
-aliases: ["/docs/quickstart/"]
 ---
 
 이 가이드는 헬름을 빠르게 시작하는 방법에 대해 다룬다.

--- a/content/ko/docs/topics/architecture.md
+++ b/content/ko/docs/topics/architecture.md
@@ -1,7 +1,6 @@
 ---
 title: "헬름 아키텍처"
 description: "헬름 아키텍처를 개괄적으로 설명한다."
-aliases: ["/docs/architecture/"]
 weight: 8
 ---
 


### PR DESCRIPTION
The aliases should point to the en docs for legacy purposes. Having
them in the ko docs as well is overriding the pointers to the en
docs