### PR TITLE
Added documentation regarding use of $ for accessing objects from parent scope.

### DIFF
--- a/content/en/docs/chart_template_guide/control_structures.md
+++ b/content/en/docs/chart_template_guide/control_structures.md
@@ -315,6 +315,16 @@ because the scope is reset after `{{ end }}`.
   release: {{ .Release.Name }}
 ```
 
+Or, we can use `$` for accessing the object `Release.Name` from the parent scope. This, for example, will work.
+
+```yaml
+  {{- with .Values.favorite }}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
+  release: {{ $.Release.Name }}
+  {{- end }}
+```
+
 After looking at `range`, we will take a look at template variables, which offer
 one solution to the scoping issue above.
 
@@ -356,6 +366,25 @@ data:
     - {{ . | title | quote }}
     {{- end }}
 
+```
+
+We can use `$` for accessing the list `Values.pizzaToppings` from the parent scope. This, for example, will work.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+data:
+  myvalue: "Hello World"
+  {{- with .Values.favorite }}
+  drink: {{ .drink | default "tea" | quote }}
+  food: {{ .food | upper | quote }}
+  toppings: |-
+    {{- range $.Values.pizzaToppings }}
+    - {{ . | title | quote }}
+    {{- end }}
+  {{- end }}
 ```
 
 Let's take a closer look at the `toppings:` list. The `range` function will


### PR DESCRIPTION
Updated control flow documents to include information on how to access parent object using $. Inside 'with' and 'range'.

Signed-off-by: Pankaj Mehra <ppankajmehra050@gmail.com>