### PR TITLE
Clarify valid chart naming scheme

### DIFF
--- a/content/en/docs/chart_best_practices/conventions.md
+++ b/content/en/docs/chart_best_practices/conventions.md
@@ -9,7 +9,7 @@ This part of the Best Practices Guide explains general conventions.
 
 ## Chart Names
 
-Chart names should be lower case letters and numbers. Words _may_ be separated
+Chart names must be lower case letters and numbers. Words _may_ be separated
 with dashes (-):
 
 Examples:
@@ -20,7 +20,7 @@ nginx-lego
 aws-cluster-autoscaler
 ```
 
-Neither uppercase letters nor underscores should be used in chart names. Dots
+Neither uppercase letters nor underscores can be used in chart names. Dots
 should not be used in chart names.
 
 The directory that contains a chart MUST have the same name as the chart. Thus,


### PR DESCRIPTION
As noted in issue [#8012](https://github.com/helm/helm/issues/8012), the
ValidName regex have been incorrect for a while. While one could not
install charts with uppercase letters in the names, one did not get a
lint warning. I believe that is fixed since
[PR #8013](https://github.com/helm/helm/pull/8013).

This change clarifies that in the documentation.

I'm not quite certain if the PR fixes other cases too, and if that too should be clarified in the documentation. I hope someone can help me make sure the docs do describe the naming scheme correctly now.