### PR TITLE
feat(docs): introduce markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+    "default": true,
+    "MD013": {
+        "code_block_line_length": 999,
+        "tables": false
+    },
+    "MD014": false,
+    "MD025": false,
+    "MD026": false,
+    "MD033": false
+}

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -6,8 +6,9 @@ description: "Everything you need to know about how the documentation is organiz
 # Welcome
 
 Welcome to the [Helm](https://helm.sh/) documentation. Helm is the package
-manager for Kubernetes, and you can read detailed background information in
-the [CNCF Helm Project Journey report](https://www.cncf.io/cncf-helm-project-journey/).
+manager for Kubernetes, and you can read detailed background information in the
+[CNCF Helm Project Journey
+report](https://www.cncf.io/cncf-helm-project-journey/).
 
 # How the documentation is organized
 

--- a/content/en/docs/chart_best_practices/conventions.md
+++ b/content/en/docs/chart_best_practices/conventions.md
@@ -48,6 +48,7 @@ There are a few conventions for using the words _Helm_ and _helm_.
 - _Helm_ refers to the project as a whole
 - `helm` refers to the client-side command
 - The term `chart` does not need to be capitalized, as it is not a proper noun
-- However, `Chart.yaml` does need to be capitalized because the file name is case sensitive
+- However, `Chart.yaml` does need to be capitalized because the file name is
+  case sensitive
 
 When in doubt, use _Helm_ (with an uppercase 'H').

--- a/content/en/docs/chart_best_practices/custom_resource_definitions.md
+++ b/content/en/docs/chart_best_practices/custom_resource_definitions.md
@@ -39,19 +39,19 @@ installation step, you can pass the `--skip-crds` flag.
 
 #### Some caveats (and explanations)
 
-There is no support at this time for upgrading or deleting CRDs using Helm.
-This was an explicit decision after much community discussion due to the danger
-for unintentional data loss. Furthermore, there is currently no community
-consensus around how to handle CRDs and their lifecycle. As this evolves, Helm
-will add support for those use cases.
+There is no support at this time for upgrading or deleting CRDs using Helm. This
+was an explicit decision after much community discussion due to the danger for
+unintentional data loss. Furthermore, there is currently no community consensus
+around how to handle CRDs and their lifecycle. As this evolves, Helm will add
+support for those use cases.
 
 The `--dry-run` flag of `helm install` and `helm upgrade` is not currently
 supported for CRDs. The purpose of "Dry Run" is to validate that the output of
 the chart will actually work if sent to the server. But CRDs are a modification
 of the server's behavior. Helm cannot install the CRD on a dry run, so the
 discovery client will not know about that Custom Resource (CR), and validation
-will fail. You can alternatively move the CRDs to their own chart or use
-`helm template` instead.
+will fail. You can alternatively move the CRDs to their own chart or use `helm
+template` instead.
 
 Another important point to consider in the discussion around CRD support is how
 the rendering of templates is handled. One of the distinct disadvantages of the

--- a/content/en/docs/chart_best_practices/dependencies.md
+++ b/content/en/docs/chart_best_practices/dependencies.md
@@ -37,16 +37,17 @@ allowed in the official Helm repository.
 
 #### Experimental support for Charts hosted on OCI registries
 
-If you have [enabled experimental OCI support](/docs/registries/), you can specify
-an OCI reference (`oci://registry/group/image:tag`) for the repository URL.
+If you have [enabled experimental OCI support](/docs/registries/), you can
+specify an OCI reference (`oci://registry/group/image:tag`) for the repository
+URL.
 
 When specifying an OCI reference, you may omit the `version` argument if your
 repository URL contains an image tag (`oci://nginx:1.10`). If you do not specify
-a tag on the URL, the `version` will be used as the tag. This means that OCI URLs
-**do not support SemVer constraints**, only tagged versions are supported.
+a tag on the URL, the `version` will be used as the tag. This means that OCI
+URLs **do not support SemVer constraints**, only tagged versions are supported.
 
-If you specify both a tag and a version, the tag takes precedence and the version
-is ignored.
+If you specify both a tag and a version, the tag takes precedence and the
+version is ignored.
 
 ## Conditions and Tags
 
@@ -64,9 +65,9 @@ When multiple subcharts (dependencies) together provide an optional or swappable
 feature, those charts should share the same tags.
 
 For example, if both `nginx` and `memcached` together provide performance
-optimizations for the main app in the chart, and are required to both be
-present when that feature is enabled, then they should both have a tags section
-like this:
+optimizations for the main app in the chart, and are required to both be present
+when that feature is enabled, then they should both have a tags section like
+this:
 
 ```yaml
 tags:

--- a/content/en/docs/chart_best_practices/rbac.md
+++ b/content/en/docs/chart_best_practices/rbac.md
@@ -57,9 +57,9 @@ controls themselves can set this value to `false` (in which case see below).
 
 ## Using RBAC Resources
 
-`serviceAccount.name` should be set to the name of the ServiceAccount to be used by
-access-controlled resources created by the chart.  If `serviceAccount.create` is
-true, then a ServiceAccount with this name should be created.  If the name is
+`serviceAccount.name` should be set to the name of the ServiceAccount to be used
+by access-controlled resources created by the chart.  If `serviceAccount.create`
+is true, then a ServiceAccount with this name should be created.  If the name is
 not set, then a name is generated using the `fullname` template, If
 `serviceAccount.create` is false, then it should not be created, but it should
 still be associated with the same resources so that manually-created RBAC

--- a/content/en/docs/chart_template_guide/accessing_files.md
+++ b/content/en/docs/chart_template_guide/accessing_files.md
@@ -32,7 +32,8 @@ this works:
 - [Basic example](#basic-example)
 - [Path helpers](#path-helpers)
 - [Glob patterns](#glob-patterns)
-- [ConfigMap and Secrets utility functions](#configmap-and-secrets-utility-functions)
+- [ConfigMap and Secrets utility
+  functions](#configmap-and-secrets-utility-functions)
 - [Encoding](#encoding)
 - [Lines](#lines)
 
@@ -233,12 +234,11 @@ data:
     {{ . }}{{ end }}
 ```
 
-There is no way to pass files external to the chart during `helm
-install`. So if you are asking users to supply data, it must be loaded using
-`helm install -f` or `helm install --set`.
+There is no way to pass files external to the chart during `helm install`. So if
+you are asking users to supply data, it must be loaded using `helm install -f`
+or `helm install --set`.
 
 This discussion wraps up our dive into the tools and techniques for writing Helm
 templates. In the next section we will see how you can use one special file,
 `templates/NOTES.txt`, to send post-installation instructions to the users of
 your chart.
-

--- a/content/en/docs/chart_template_guide/builtin_objects.md
+++ b/content/en/docs/chart_template_guide/builtin_objects.md
@@ -26,8 +26,8 @@ access in your templates.
     upgrade or rollback.
   - `Release.IsInstall`: This is set to `true` if the current operation is an
     install.
-  - `Release.Revision`: The revision number for this release. On install, this is
-    1, and it is incremented with each upgrade and rollback.
+  - `Release.Revision`: The revision number for this release. On install, this
+    is 1, and it is incremented with each upgrade and rollback.
   - `Release.Service`: The service that is rendering the present template. On
     Helm, this is always `Helm`.
 - `Values`: Values passed into the template from the `values.yaml` file and from
@@ -35,8 +35,8 @@ access in your templates.
 - `Chart`: The contents of the `Chart.yaml` file. Any data in `Chart.yaml` will
   be accessible here. For example `{{ .Chart.Name }}-{{ .Chart.Version }}` will
   print out the `mychart-0.1.0`.
-  - The available fields are listed in the [Charts
-    Guide]({{< ref "/docs/topics/charts.md#the-chartyaml-file" >}})
+  - The available fields are listed in the [Charts Guide]({{< ref
+    "/docs/topics/charts.md#the-chartyaml-file" >}})
 - `Files`: This provides access to all non-special files in a chart. While you
   cannot use it to access templates, you can use it to access other files in the
   chart. See the section _Accessing Files_ for more.
@@ -49,8 +49,8 @@ access in your templates.
     the given shell glob pattern.
   - `Files.Lines` is a function that reads a file line-by-line. This is useful
     for iterating over each line in a file.
-  - `Files.AsSecrets` is a function that returns the file bodies as Base 64 encoded
-    strings.
+  - `Files.AsSecrets` is a function that returns the file bodies as Base 64
+    encoded strings.
   - `Files.AsConfig` is a function that returns file bodies as a YAML map.
 - `Capabilities`: This provides information about what capabilities the
   Kubernetes cluster supports.
@@ -58,7 +58,8 @@ access in your templates.
   - `Capabilities.APIVersions.Has $version` indicates whether a version (e.g.,
     `batch/v1`) or resource (e.g., `apps/v1/Deployment`) is available on the
     cluster.
-  - `Capabilities.KubeVersion` and `Capabilities.KubeVersion.Version` is the Kubernetes version.
+  - `Capabilities.KubeVersion` and `Capabilities.KubeVersion.Version` is the
+    Kubernetes version.
   - `Capabilities.KubeVersion.Major` is the Kubernetes major version.
   - `Capabilities.KubeVersion.Minor` is the Kubernetes minor version.
 - `Template`: Contains information about the current template that is being

--- a/content/en/docs/chart_template_guide/control_structures.md
+++ b/content/en/docs/chart_template_guide/control_structures.md
@@ -315,9 +315,9 @@ because the scope is reset after `{{ end }}`.
   release: {{ .Release.Name }}
 ```
 
-Or, we can use `$` for accessing the object `Release.Name` from the parent scope.
-`$` is mapped to the root scope when template execution begins and it does not
-change during template execution. The following would work as well:
+Or, we can use `$` for accessing the object `Release.Name` from the parent
+scope. `$` is mapped to the root scope when template execution begins and it
+does not change during template execution. The following would work as well:
 
 ```yaml
   {{- with .Values.favorite }}

--- a/content/en/docs/chart_template_guide/debugging.md
+++ b/content/en/docs/chart_template_guide/debugging.md
@@ -13,8 +13,8 @@ There are a few commands that can help you debug.
 - `helm lint` is your go-to tool for verifying that your chart follows best
   practices
 - `helm install --dry-run --debug` or `helm template --debug`: We've seen this
-  trick already. It's a great way to have the server render your templates,
-  then return the resulting manifest file.
+  trick already. It's a great way to have the server render your templates, then
+  return the resulting manifest file.
 - `helm get manifest`: This is a good way to see what templates are installed on
   the server.
 

--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -4,7 +4,8 @@ description: "A list of template functions available in Helm"
 weight: 6
 ---
 
-Helm includes many template functions you can take advantage of in templates. They are listed here and broken down by the following categories:
+Helm includes many template functions you can take advantage of in templates.
+They are listed here and broken down by the following categories:
 
 * [Cryptographic and Security](#cryptographic-and-security-functions)
 * [Date](#date-functions)
@@ -26,7 +27,10 @@ Helm includes many template functions you can take advantage of in templates. Th
 
 ## Logic and Flow Control Functions
 
-Helm includes numerous logic and control flow functions including [and](#and), [coalesce](#coalesce), [default](#default), [empty](#empty), [eq](#eq), [fail](#fail), [ge](#ge), [gt](#gt), [le](#le), [lt](#lt), [ne](#ne), [not](#not), and [or](#or).
+Helm includes numerous logic and control flow functions including [and](#and),
+[coalesce](#coalesce), [default](#default), [empty](#empty), [eq](#eq),
+[fail](#fail), [ge](#ge), [gt](#gt), [le](#le), [lt](#lt), [ne](#ne),
+[not](#not), and [or](#or).
 
 ### and
 
@@ -38,7 +42,8 @@ and .Arg1 .Arg2
 
 ### or
 
-Returns the boolean or of the two arguments. It returns the first non-empty argument or the last argument.
+Returns the boolean or of the two arguments. It returns the first non-empty
+argument or the last argument.
 
 ```
 or .Arg1 .Arg2
@@ -70,7 +75,8 @@ ne .Arg1 .Arg2
 
 ### lt
 
-Returns a boolean true if the first argument is less than the second. False is returned otherwise (e.g., Arg1 < Arg2).
+Returns a boolean true if the first argument is less than the second. False is
+returned otherwise (e.g., Arg1 < Arg2).
 
 ```
 lt .Arg1 .Arg2
@@ -78,7 +84,8 @@ lt .Arg1 .Arg2
 
 ### le
 
-Returns a boolean true if the first argument is less than or equal to the second. False is returned otherwise (e.g., Arg1 <= Arg2).
+Returns a boolean true if the first argument is less than or equal to the
+second. False is returned otherwise (e.g., Arg1 <= Arg2).
 
 ```
 le .Arg1 .Arg2
@@ -86,7 +93,8 @@ le .Arg1 .Arg2
 
 ### gt
 
-Returns a boolean true if the first argument is greater than the second. False is returned otherwise (e.g., Arg1 > Arg2).
+Returns a boolean true if the first argument is greater than the second. False
+is returned otherwise (e.g., Arg1 > Arg2).
 
 ```
 gt .Arg1 .Arg2
@@ -94,7 +102,8 @@ gt .Arg1 .Arg2
 
 ### ge
 
-Returns a boolean true if the first argument is greater than or equal to the second. False is returned otherwise (e.g., Arg1 >= Arg2).
+Returns a boolean true if the first argument is greater than or equal to the
+second. False is returned otherwise (e.g., Arg1 >= Arg2).
 
 ```
 ge .Arg1 .Arg2
@@ -162,9 +171,10 @@ This function is useful for scanning through multiple variables or values:
 coalesce .name .parent.name "Matt"
 ```
 
-The above will first check to see if `.name` is empty. If it is not, it will return
-that value. If it _is_ empty, `coalesce` will evaluate `.parent.name` for emptiness.
-Finally, if both `.name` and `.parent.name` are empty, it will return `Matt`.
+The above will first check to see if `.name` is empty. If it is not, it will
+return that value. If it _is_ empty, `coalesce` will evaluate `.parent.name` for
+emptiness. Finally, if both `.name` and `.parent.name` are empty, it will return
+`Matt`.
 
 ### ternary
 
@@ -202,7 +212,22 @@ The above returns `"bar"`.
 
 ## String Functions
 
-Helm includes the following string functions: [abbrev](#abbrev), [abbrevboth](#abbrevboth), [camelcase](#camelcase), [cat](#cat), [contains](#contains), [hasPrefix](#hasprefix-and-hassuffix), [hasSuffix](#hasprefix-and-hassuffix), [indent](#indent), [initials](#initials), [kebabcase](#kebabcase), [lower](#lower), [nindent](#nindent), [nospace](#nospace), [plural](#plural), [print](#print), [printf](#printf), [println](#println), [quote](#quote-and-squote), [randAlpha](#randalphanum-randalpha-randnumeric-and-randascii), [randAlphaNum](#randalphanum-randalpha-randnumeric-and-randascii), [randAscii](#randalphanum-randalpha-randnumeric-and-randascii), [randNumeric](#randalphanum-randalpha-randnumeric-and-randascii), [repeat](#repeat), [replace](#replace), [shuffle](#shuffle), [snakecase](#snakecase), [squote](#quote-and-squote), [substr](#substr), [swapcase](#swapcase), [title](#title), [trim](#trim), [trimAll](#trimall), [trimPrefix](#trimprefix), [trimSuffix](#trimsuffix), [trunc](#trunc), [untitle](#untitle), [upper](#upper), [wrap](#wrap), and [wrapWith](#wrapwith).
+Helm includes the following string functions: [abbrev](#abbrev),
+[abbrevboth](#abbrevboth), [camelcase](#camelcase), [cat](#cat),
+[contains](#contains), [hasPrefix](#hasprefix-and-hassuffix),
+[hasSuffix](#hasprefix-and-hassuffix), [indent](#indent), [initials](#initials),
+[kebabcase](#kebabcase), [lower](#lower), [nindent](#nindent),
+[nospace](#nospace), [plural](#plural), [print](#print), [printf](#printf),
+[println](#println), [quote](#quote-and-squote),
+[randAlpha](#randalphanum-randalpha-randnumeric-and-randascii),
+[randAlphaNum](#randalphanum-randalpha-randnumeric-and-randascii),
+[randAscii](#randalphanum-randalpha-randnumeric-and-randascii),
+[randNumeric](#randalphanum-randalpha-randnumeric-and-randascii),
+[repeat](#repeat), [replace](#replace), [shuffle](#shuffle),
+[snakecase](#snakecase), [squote](#quote-and-squote), [substr](#substr),
+[swapcase](#swapcase), [title](#title), [trim](#trim), [trimAll](#trimall),
+[trimPrefix](#trimprefix), [trimSuffix](#trimsuffix), [trunc](#trunc),
+[untitle](#untitle), [upper](#upper), [wrap](#wrap), and [wrapWith](#wrapwith).
 
 ### print
 
@@ -214,7 +239,8 @@ print "Matt has " .Dogs " dogs"
 
 Types that are not strings are converted to strings where possible.
 
-Note, when two arguments next to each other are not strings a space is added between them.
+Note, when two arguments next to each other are not strings a space is added
+between them.
 
 ### println
 
@@ -222,18 +248,20 @@ Works the same way as [print](#print) but adds a new line at the end.
 
 ### printf
 
-Returns a string based on a formatting string and the arguments to pass to it in order.
+Returns a string based on a formatting string and the arguments to pass to it in
+order.
 
 ```
 printf "%s has %d dogs." .Name .NumberDogs
 ```
 
-The placeholder to use depends on the type for the argument being passed in. This includes:
+The placeholder to use depends on the type for the argument being passed in.
+This includes:
 
 General purpose:
 
-* `%v` the value in a default format
-	when printing dicts, the plus flag (%+v) adds field names
+* `%v` the value in a default format when printing dicts, the plus flag (%+v)
+  adds field names
 * `%%` a literal percent sign; consumes no value
 
 Boolean:
@@ -254,14 +282,16 @@ Integer:
 
  Floating-point and complex constituents:
 
-* `%b` decimalless scientific notation with exponent a power of two, e.g. -123456p-78
+* `%b` decimalless scientific notation with exponent a power of two, e.g.
+  -123456p-78
 * `%e` scientific notation, e.g. -1.234456e+78
 * `%E` scientific notation, e.g. -1.234456E+78
 * `%f` decimal point but no exponent, e.g. 123.456
 * `%F` synonym for %f
 * `%g` %e for large exponents, %f otherwise.
 * `%G` %E for large exponents, %F otherwise
-* `%x` hexadecimal notation (with decimal power of two exponent), e.g. -0x1.23abcp+20
+* `%x` hexadecimal notation (with decimal power of two exponent), e.g.
+  -0x1.23abcp+20
 * `%X` upper-case hexadecimal notation, e.g. -0X1.23ABCP+20
 
 String and slice of bytes (treated equivalently with these verbs):
@@ -412,7 +442,8 @@ Parameters:
 abbrev 5 "hello world"
 ```
 
-The above returns `he...`, since it counts the width of the ellipses against the maximum length.
+The above returns `he...`, since it counts the width of the ellipses against the
+maximum length.
 
 ### abbrevboth
 
@@ -565,8 +596,8 @@ len $fish | plural "one anchovy" "many anchovies"
 ```
 
 In the above, if the length of the string is 1, the first argument will be
-printed (`one anchovy`). Otherwise, the second argument will be printed
-(`many anchovies`).
+printed (`one anchovy`). Otherwise, the second argument will be printed (`many
+anchovies`).
 
 The arguments are:
 
@@ -575,8 +606,8 @@ The arguments are:
 - length integer
 
 NOTE: Helm does not currently support languages with more complex pluralization
-rules. And `0` is considered a plural because the English language treats it
-as such (`zero anchovies`).
+rules. And `0` is considered a plural because the English language treats it as
+such (`zero anchovies`).
 
 ### snakecase
 
@@ -648,12 +679,14 @@ The following type conversion functions are provided by Helm:
 - `toString`: Convert to a string.
 - `toStrings`: Convert a list, slice, or array to a list of strings.
 - `toJson` (`mustToJson`): Convert list, slice, array, dict, or object to JSON.
-- `toPrettyJson` (`mustToPrettyJson`): Convert list, slice, array, dict, or object to indented JSON.
-- `toRawJson` (`mustToRawJson`): Convert list, slice, array, dict, or object to JSON with HTML characters unescaped.
+- `toPrettyJson` (`mustToPrettyJson`): Convert list, slice, array, dict, or
+  object to indented JSON.
+- `toRawJson` (`mustToRawJson`): Convert list, slice, array, dict, or object to
+  JSON with HTML characters unescaped.
 
 Only `atoi` requires that the input be a specific type. The others will attempt
-to convert from any type to the destination type. For example, `int64` can convert
-floats to ints, and it can also convert strings to ints.
+to convert from any type to the destination type. For example, `int64` can
+convert floats to ints, and it can also convert strings to ints.
 
 ### toStrings
 
@@ -663,8 +696,8 @@ Given a list-like collection, produce a slice of strings.
 list 1 2 3 | toStrings
 ```
 
-The above converts `1` to `"1"`, `2` to `"2"`, and so on, and then returns
-them as a list.
+The above converts `1` to `"1"`, `2` to `"2"`, and so on, and then returns them
+as a list.
 
 ### toDecimal
 
@@ -678,8 +711,9 @@ The above converts `0777` to `511` and returns the value as an int64.
 
 ### toJson, mustToJson
 
-The `toJson` function encodes an item into a JSON string. If the item cannot be converted to JSON the function will return an empty string.
-`mustToJson` will return an error in case the item cannot be encoded in JSON.
+The `toJson` function encodes an item into a JSON string. If the item cannot be
+converted to JSON the function will return an empty string. `mustToJson` will
+return an error in case the item cannot be encoded in JSON.
 
 ```
 toJson .Item
@@ -689,7 +723,8 @@ The above returns JSON string representation of `.Item`.
 
 ### toPrettyJson, mustToPrettyJson
 
-The `toPrettyJson` function encodes an item into a pretty (indented) JSON string.
+The `toPrettyJson` function encodes an item into a pretty (indented) JSON
+string.
 
 ```
 toPrettyJson .Item
@@ -699,7 +734,8 @@ The above returns indented JSON string representation of `.Item`.
 
 ### toRawJson, mustToRawJson
 
-The `toRawJson` function encodes an item into JSON string with HTML characters unescaped.
+The `toRawJson` function encodes an item into JSON string with HTML characters
+unescaped.
 
 ```
 toRawJson .Item
@@ -709,7 +745,14 @@ The above returns unescaped JSON string representation of `.Item`.
 
 ## Regular Expressions
 
-Helm includes the following regular expression functions: [regexFind (mustRegexFind)](#regexfindall-mustregexfindall), [regexFindAll (mustRegexFindAll)](#regexfind-mustregexfind), [regexMatch (mustRegexMatch)](#regexmatch-mustregexmatch), [regexReplaceAll (mustRegexReplaceAll)](#regexreplaceall-mustregexreplaceall), [regexReplaceAllLiteral (mustRegexReplaceAllLiteral)](#regexreplaceallliteral-mustregexreplaceallliteral), [regexSplit (mustRegexSplit)](#regexsplit-mustregexsplit).
+Helm includes the following regular expression functions: [regexFind
+(mustRegexFind)](#regexfindall-mustregexfindall), [regexFindAll
+(mustRegexFindAll)](#regexfind-mustregexfind), [regexMatch
+(mustRegexMatch)](#regexmatch-mustregexmatch), [regexReplaceAll
+(mustRegexReplaceAll)](#regexreplaceall-mustregexreplaceall),
+[regexReplaceAllLiteral
+(mustRegexReplaceAllLiteral)](#regexreplaceallliteral-mustregexreplaceallliteral),
+[regexSplit (mustRegexSplit)](#regexsplit-mustregexsplit).
 
 ### regexMatch, mustRegexMatch
 
@@ -721,13 +764,14 @@ regexMatch "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$" "test@acme.com"
 
 The above produces `true`
 
-`regexMatch` panics if there is a problem and `mustRegexMatch` returns an error to the
-template engine if there is a problem.
+`regexMatch` panics if there is a problem and `mustRegexMatch` returns an error
+to the template engine if there is a problem.
 
 ### regexFindAll, mustRegexFindAll
 
 Returns a slice of all matches of the regular expression in the input string.
-The last parameter n determines the number of substrings to return, where -1 means return all matches
+The last parameter n determines the number of substrings to return, where -1
+means return all matches
 
 ```
 regexFindAll "[2,4,6,8]" "123456789" -1
@@ -735,8 +779,8 @@ regexFindAll "[2,4,6,8]" "123456789" -1
 
 The above produces `[2 4 6 8]`
 
-`regexFindAll` panics if there is a problem and `mustRegexFindAll` returns an error to the
-template engine if there is a problem.
+`regexFindAll` panics if there is a problem and `mustRegexFindAll` returns an
+error to the template engine if there is a problem.
 
 ### regexFind, mustRegexFind
 
@@ -748,13 +792,15 @@ regexFind "[a-zA-Z][1-9]" "abcd1234"
 
 The above produces `d1`
 
-`regexFind` panics if there is a problem and `mustRegexFind` returns an error to the
-template engine if there is a problem.
+`regexFind` panics if there is a problem and `mustRegexFind` returns an error to
+the template engine if there is a problem.
 
 ### regexReplaceAll, mustRegexReplaceAll
 
-Returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement.
-Inside string replacement, $ signs are interpreted as in Expand, so for instance $1 represents the text of the first submatch
+Returns a copy of the input string, replacing matches of the Regexp with the
+replacement string replacement. Inside string replacement, $ signs are
+interpreted as in Expand, so for instance $1 represents the text of the first
+submatch
 
 ```
 regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"
@@ -762,13 +808,14 @@ regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"
 
 The above produces `-W-xxW-`
 
-`regexReplaceAll` panics if there is a problem and `mustRegexReplaceAll` returns an error to the
-template engine if there is a problem.
+`regexReplaceAll` panics if there is a problem and `mustRegexReplaceAll` returns
+an error to the template engine if there is a problem.
 
 ### regexReplaceAllLiteral, mustRegexReplaceAllLiteral
 
-Returns a copy of the input string, replacing matches of the Regexp with the replacement string replacement
-The replacement string is substituted directly, without using Expand
+Returns a copy of the input string, replacing matches of the Regexp with the
+replacement string replacement The replacement string is substituted directly,
+without using Expand
 
 ```
 regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}"
@@ -776,12 +823,16 @@ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}"
 
 The above produces `-${1}-${1}-`
 
-`regexReplaceAllLiteral` panics if there is a problem and `mustRegexReplaceAllLiteral` returns an error to the
-template engine if there is a problem.
+`regexReplaceAllLiteral` panics if there is a problem and
+`mustRegexReplaceAllLiteral` returns an error to the template engine if there is
+a problem.
 
 ### regexSplit, mustRegexSplit
 
-Slices the input string into substrings separated by the expression and returns a slice of the substrings between those expression matches. The last parameter `n` determines the number of substrings to return, where `-1` means return all matches
+Slices the input string into substrings separated by the expression and returns
+a slice of the substrings between those expression matches. The last parameter
+`n` determines the number of substrings to return, where `-1` means return all
+matches
 
 ```
 regexSplit "z+" "pizza" -1
@@ -789,12 +840,17 @@ regexSplit "z+" "pizza" -1
 
 The above produces `[pi a]`
 
-`regexSplit` panics if there is a problem and `mustRegexSplit` returns an error to the
-template engine if there is a problem.
+`regexSplit` panics if there is a problem and `mustRegexSplit` returns an error
+to the template engine if there is a problem.
 
 ## Cryptographic and Security Functions
 
-Helm provides some advanced cryptographic functions. They include [adler32sum](#adler32sum), [buildCustomCert](#buildcustomcert), [decryptAES](#decryptaes), [derivePassword](#derivepassword), [encryptAES](#encryptaes), [genCA](#genca), [genPrivateKey](#genprivatekey), [genSelfSignedCert](#genselfsignedcert), [genSignedCert](#gensignedcert), [htpasswd](#htpasswd), [sha1sum](#sha1sum), and [sha256sum](#sha256sum).
+Helm provides some advanced cryptographic functions. They include
+[adler32sum](#adler32sum), [buildCustomCert](#buildcustomcert),
+[decryptAES](#decryptaes), [derivePassword](#derivepassword),
+[encryptAES](#encryptaes), [genCA](#genca), [genPrivateKey](#genprivatekey),
+[genSelfSignedCert](#genselfsignedcert), [genSignedCert](#gensignedcert),
+[htpasswd](#htpasswd), [sha1sum](#sha1sum), and [sha256sum](#sha256sum).
 
 ### sha1sum
 
@@ -812,8 +868,8 @@ The `sha256sum` function receives a string, and computes it's SHA256 digest.
 sha256sum "Hello world!"
 ```
 
-The above will compute the SHA 256 sum in an "ASCII armored" format that is
-safe to print.
+The above will compute the SHA 256 sum in an "ASCII armored" format that is safe
+to print.
 
 ### adler32sum
 
@@ -825,7 +881,10 @@ adler32sum "Hello world!"
 
 ### htpasswd
 
-The `htpasswd` function takes a `username` and `password` and generates a `bcrypt` hash of the password. The result can be used for basic authentication on an [Apache HTTP Server](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html#basic).
+The `htpasswd` function takes a `username` and `password` and generates a
+`bcrypt` hash of the password. The result can be used for basic authentication
+on an [Apache HTTP
+Server](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html#basic).
 
 ```
 htpasswd "myUser" "myPassword"
@@ -836,8 +895,8 @@ Note that it is insecure to store the password directly in the template.
 ### derivePassword
 
 The `derivePassword` function can be used to derive a specific password based on
-some shared "master password" constraints. The algorithm for this is
-[well specified](https://masterpassword.app/masterpassword-algorithm.pdf).
+some shared "master password" constraints. The algorithm for this is [well
+specified](https://masterpassword.app/masterpassword-algorithm.pdf).
 
 ```
 derivePassword 1 "long" "password" "user" "example.com"
@@ -876,8 +935,8 @@ Example:
 $ca := buildCustomCert "base64-encoded-ca-crt" "base64-encoded-ca-key"
 ```
 
-Note that the returned object can be passed to the `genSignedCert` function
-to sign a certificate using this CA.
+Note that the returned object can be passed to the `genSignedCert` function to
+sign a certificate using this CA.
 
 ### genCA
 
@@ -899,8 +958,8 @@ Example:
 $ca := genCA "foo-ca" 365
 ```
 
-Note that the returned object can be passed to the `genSignedCert` function
-to sign a certificate using this CA.
+Note that the returned object can be passed to the `genSignedCert` function to
+sign a certificate using this CA.
 
 ### genSelfSignedCert
 
@@ -946,7 +1005,8 @@ $cert := genSignedCert "foo.com" (list "10.0.0.1" "10.0.0.2") (list "bar.com" "b
 
 ### encryptAES
 
-The `encryptAES` function encrypts text with AES-256 CBC and returns a base64 encoded string.
+The `encryptAES` function encrypts text with AES-256 CBC and returns a base64
+encoded string.
 
 ```
 encryptAES "secretkey" "plaintext"
@@ -963,7 +1023,12 @@ algorithm and returns the decoded text.
 
 ## Date Functions
 
-Helm includes the following date functions you can use in templates: [ago](#ago), [date](#date), [dateInZone](#dateinzone), [dateModify (mustDateModify)](#datemodify-mustdatemodify), [duration](#duration), [durationRound](#durationround), [htmlDate](#htmldate), [htmlDateInZone](#htmldateinzone), [now](#now), [toDate (mustToDate)](#todate-musttodate), and [unixEpoch](#unixepoch).
+Helm includes the following date functions you can use in templates:
+[ago](#ago), [date](#date), [dateInZone](#dateinzone), [dateModify
+(mustDateModify)](#datemodify-mustdatemodify), [duration](#duration),
+[durationRound](#durationround), [htmlDate](#htmldate),
+[htmlDateInZone](#htmldateinzone), [now](#now), [toDate
+(mustToDate)](#todate-musttodate), and [unixEpoch](#unixepoch).
 
 ### now
 
@@ -993,7 +1058,8 @@ Format the date to YEAR-MONTH-DAY:
 now | date "2006-01-02"
 ```
 
-Date formatting in Go is a [little bit different](https://pauladamsmith.com/blog/2011/05/go_time.html).
+Date formatting in Go is a [little bit
+different](https://pauladamsmith.com/blog/2011/05/go_time.html).
 
 In short, take this as the base date:
 
@@ -1001,8 +1067,8 @@ In short, take this as the base date:
 Mon Jan 2 15:04:05 MST 2006
 ```
 
-Write it in the format you want. Above, `2006-01-02` is the same date, but
-in the format we want.
+Write it in the format you want. Above, `2006-01-02` is the same date, but in
+the format we want.
 
 ### dateInZone
 
@@ -1024,8 +1090,9 @@ duration 95
 
 ### durationRound
 
-Rounds a given duration to the most significant unit. Strings and `time.Duration`
-gets parsed as a duration, while a `time.Time` is calculated as the duration since.
+Rounds a given duration to the most significant unit. Strings and
+`time.Duration` gets parsed as a duration, while a `time.Time` is calculated as
+the duration since.
 
 This return 2h
 
@@ -1057,7 +1124,8 @@ Subtract an hour and thirty minutes from the current time:
 now | date_modify "-1.5h"
 ```
 
-If the modification format is wrong `dateModify` will return the date unmodified. `mustDateModify` will return an error otherwise.
+If the modification format is wrong `dateModify` will return the date
+unmodified. `mustDateModify` will return an error otherwise.
 
 ### htmlDate
 
@@ -1080,11 +1148,10 @@ htmlDateInZone (now) "UTC"
 
 `toDate` converts a string to a date. The first argument is the date layout and
 the second the date string. If the string can't be convert it returns the zero
-value.
-`mustToDate` will return an error in case the string cannot be converted.
+value. `mustToDate` will return an error in case the string cannot be converted.
 
-This is useful when you want to convert a string date to another format
-(using pipe). The example below converts "2017-12-31" to "31/12/2017".
+This is useful when you want to convert a string date to another format (using
+pipe). The example below converts "2017-12-31" to "31/12/2017".
 
 ```
 toDate "2006-01-02" "2017-12-31" | date "02/01/2006"
@@ -1101,7 +1168,12 @@ type, even another `dict` or `list`.
 Unlike `list`s, `dict`s are not immutable. The `set` and `unset` functions will
 modify the contents of a dictionary.
 
-Helm provides the following functions to support working with dicts: [deepCopy (mustDeepCopy)](#deepcopy-mustdeepcopy), [dict](#dict), [get](#get), [hasKey](#haskey), [keys](#keys), [merge (mustMerge)](#merge-mustmerge), [mergeOverwrite (mustMergeOverwrite)](#mergeoverwrite-mustmergeoverwrite), [omit](#omit), [pick](#pick), [pluck](#pluck), [set](#set), [unset](#unset), and [values](#values).
+Helm provides the following functions to support working with dicts: [deepCopy
+(mustDeepCopy)](#deepcopy-mustdeepcopy), [dict](#dict), [get](#get),
+[hasKey](#haskey), [keys](#keys), [merge (mustMerge)](#merge-mustmerge),
+[mergeOverwrite (mustMergeOverwrite)](#mergeoverwrite-mustmergeoverwrite),
+[omit](#omit), [pick](#pick), [pluck](#pluck), [set](#set), [unset](#unset), and
+[values](#values).
 
 ### dict
 
@@ -1124,8 +1196,8 @@ get $myDict "key1"
 
 The above returns `"value1"`
 
-Note that if the key is not found, this operation will simply return `""`. No error
-will be generated.
+Note that if the key is not found, this operation will simply return `""`. No
+error will be generated.
 
 ### set
 
@@ -1135,8 +1207,9 @@ Use `set` to add a new key/value pair to a dictionary.
 $_ := set $myDict "name4" "value4"
 ```
 
-Note that `set` _returns the dictionary_ (a requirement of Go template functions),
-so you may need to trap the value as done above with the `$_` assignment.
+Note that `set` _returns the dictionary_ (a requirement of Go template
+functions), so you may need to trap the value as done above with the `$_`
+assignment.
 
 ### unset
 
@@ -1170,7 +1243,8 @@ get a list of all of the matches:
 pluck "name1" $myDict $myOtherDict
 ```
 
-The above will return a `list` containing every found value (`[value1 otherValue1]`).
+The above will return a `list` containing every found value (`[value1
+otherValue1]`).
 
 If the give key is _not found_ in a map, that map will not have an item in the
 list (and the length of the returned list will be less than the number of dicts
@@ -1184,15 +1258,17 @@ matching key out of a collection of dictionaries.
 
 ### merge, mustMerge
 
-Merge two or more dictionaries into one, giving precedence to the dest dictionary:
+Merge two or more dictionaries into one, giving precedence to the dest
+dictionary:
 
 ```
 $newdict := merge $dest $source1 $source2
 ```
 
-This is a deep merge operation but not a deep copy operation. Nested objects that
-are merged are the same instance on both dicts. If you want a deep copy along
-with the merge than use the `deepCopy` function along with merging. For example,
+This is a deep merge operation but not a deep copy operation. Nested objects
+that are merged are the same instance on both dicts. If you want a deep copy
+along with the merge than use the `deepCopy` function along with merging. For
+example,
 
 ```
 deepCopy $source | merge $dest
@@ -1202,8 +1278,8 @@ deepCopy $source | merge $dest
 
 ### mergeOverwrite, mustMergeOverwrite
 
-Merge two or more dictionaries into one, giving precedence from **right to left**, effectively
-overwriting values in the dest dictionary:
+Merge two or more dictionaries into one, giving precedence from **right to
+left**, effectively overwriting values in the dest dictionary:
 
 Given:
 
@@ -1231,9 +1307,10 @@ newdict:
 $newdict := mergeOverwrite $dest $source1 $source2
 ```
 
-This is a deep merge operation but not a deep copy operation. Nested objects that
-are merged are the same instance on both dicts. If you want a deep copy along
-with the merge than use the `deepCopy` function along with merging. For example,
+This is a deep merge operation but not a deep copy operation. Nested objects
+that are merged are the same instance on both dicts. If you want a deep copy
+along with the merge than use the `deepCopy` function along with merging. For
+example,
 
 ```
 deepCopy $source | mergeOverwrite $dest
@@ -1243,16 +1320,16 @@ deepCopy $source | mergeOverwrite $dest
 
 ### keys
 
-The `keys` function will return a `list` of all of the keys in one or more `dict`
-types. Since a dictionary is _unordered_, the keys will not be in a predictable order.
-They can be sorted with `sortAlpha`.
+The `keys` function will return a `list` of all of the keys in one or more
+`dict` types. Since a dictionary is _unordered_, the keys will not be in a
+predictable order. They can be sorted with `sortAlpha`.
 
 ```
 keys $myDict | sortAlpha
 ```
 
-When supplying multiple dictionaries, the keys will be concatenated. Use the `uniq`
-function along with `sortAlpha` to get a unqiue, sorted list of keys.
+When supplying multiple dictionaries, the keys will be concatenated. Use the
+`uniq` function along with `sortAlpha` to get a unqiue, sorted list of keys.
 
 ```
 keys $myDict $myOtherDict | uniq | sortAlpha
@@ -1271,8 +1348,8 @@ The above returns `{name1: value1, name2: value2}`
 
 ### omit
 
-The `omit` function is similar to `pick`, except it returns a new `dict` with all
-the keys that _do not_ match the given keys.
+The `omit` function is similar to `pick`, except it returns a new `dict` with
+all the keys that _do not_ match the given keys.
 
 ```
 $new := omit $myDict "name1" "name3"
@@ -1296,9 +1373,9 @@ then use `sortAlpha`.
 ### deepCopy, mustDeepCopy
 
 The `deepCopy` and `mustDeepCopy` functions takes a value and makes a deep copy
-of the value. This includes dicts and other structures. `deepCopy` panics
-when there is a problem while `mustDeepCopy` returns an error to the template
-system when there is an error.
+of the value. This includes dicts and other structures. `deepCopy` panics when
+there is a problem while `mustDeepCopy` returns an error to the template system
+when there is an error.
 
 ```
 dict "a" 1 "b" 2 | deepCopy
@@ -1307,8 +1384,8 @@ dict "a" 1 "b" 2 | deepCopy
 ### A Note on Dict Internals
 
 A `dict` is implemented in Go as a `map[string]interface{}`. Go developers can
-pass `map[string]interface{}` values into the context to make them available
-to templates as `dict`s.
+pass `map[string]interface{}` values into the context to make them available to
+templates as `dict`s.
 
 ## Encoding Functions
 
@@ -1331,7 +1408,16 @@ $myList := list 1 2 3 4 5
 
 The above creates a list of `[1 2 3 4 5]`.
 
-Helm provides the following list functions: [append (mustAppend)](#append-mustappend), [compact (mustCompact)](#compact-mustcompact), [concat](#concat), [first (mustFirst)](#first-mustfirst), [has (mustHas)](#has-musthas), [initial (mustInitial)](#initial-mustinitial), [last (mustLast)](#last-mustlast), [prepend (mustPrepend)](#prepend-mustprepend), [rest (mustRest)](#rest-mustrest), [reverse (mustReverse)](#reverse-mustreverse), [seq](#seq), [slice (mustSlice)](#slice-mustslice), [uniq (mustUniq)](#uniq-mustuniq), [until](#until), [untilStep](#untilstep), and [without (mustWithout)](#without-mustwithout).
+Helm provides the following list functions: [append
+(mustAppend)](#append-mustappend), [compact
+(mustCompact)](#compact-mustcompact), [concat](#concat), [first
+(mustFirst)](#first-mustfirst), [has (mustHas)](#has-musthas), [initial
+(mustInitial)](#initial-mustinitial), [last (mustLast)](#last-mustlast),
+[prepend (mustPrepend)](#prepend-mustprepend), [rest
+(mustRest)](#rest-mustrest), [reverse (mustReverse)](#reverse-mustreverse),
+[seq](#seq), [slice (mustSlice)](#slice-mustslice), [uniq
+(mustUniq)](#uniq-mustuniq), [until](#until), [untilStep](#untilstep), and
+[without (mustWithout)](#without-mustwithout).
 
 ### first, mustFirst
 
@@ -1360,11 +1446,11 @@ then calling `first`.
 
 ### initial, mustInitial
 
-This compliments `last` by returning all _but_ the last element.
-`initial $myList` returns `[1 2 3 4]`.
+This compliments `last` by returning all _but_ the last element. `initial
+$myList` returns `[1 2 3 4]`.
 
-`initial` panics if there is a problem while `mustInitial` returns an error to the
-template engine if there is a problem.
+`initial` panics if there is a problem while `mustInitial` returns an error to
+the template engine if there is a problem.
 
 ### append, mustAppend
 
@@ -1389,8 +1475,8 @@ prepend $myList 0
 
 The above would produce `[0 1 2 3 4 5]`. `$myList` would remain unaltered.
 
-`prepend` panics if there is a problem while `mustPrepend` returns an error to the
-template engine if there is a problem.
+`prepend` panics if there is a problem while `mustPrepend` returns an error to
+the template engine if there is a problem.
 
 ### concat
 
@@ -1412,8 +1498,8 @@ reverse $myList
 
 The above would generate the list `[5 4 3 2 1]`.
 
-`reverse` panics if there is a problem while `mustReverse` returns an error to the
-template engine if there is a problem.
+`reverse` panics if there is a problem while `mustReverse` returns an error to
+the template engine if there is a problem.
 
 ### uniq, mustUniq
 
@@ -1446,8 +1532,8 @@ without $myList 1 3 5
 
 That would produce `[2 4]`
 
-`without` panics if there is a problem while `mustWithout` returns an error to the
-template engine if there is a problem.
+`without` panics if there is a problem while `mustWithout` returns an error to
+the template engine if there is a problem.
 
 ### has, mustHas
 
@@ -1478,8 +1564,8 @@ template engine if there is a problem.
 
 ### slice, mustSlice
 
-To get partial elements of a list, use `slice list [n] [m]`. It is
-equivalent of `list[n:m]`.
+To get partial elements of a list, use `slice list [n] [m]`. It is equivalent of
+`list[n:m]`.
 
 - `slice $myList` returns `[1 2 3 4 5]`. It is same as `myList[:]`.
 - `slice $myList 3` returns `[4 5]`. It is same as `myList[3:]`.
@@ -1510,16 +1596,19 @@ you to define a start, stop, and step:
 untilStep 3 6 2
 ```
 
-The above will produce `[3 5]` by starting with 3, and adding 2 until it is equal
-or greater than 6. This is similar to Python's `range` function.
+The above will produce `[3 5]` by starting with 3, and adding 2 until it is
+equal or greater than 6. This is similar to Python's `range` function.
 
 ### seq
 
 Works like the bash `seq` command.
 
-* 1 parameter  (end) - will generate all counting integers between 1 and `end` inclusive.
-* 2 parameters (start, end) - will generate all counting integers between `start` and `end` inclusive incrementing or decrementing by 1.
-* 3 parameters (start, step, end) - will generate all counting integers between `start` and `end` inclusive incrementing or decrementing by `step`.
+* 1 parameter  (end) - will generate all counting integers between 1 and `end`
+  inclusive.
+* 2 parameters (start, end) - will generate all counting integers between
+  `start` and `end` inclusive incrementing or decrementing by 1.
+* 3 parameters (start, step, end) - will generate all counting integers between
+  `start` and `end` inclusive incrementing or decrementing by `step`.
 
 ```
 seq 5       => 1 2 3 4 5
@@ -1534,7 +1623,9 @@ seq 0 -2 -5 => 0 -2 -4
 
 All math functions operate on `int64` values unless specified otherwise.
 
-The following math functions are available: [add](#add), [add1](#add1), [ceil](#ceil), [div](#div), [floor](#floor), [len](#len), [max](#max), [min](#min), [mod](#mod), [mul](#mul), [round](#round), and [sub](#sub).
+The following math functions are available: [add](#add), [add1](#add1),
+[ceil](#ceil), [div](#div), [floor](#floor), [len](#len), [max](#max),
+[min](#min), [mod](#mod), [mul](#mul), [round](#round), and [sub](#sub).
 
 ### add
 
@@ -1598,7 +1689,8 @@ Returns the greatest float value greater than or equal to input value
 
 ### round
 
-Returns a float value with the remainder rounded to the given number to digits after the decimal point.
+Returns a float value with the remainder rounded to the given number to digits
+after the decimal point.
 
 `round 123.555555 3` will return `123.556`
 
@@ -1622,7 +1714,10 @@ getHostByName "www.google.com" would return the corresponding ip address of www.
 
 ## File Path Functions
 
-While Helm template functions do not grant access to the filesystem, they do provide functions for working with strings that follow file path conventions. Those include [base](#base), [clean](#clean), [dir](#dir), [ext](#ext), and [isAbs](#isabs).
+While Helm template functions do not grant access to the filesystem, they do
+provide functions for working with strings that follow file path conventions.
+Those include [base](#base), [clean](#clean), [dir](#dir), [ext](#ext), and
+[isAbs](#isabs).
 
 ### base
 
@@ -1636,8 +1731,8 @@ The above prints "baz"
 
 ### dir
 
-Return the directory, stripping the last part of the path. So `dir "foo/bar/baz"`
-returns `foo/bar`
+Return the directory, stripping the last part of the path. So `dir
+"foo/bar/baz"` returns `foo/bar`
 
 ### clean
 
@@ -1666,13 +1761,17 @@ To check whether a file path is absolute, use `isAbs`.
 ## Reflection Functions
 
 Helm provides rudimentary reflection tools. These help advanced template
-developers understand the underlying Go type information for a particular value. Helm is written in Go and is strongly typed. The type system applies within templates.
+developers understand the underlying Go type information for a particular value.
+Helm is written in Go and is strongly typed. The type system applies within
+templates.
 
 Go has several primitive _kinds_, like `string`, `slice`, `int64`, and `bool`.
 
 Go has an open _type_ system that allows developers to create their own types.
 
-Helm provides a set of functions for each via [kind functions](#kind-functions) and [type functions](#type-functions). A [deepEqual](#deepequal) function is also provided to compare to values.
+Helm provides a set of functions for each via [kind functions](#kind-functions)
+and [type functions](#type-functions). A [deepEqual](#deepequal) function is
+also provided to compare to values.
 
 ### Kind Functions
 
@@ -1700,11 +1799,13 @@ Types are slightly harder to work with, so there are three different functions:
 - `typeIsLike` works as `typeIs`, except that it also dereferences pointers.
 
 **Note:** None of these can test whether or not something implements a given
-interface, since doing so would require compiling the interface in ahead of time.
+interface, since doing so would require compiling the interface in ahead of
+time.
 
 ### deepEqual
 
-`deepEqual` returns true if two values are ["deeply equal"](https://golang.org/pkg/reflect/#DeepEqual)
+`deepEqual` returns true if two values are ["deeply
+equal"](https://golang.org/pkg/reflect/#DeepEqual)
 
 Works for non-primitive types as well (compared to the built-in `eq`).
 
@@ -1716,8 +1817,10 @@ The above will return `true`
 
 ## Semantic Version Functions
 
-Some version schemes are easily parseable and comparable. Helm provides functions
-for working with [SemVer 2](http://semver.org) versions. These include [semver](#semver) and [semverCompare](#semvercompare). Below you will also find details on using ranges for comparisons.
+Some version schemes are easily parseable and comparable. Helm provides
+functions for working with [SemVer 2](http://semver.org) versions. These include
+[semver](#semver) and [semverCompare](#semvercompare). Below you will also find
+details on using ranges for comparisons.
 
 ### semver
 
@@ -1739,8 +1842,8 @@ properties:
 - `$version.Metadata`: The build metadata (`123` above)
 - `$version.Original`: The original version as a string
 
-Additionally, you can compare a `Version` to another `version` using the `Compare`
-function:
+Additionally, you can compare a `Version` to another `version` using the
+`Compare` function:
 
 ```
 semver "1.4.3" | (semver "1.2.3").Compare
@@ -1750,7 +1853,8 @@ The above will return `-1`.
 
 The return values are:
 
-- `-1` if the given semver is greater than the semver whose `Compare` method was called
+- `-1` if the given semver is greater than the semver whose `Compare` method was
+  called
 - `1` if the version who's `Compare` function was called is greater.
 - `0` if they are the same version
 
@@ -1763,19 +1867,20 @@ A more robust comparison function is provided as `semverCompare`. This version
 supports version ranges:
 
 - `semverCompare "1.2.3" "1.2.3"` checks for an exact match
-- `semverCompare "^1.2.0" "1.2.3"` checks that the major and minor versions match, and that the patch 
-  number of the second version is _greater than or equal to_ the first parameter.
+- `semverCompare "^1.2.0" "1.2.3"` checks that the major and minor versions
+  match, and that the patch number of the second version is _greater than or
+  equal to_ the first parameter.
 
-The SemVer functions use the [Masterminds semver library](https://github.com/Masterminds/semver),
-from the creators of Sprig.
+The SemVer functions use the [Masterminds semver
+library](https://github.com/Masterminds/semver), from the creators of Sprig.
 
 ### Basic Comparisons
 
 There are two elements to the comparisons. First, a comparison string is a list
 of space or comma separated AND comparisons. These are then separated by || (OR)
 comparisons. For example, `">= 1.2 < 3.0.0 || >= 4.2.3"` is looking for a
-comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
-greater than or equal to 4.2.3.
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is greater
+than or equal to 4.2.3.
 
 The basic comparisons are:
 
@@ -1793,30 +1898,32 @@ API compliant with their release counterpart. It says,_
 
 Pre-releases, for those not familiar with them, are used for software releases
 prior to stable or generally available releases. Examples of prereleases include
-development, alpha, beta, and release candidate releases. A prerelease may be
-a version such as `1.2.3-beta.1` while the stable release would be `1.2.3`. In the
+development, alpha, beta, and release candidate releases. A prerelease may be a
+version such as `1.2.3-beta.1` while the stable release would be `1.2.3`. In the
 order of precedence, prereleases come before their associated releases. In this
 example `1.2.3-beta.1 < 1.2.3`.
 
-According to the Semantic Version specification prereleases may not be
-API compliant with their release counterpart. It says,
+According to the Semantic Version specification prereleases may not be API
+compliant with their release counterpart. It says,
 
-> A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version.
+> A pre-release version indicates that the version is unstable and might not
+> satisfy the intended compatibility requirements as denoted by its associated
+> normal version.
 
 SemVer comparisons using constraints without a prerelease comparator will skip
 prerelease versions. For example, `>=1.2.3` will skip prereleases when looking
 at a list of releases while `>=1.2.3-0` will evaluate and find prereleases.
 
 The reason for the `0` as a pre-release version in the example comparison is
-because pre-releases can only contain ASCII alphanumerics and hyphens (along with
-`.` separators), per the spec. Sorting happens in ASCII sort order, again per the
-spec. The lowest character is a `0` in ASCII sort order
-(see an [ASCII Table](http://www.asciitable.com/))
+because pre-releases can only contain ASCII alphanumerics and hyphens (along
+with `.` separators), per the spec. Sorting happens in ASCII sort order, again
+per the spec. The lowest character is a `0` in ASCII sort order (see an [ASCII
+Table](http://www.asciitable.com/))
 
-Understanding ASCII sort ordering is important because A-Z comes before a-z. That
-means `>=1.2.3-BETA` will return `1.2.3-alpha`. What you might expect from case
-sensitivity doesn't apply here. This is due to ASCII sort ordering which is what
-the spec specifies.
+Understanding ASCII sort ordering is important because A-Z comes before a-z.
+That means `>=1.2.3-BETA` will return `1.2.3-alpha`. What you might expect from
+case sensitivity doesn't apply here. This is due to ASCII sort ordering which is
+what the spec specifies.
 
 ### Hyphen Range Comparisons
 
@@ -1829,8 +1936,8 @@ These look like:
 ### Wildcards In Comparisons
 
 The `x`, `X`, and `*` characters can be used as a wildcard character. This works
-for all comparison operators. When used on the `=` operator it falls
-back to the patch level comparison (see tilde below). For example,
+for all comparison operators. When used on the `=` operator it falls back to the
+patch level comparison (see tilde below). For example,
 
 - `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
 - `>= 1.2.x` is equivalent to `>= 1.2.0`
@@ -1868,7 +1975,8 @@ major change is API breaking. For example,
 
 ## URL Functions
 
-Helm includes the [urlParse](#urlparse), [urlJoin](#urljoin), and [urlquery](#urlquery) functions enabling you to work with URL parts.
+Helm includes the [urlParse](#urlparse), [urlJoin](#urljoin), and
+[urlquery](#urlquery) functions enabling you to work with URL parts.
 
 ### urlParse
 
@@ -1890,7 +1998,8 @@ fragment: 'anchor'
 userinfo: 'admin:secret'
 ```
 
-This is implemented used the URL packages from the Go standard library. For more info, check https://golang.org/pkg/net/url/#URL
+This is implemented used the URL packages from the Go standard library. For more
+info, check https://golang.org/pkg/net/url/#URL
 
 ### urlJoin
 
@@ -1907,7 +2016,8 @@ proto://host:80/path?query#fragment
 
 ### urlquery
 
-Returns the escaped version of the value passed in as an argument so that it is suitable for embedding in the query portion of a URL.
+Returns the escaped version of the value passed in as an argument so that it is
+suitable for embedding in the query portion of a URL.
 
 ```
 $var := urlquery "string for query"
@@ -1925,13 +2035,17 @@ The above returns a new UUID of the v4 (randomly generated) type.
 
 ## Kubernetes and Chart Functions
 
-Helm includes functions for working with Kubernetes including [.Capabilities.APIVersions.Has](#capabilitiesapiversionshas), [Files](#file-functions), and [lookup](#lookup).
+Helm includes functions for working with Kubernetes including
+[.Capabilities.APIVersions.Has](#capabilitiesapiversionshas),
+[Files](#file-functions), and [lookup](#lookup).
 
 ### lookup
 
-`lookup` is used to look up resource in a running cluster. When used with the `helm template` command it always returns an empty response.
+`lookup` is used to look up resource in a running cluster. When used with the
+`helm template` command it always returns an empty response.
 
-You can find more detail in the [documentation on the lookup function](functions_and_pipelines.md/#using-the-lookup-function).
+You can find more detail in the [documentation on the lookup
+function](functions_and_pipelines.md/#using-the-lookup-function).
 
 ### .Capabilities.APIVersions.Has
 
@@ -1942,10 +2056,15 @@ Returns if an API version or resource is available in a cluster.
 .Capabilities.APIVersions.Has "apps/v1/Deployment"
 ```
 
-More information is available on the [built-in object documentation](builtin_objects.md).
+More information is available on the [built-in object
+documentation](builtin_objects.md).
 
 ### File Functions
 
-There are several functions that enable you to get to non-special files within a chart. For example, to access application configuration files. These are documented in [Accessing Files Inside Templates](accessing_files.md).
+There are several functions that enable you to get to non-special files within a
+chart. For example, to access application configuration files. These are
+documented in [Accessing Files Inside Templates](accessing_files.md).
 
-_Note, the documentation for many of these functions come from [Sprig](https://github.com/Masterminds/sprig). Sprig is a template funciton library available to Go applications._
+_Note, the documentation for many of these functions come from
+[Sprig](https://github.com/Masterminds/sprig). Sprig is a template funciton
+library available to Go applications._

--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -260,8 +260,8 @@ This includes:
 
 General purpose:
 
-* `%v` the value in a default format when printing dicts, the plus flag (%+v)
-  adds field names
+* `%v` the value in a default format
+  * when printing dicts, the plus flag (%+v) adds field names
 * `%%` a literal percent sign; consumes no value
 
 Boolean:

--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -29,9 +29,8 @@ single argument.
 
 Helm has over 60 available functions. Some of them are defined by the [Go
 template language](https://godoc.org/text/template) itself. Most of the others
-are part of the [Sprig template
-library](https://masterminds.github.io/sprig/). We'll see many of them
-as we progress through the examples.
+are part of the [Sprig template library](https://masterminds.github.io/sprig/).
+We'll see many of them as we progress through the examples.
 
 > While we talk about the "Helm template language" as if it is Helm-specific, it
 > is actually a combination of the Go template language, some extra functions,
@@ -157,8 +156,8 @@ favorite:
   food: pizza
 ```
 
-Now re-running `helm install --dry-run --debug fair-worm ./mychart` will produce this
-YAML:
+Now re-running `helm install --dry-run --debug fair-worm ./mychart` will produce
+this YAML:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml
@@ -192,8 +191,9 @@ language.
 
 ## Using the `lookup` function
 
-The `lookup` function can be used to _look up_ resources in a running cluster. The synopsis of the
-lookup function is `lookup apiVersion, kind, namespace, name -> resource or resource list`.
+The `lookup` function can be used to _look up_ resources in a running cluster.
+The synopsis of the lookup function is `lookup apiVersion, kind, namespace, name
+-> resource or resource list`.
 
 | parameter  | type   |
 |------------|--------|
@@ -202,7 +202,8 @@ lookup function is `lookup apiVersion, kind, namespace, name -> resource or reso
 | namespace  | string |
 | name       | string |
 
-Both `name` and `namespace` are optional and can be passed as an empty string (`""`).
+Both `name` and `namespace` are optional and can be passed as an empty string
+(`""`).
 
 The following combination of parameters are possible:
 
@@ -214,17 +215,18 @@ The following combination of parameters are possible:
 | `kubectl get namespace mynamespace`    | `lookup "v1" "Namespace" "" "mynamespace"` |
 | `kubectl get namespaces`               | `lookup "v1" "Namespace" "" ""`            |
 
-When `lookup` returns an object, it will return a dictionary. This dictionary can be further
-navigated to extract specific values.
+When `lookup` returns an object, it will return a dictionary. This dictionary
+can be further navigated to extract specific values.
 
-The following example will return the annotations present for the `mynamespace` object:
+The following example will return the annotations present for the `mynamespace`
+object:
 
 ```go
 (lookup "v1" "Namespace" "" "mynamespace").metadata.annotations
 ```
 
-When `lookup` returns a list of objects, it is possible to access the object list via the `items`
-field:
+When `lookup` returns a list of objects, it is possible to access the object
+list via the `items` field:
 
 ```go
 {{ range $index, $service := (lookup "v1" "Service" "mynamespace" "").items }}
@@ -232,16 +234,17 @@ field:
 {{ end }}
 ```
 
-When no object is found, an empty value is returned. This can be used to check for the existence of
-an object.
+When no object is found, an empty value is returned. This can be used to check
+for the existence of an object.
 
-The `lookup` function uses Helm's existing Kubernetes connection configuration to query Kubernetes.
-If any error is returned when interacting with calling the API server (for example due to lack of
-permission to access a resource), helm's template processing will fail.
+The `lookup` function uses Helm's existing Kubernetes connection configuration
+to query Kubernetes. If any error is returned when interacting with calling the
+API server (for example due to lack of permission to access a resource), helm's
+template processing will fail.
 
-Keep in mind that Helm is not supposed to contact the Kubernetes API Server during a `helm template`
-or a `helm install|update|delete|rollback --dry-run`, so the `lookup` function will return `nil` in 
-such a case.
+Keep in mind that Helm is not supposed to contact the Kubernetes API Server
+during a `helm template` or a `helm install|update|delete|rollback --dry-run`,
+so the `lookup` function will return `nil` in such a case.
 
 ## Operators are functions
 

--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -3,7 +3,6 @@ title: "Getting Started"
 weight: 2
 description: "A quick guide on Chart templates."
 aliases: ["/intro/getting_started/"]
-
 ---
 
 In this section of the guide, we'll create a chart and then add a first
@@ -99,8 +98,8 @@ data:
 recommend using the suffix `.yaml` for YAML files and `.tpl` for helpers.
 
 The YAML file above is a bare-bones ConfigMap, having the minimal necessary
-fields. In virtue of the fact that this file is in the `mychart/templates/` directory,
-it will be sent through the template engine.
+fields. In virtue of the fact that this file is in the `mychart/templates/`
+directory, it will be sent through the template engine.
 
 It is just fine to put a plain YAML file like this in the `mychart/templates/`
 directory. When Helm reads this template, it will simply send it to Kubernetes
@@ -119,7 +118,8 @@ REVISION: 1
 TEST SUITE: None
 ```
 
-Using Helm, we can retrieve the release and see the actual template that was loaded.
+Using Helm, we can retrieve the release and see the actual template that was
+loaded.
 
 ```console
 $ helm get manifest full-coral
@@ -167,8 +167,8 @@ data:
   myvalue: "Hello World"
 ```
 
-The big change comes in the value of the `name:` field, which is now `{{
-.Release.Name }}-configmap`.
+The big change comes in the value of the `name:` field, which is now
+`{{.Release.Name }}-configmap`.
 
 > A template directive is enclosed in `{{` and `}}` blocks.
 
@@ -200,17 +200,17 @@ TEST SUITE: None
 
 You can run `helm get manifest clunky-serval` to see the entire generated YAML.
 
-Note that the config map inside kubernetes name is
-`clunky-serval-configmap` instead of `mychart-configmap` previously.
+Note that the config map inside kubernetes name is `clunky-serval-configmap`
+instead of `mychart-configmap` previously.
 
 At this point, we've seen templates at their most basic: YAML files that have
 template directives embedded in `{{` and `}}`. In the next part, we'll take a
 deeper look into templates. But before moving on, there's one quick trick that
 can make building templates faster: When you want to test the template
 rendering, but not actually install anything, you can use `helm install --debug
---dry-run goodly-guppy ./mychart`. This will render the templates. But instead of installing
-the chart, it will return the rendered template to you so you can see the
-output:
+--dry-run goodly-guppy ./mychart`. This will render the templates. But instead
+of installing the chart, it will return the rendered template to you so you can
+see the output:
 
 ```console
 $ helm install --debug --dry-run goodly-guppy ./mychart
@@ -271,6 +271,6 @@ Using `--dry-run` will make it easier to test your code, but it won't ensure
 that Kubernetes itself will accept the templates you generate. It's best not to
 assume that your chart will install just because `--dry-run` works.
 
-In the [Chart Template Guide](_index.md), we take the
-basic chart we defined here and explore the Helm template language in detail.
-And we'll get started with built-in objects.
+In the [Chart Template Guide](_index.md), we take the basic chart we defined
+here and explore the Helm template language in detail. And we'll get started
+with built-in objects.

--- a/content/en/docs/chart_template_guide/helm_ignore_file.md
+++ b/content/en/docs/chart_template_guide/helm_ignore_file.md
@@ -4,13 +4,19 @@ description: "The `.helmignore` file is used to specify files you don't want to 
 weight: 12
 ---
 
-The `.helmignore` file is used to specify files you don't want to include in your helm chart.
+The `.helmignore` file is used to specify files you don't want to include in
+your helm chart.
 
-If this file exists, the `helm package` command will ignore all the files that match the pattern specified in the `.helmignore` file while packaging your application.
+If this file exists, the `helm package` command will ignore all the files that
+match the pattern specified in the `.helmignore` file while packaging your
+application.
 
-This can help in avoiding unnecessary or sensitive files or directories from being added in your helm chart.
+This can help in avoiding unnecessary or sensitive files or directories from
+being added in your helm chart.
 
-The `.helmignore` file supports Unix shell glob matching, relative path matching, and negation (prefixed with !). Only one pattern per line is considered.
+The `.helmignore` file supports Unix shell glob matching, relative path
+matching, and negation (prefixed with !). Only one pattern per line is
+considered.
 
 Here is an example `.helmignore` file:
 
@@ -23,5 +29,5 @@ temp?
 ```
 
 **We'd love your help** making this document better. To add, correct, or remove
-information, [file an issue](https://github.com/helm/helm/issues) or
-send us a pull request.
+information, [file an issue](https://github.com/helm/helm/issues) or send us a
+pull request.

--- a/content/en/docs/chart_template_guide/named_templates.md
+++ b/content/en/docs/chart_template_guide/named_templates.md
@@ -202,7 +202,8 @@ Note that we pass `.` at the end of the `template` call. We could just as easily
 pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want
 is the top-level scope.
 
-Now when we execute this template with `helm install --dry-run --debug plinking-anaco ./mychart`, we get this:
+Now when we execute this template with `helm install --dry-run --debug
+plinking-anaco ./mychart`, we get this:
 
 ```yaml
 # Source: mychart/templates/configmap.yaml

--- a/content/en/docs/chart_template_guide/notes_files.md
+++ b/content/en/docs/chart_template_guide/notes_files.md
@@ -5,9 +5,9 @@ weight: 10
 ---
 
 In this section we are going to look at Helm's tool for providing instructions
-to your chart users. At the end of a `helm install` or `helm upgrade`, Helm
-can print out a block of helpful information for users. This information is
-highly customizable using templates.
+to your chart users. At the end of a `helm install` or `helm upgrade`, Helm can
+print out a block of helpful information for users. This information is highly
+customizable using templates.
 
 To add installation notes to your chart, simply create a `templates/NOTES.txt`
 file. This file is plain text, but it is processed like as a template, and has
@@ -27,7 +27,8 @@ To learn more about the release, try:
 
 ```
 
-Now if we run `helm install rude-cardinal ./mychart` we will see this message at the bottom:
+Now if we run `helm install rude-cardinal ./mychart` we will see this message at
+the bottom:
 
 ```
 RESOURCES:

--- a/content/en/docs/chart_template_guide/subcharts_and_globals.md
+++ b/content/en/docs/chart_template_guide/subcharts_and_globals.md
@@ -35,8 +35,8 @@ $ rm -rf mysubchart/templates/*.*
 
 Notice that just as before, we deleted all of the base templates so that we can
 start from scratch. In this guide, we are focused on how templates work, not on
-managing dependencies. But the [Charts Guide]({{< ref "../topics/charts.md" >}}) has more information
-on how subcharts work.
+managing dependencies. But the [Charts Guide]({{< ref "../topics/charts.md" >}})
+has more information on how subcharts work.
 
 ## Adding Values and a Template to the Subchart
 
@@ -238,8 +238,7 @@ will only accept a string literal.
 
 The Go template language provides a `block` keyword that allows developers to
 provide a default implementation which is overridden later. In Helm charts,
-blocks are not the best tool for overriding because if multiple
-implementations of the same block are provided, the one selected is
-unpredictable.
+blocks are not the best tool for overriding because if multiple implementations
+of the same block are provided, the one selected is unpredictable.
 
 The suggestion is to instead use `include`.

--- a/content/en/docs/chart_template_guide/values_files.md
+++ b/content/en/docs/chart_template_guide/values_files.md
@@ -5,8 +5,8 @@ weight: 4
 ---
 
 In the previous section we looked at the built-in objects that Helm templates
-offer. One of the built-in objects is `Values`. This object provides access
-to values passed into the chart. Its contents come from multiple sources:
+offer. One of the built-in objects is `Values`. This object provides access to
+values passed into the chart. Its contents come from multiple sources:
 
 - The `values.yaml` file in the chart
 - If this is a subchart, the `values.yaml` file of a parent chart

--- a/content/en/docs/chart_template_guide/wrapping_up.md
+++ b/content/en/docs/chart_template_guide/wrapping_up.md
@@ -4,23 +4,41 @@ description: "Wrapping up - some useful pointers to other documentation that wil
 weight: 14
 ---
 
-This guide is intended to give you, the chart developer, a strong understanding of how to use Helm's template language. The guide focuses on the technical aspects of template development.
+This guide is intended to give you, the chart developer, a strong understanding
+of how to use Helm's template language. The guide focuses on the technical
+aspects of template development.
 
-But there are many things this guide has not covered when it comes to the practical day-to-day development of charts. Here are some useful pointers to other documentation that will help you as you create new charts:
+But there are many things this guide has not covered when it comes to the
+practical day-to-day development of charts. Here are some useful pointers to
+other documentation that will help you as you create new charts:
 
-- The [Helm Charts project](https://github.com/helm/charts) is an indispensable source of charts. That project also sets the standard for best practices in chart development.
-- The Kubernetes [Documentation](https://kubernetes.io/docs/home/) provides detailed examples of the various resource kinds that you can use, from ConfigMaps and Secrets to DaemonSets and Deployments.
-- The Helm [Charts Guide](../../topics/charts/) explains the workflow of using charts.
-- The Helm [Chart Hooks Guide](../../topics/charts_hooks/) explains how to create lifecycle hooks.
-- The Helm [Charts Tips and Tricks](../../howto/charts_tips_and_tricks/) article provides some useful tips for writing charts.
-- The [Sprig documentation](https://github.com/Masterminds/sprig) documents more than sixty of the template functions.
-- The [Go template docs](https://godoc.org/text/template) explain the template syntax in detail.
-- The [Schelm tool](https://github.com/databus23/schelm) is a nice helper utility for debugging charts.
+- The [Helm Charts project](https://github.com/helm/charts) is an indispensable
+  source of charts. That project also sets the standard for best practices in
+  chart development.
+- The Kubernetes [Documentation](https://kubernetes.io/docs/home/) provides
+  detailed examples of the various resource kinds that you can use, from
+  ConfigMaps and Secrets to DaemonSets and Deployments.
+- The Helm [Charts Guide](../../topics/charts/) explains the workflow of using
+  charts.
+- The Helm [Chart Hooks Guide](../../topics/charts_hooks/) explains how to
+  create lifecycle hooks.
+- The Helm [Charts Tips and Tricks](../../howto/charts_tips_and_tricks/) article
+  provides some useful tips for writing charts.
+- The [Sprig documentation](https://github.com/Masterminds/sprig) documents more
+  than sixty of the template functions.
+- The [Go template docs](https://godoc.org/text/template) explain the template
+  syntax in detail.
+- The [Schelm tool](https://github.com/databus23/schelm) is a nice helper
+  utility for debugging charts.
 
-Sometimes it's easier to ask a few questions and get answers from experienced developers. The best place to do this is in the [Kubernetes Slack](https://kubernetes.slack.com) Helm channels:
+Sometimes it's easier to ask a few questions and get answers from experienced
+developers. The best place to do this is in the [Kubernetes
+Slack](https://kubernetes.slack.com) Helm channels:
 
 - [#helm-users](https://kubernetes.slack.com/messages/helm-users)
 - [#helm-dev](https://kubernetes.slack.com/messages/helm-dev)
 - [#charts](https://kubernetes.slack.com/messages/charts)
 
-Finally, if you find errors or omissions in this document, want to suggest some new content, or would like to contribute, visit [The Helm Project](https://github.com/helm/helm).
+Finally, if you find errors or omissions in this document, want to suggest some
+new content, or would like to contribute, visit [The Helm
+Project](https://github.com/helm/helm).

--- a/content/en/docs/community/developers.md
+++ b/content/en/docs/community/developers.md
@@ -57,16 +57,24 @@ The code for the Helm project is organized as follows:
 - The `scripts/` directory contains a number of utility scripts. Most of these
   are used by the CI/CD pipeline.
 
-Go dependency management is in flux, and it is likely to change during the course of Helm's lifecycle. We encourage developers to _not_ try to manually manage dependencies. Instead, we suggest relying upon the project's `Makefile` to do that for you. With Helm 3, it is recommended that you are on Go version 1.13 or later.
+Go dependency management is in flux, and it is likely to change during the
+course of Helm's lifecycle. We encourage developers to _not_ try to manually
+manage dependencies. Instead, we suggest relying upon the project's `Makefile`
+to do that for you. With Helm 3, it is recommended that you are on Go version
+1.13 or later.
 
 ### Writing Documentation
 
-Since Helm 3, documentation has been moved to its own repository. When writing new features, please write accompanying documentation and submit it to the [helm-www](https://github.com/helm/helm-www) repository.
+Since Helm 3, documentation has been moved to its own repository. When writing
+new features, please write accompanying documentation and submit it to the
+[helm-www](https://github.com/helm/helm-www) repository.
 
 ### Git Conventions
 
 We use Git for our version control system. The `master` branch is the home of
-the current development candidate. Releases are tagged. If you are working on patches for Helm v2, the branch `dev-v2` is the base branch from which Helm 2 releases are cut.
+the current development candidate. Releases are tagged. If you are working on
+patches for Helm v2, the branch `dev-v2` is the base branch from which Helm 2
+releases are cut.
 
 We accept changes to the code via GitHub Pull Requests (PRs). One workflow for
 doing this is as follows:
@@ -129,4 +137,6 @@ Read more:
 - The Go Wiki has a great article on
   [formatting](https://github.com/golang/go/wiki/CodeReviewComments).
 
-If you run the `make test` target, not only will unit tests be run, but so will style tests. If the `make test` target fails, even for stylistic reasons, your PR will not be considered ready for merging.
+If you run the `make test` target, not only will unit tests be run, but so will
+style tests. If the `make test` target fails, even for stylistic reasons, your
+PR will not be considered ready for merging.

--- a/content/en/docs/community/history.md
+++ b/content/en/docs/community/history.md
@@ -5,14 +5,29 @@ aliases: ["/docs/history/"]
 weight: 4
 ---
 
-Helm 3 is a [CNCF project](https://www.cncf.io/projects/) in the [final stages of incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc).
+Helm 3 is a [CNCF project](https://www.cncf.io/projects/) in the [final stages
+of
+incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc).
 
-Helm began as what is now known as [Helm Classic](https://github.com/helm/helm-classic), a Deis project begun in 2015 and introduced at the inaugural KubeCon.
+Helm began as what is now known as [Helm
+Classic](https://github.com/helm/helm-classic), a Deis project begun in 2015 and
+introduced at the inaugural KubeCon.
 
-In January of 2016, the project merged with a GCS tool called Kubernetes Deployment Manager, and the project was moved under [Kubernetes](https://kubernetes.io). As a result of the merging of codebases, Helm 2.0 was released later that year. The key feature of Deployment Manager that survived in Helm 2 was the server-side component, renamed from DM to Tiller for the final Helm 2.0 release.
+In January of 2016, the project merged with a GCS tool called Kubernetes
+Deployment Manager, and the project was moved under
+[Kubernetes](https://kubernetes.io). As a result of the merging of codebases,
+Helm 2.0 was released later that year. The key feature of Deployment Manager
+that survived in Helm 2 was the server-side component, renamed from DM to Tiller
+for the final Helm 2.0 release.
 
-Helm was promoted from a Kubernetes subproject to a full-fledged CNCF project in June, 2018. Helm formed a top-level governing body and several projects were subsumed under the Helm project, including Monocular, the Helm Chart Repo, Chart Museum, and later the Helm Hub.
+Helm was promoted from a Kubernetes subproject to a full-fledged CNCF project in
+June, 2018. Helm formed a top-level governing body and several projects were
+subsumed under the Helm project, including Monocular, the Helm Chart Repo, Chart
+Museum, and later the Helm Hub.
 
-When the Helm 3 development cycle began, Tiller was removed, bringing Helm closer to its original vision of being a client tool. But Helm 3 continues to track releases inside of the Kubernetes cluster, making it possible for teams to work together on a common set of Helm releases.
+When the Helm 3 development cycle began, Tiller was removed, bringing Helm
+closer to its original vision of being a client tool. But Helm 3 continues to
+track releases inside of the Kubernetes cluster, making it possible for teams to
+work together on a common set of Helm releases.
 
 Helm 3 was released in November 2019.

--- a/content/en/docs/community/localization.md
+++ b/content/en/docs/community/localization.md
@@ -9,49 +9,86 @@ This guide explains how to localize the Helm documentation.
 
 ## Getting Started
 
-Contributions for translations use the same process as contributions for documentation. Translations are supplied through [pull requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) to the [helm-www](https://github.com/helm/helm-www) git repository and pull requests are reviewed by the team that manages the website.
+Contributions for translations use the same process as contributions for
+documentation. Translations are supplied through [pull
+requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+to the [helm-www](https://github.com/helm/helm-www) git repository and pull
+requests are reviewed by the team that manages the website.
 
 ### Two-letter Language Code
 
-Documentation is organized by the [ISO 639-1 standard](https://www.loc.gov/standards/iso639-2/php/code_list.php) for the language codes. For example, the two-letter code for Korean is `ko`.
+Documentation is organized by the [ISO 639-1
+standard](https://www.loc.gov/standards/iso639-2/php/code_list.php) for the
+language codes. For example, the two-letter code for Korean is `ko`.
 
-In content and configuration you will find the language code in use. Here are 3 examples:
+In content and configuration you will find the language code in use. Here are 3
+examples:
 
-- In the `content` directory the language codes are the subdirectories and the localized content for the language is in each directory. Primarily in the `docs` subdirectory of each language code directory.
-- The `i18n` directory contains a configuration file for each language with phrases used on the website. The files are named with the patter `[LANG].toml` where `[LANG]` is the two letter language code.
-- In the top level `config.toml` file there is configuration for navigation and other details organized by language code.
+- In the `content` directory the language codes are the subdirectories and the
+  localized content for the language is in each directory. Primarily in the
+  `docs` subdirectory of each language code directory.
+- The `i18n` directory contains a configuration file for each language with
+  phrases used on the website. The files are named with the patter `[LANG].toml`
+  where `[LANG]` is the two letter language code.
+- In the top level `config.toml` file there is configuration for navigation and
+  other details organized by language code.
 
-English, with a language code of `en`, is the default language and source for translations.
+English, with a language code of `en`, is the default language and source for
+translations.
 
 ### Fork, Branch, Change, Pull Request
 
-To contribute translations start by [creating a fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) of the [helm-www repository](https://github.com/helm/helm-www) on GitHub. You will start by committing the changes to your fork.
+To contribute translations start by [creating a
+fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
+of the [helm-www repository](https://github.com/helm/helm-www) on GitHub. You
+will start by committing the changes to your fork.
 
-By default your fork will be set to work on the default branch known as master. Please use branches to develop your changes and create pull requests. If you are unfamiliar with branches you can [read about them in the GitHub documentation](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches).
+By default your fork will be set to work on the default branch known as master.
+Please use branches to develop your changes and create pull requests. If you are
+unfamiliar with branches you can [read about them in the GitHub
+documentation](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches).
 
-Once you have a branch make changes to add translations and localize the content to a language.
+Once you have a branch make changes to add translations and localize the content
+to a language.
 
-Note, Helm uses a [Developers Certificate of Origin](https://developercertificate.org/). All commits need to have signoff. When making a commit you can use the `-s` or `--signoff` flag to use your Git configured name and email address to signoff on the commit. More details are available in the [CONTRIBUTING.md](https://github.com/helm/helm-www/blob/master/CONTRIBUTING.md#sign-your-work) file
+Note, Helm uses a [Developers Certificate of
+Origin](https://developercertificate.org/). All commits need to have signoff.
+When making a commit you can use the `-s` or `--signoff` flag to use your Git
+configured name and email address to signoff on the commit. More details are
+available in the
+[CONTRIBUTING.md](https://github.com/helm/helm-www/blob/master/CONTRIBUTING.md#sign-your-work)
+file
 
-When you are ready, create a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) with the translation back to the helm-www repository.
+When you are ready, create a [pull
+request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+with the translation back to the helm-www repository.
 
-Once a pull request has been created one of the maintainers will review it. Details on that process are in the [CONTRIBUTING.md](https://github.com/helm/helm-www/blob/master/CONTRIBUTING.md) file.
+Once a pull request has been created one of the maintainers will review it.
+Details on that process are in the
+[CONTRIBUTING.md](https://github.com/helm/helm-www/blob/master/CONTRIBUTING.md)
+file.
 
 ## Translating Content
 
-Localizing all of the Helm content is a large task. It is ok to start small. The translations can be expanded over time.
+Localizing all of the Helm content is a large task. It is ok to start small. The
+translations can be expanded over time.
 
 ### Starting A New Language
 
 When starting a new language there is a minimum needed. This includes:
 
-- Adding a `content/[LANG]/docs` directory containing an `_index.md` file. This is the top level documentation landing page.
-- Creating a `[LANG].toml` file in the `i18n` directory. Initially you can copy the `en.toml` file as a starting point.
-- Adding a section for the language to the `config.toml` file to expose the new language. An existing language section can serve as a starting point.
+- Adding a `content/[LANG]/docs` directory containing an `_index.md` file. This
+  is the top level documentation landing page.
+- Creating a `[LANG].toml` file in the `i18n` directory. Initially you can copy
+  the `en.toml` file as a starting point.
+- Adding a section for the language to the `config.toml` file to expose the new
+  language. An existing language section can serve as a starting point.
 
 ### Translating
 
-Translated content needs to reside in the `content/[LANG]/docs` directory. It should have the same URL as the English source. For example, to translate the intro into Korean it can be useful to copy the english source like:
+Translated content needs to reside in the `content/[LANG]/docs` directory. It
+should have the same URL as the English source. For example, to translate the
+intro into Korean it can be useful to copy the english source like:
 
 ```sh
 mkdir -p content/ko/docs/intro
@@ -60,16 +97,23 @@ cp content/en/docs/intro/install.md content/ko/docs/intro/install.md
 
 The content in the new file can then be translated into the other language.
 
-Note, translation tools can help with the process. This includes machine generated translations. Machine generated translations should be edited or otherwise reviewing for grammar and meaning by a native language speaker before publishing.
+Note, translation tools can help with the process. This includes machine
+generated translations. Machine generated translations should be edited or
+otherwise reviewing for grammar and meaning by a native language speaker before
+publishing.
 
 
 ## Navigating Between Languages
 
-![Screen Shot 2020-05-11 at 11 24 22 AM](https://user-images.githubusercontent.com/686194/81597103-035de600-937a-11ea-9834-cd9dcef4e914.png)
+![Screen Shot 2020-05-11 at 11 24 22
+AM](https://user-images.githubusercontent.com/686194/81597103-035de600-937a-11ea-9834-cd9dcef4e914.png)
 
-The site global [config.toml](https://github.com/helm/helm-www/blob/master/config.toml#L83L89) file is where language navigation is configured.
+The site global
+[config.toml](https://github.com/helm/helm-www/blob/master/config.toml#L83L89)
+file is where language navigation is configured.
 
-To add a new language, add a new set of parameters using the [two-letter language code](./localization/#two-letter-language-code) defined above. Example:
+To add a new language, add a new set of parameters using the [two-letter
+language code](./localization/#two-letter-language-code) defined above. Example:
 
 ```
 # Korean
@@ -83,7 +127,9 @@ weight = 1
 
 ## Resolving Internal Links
 
-Translated content will sometimes include links to pages that only exist in another language. This will result in site [build errors](https://app.netlify.com/sites/helm-merge/deploys). Example:
+Translated content will sometimes include links to pages that only exist in
+another language. This will result in site [build
+errors](https://app.netlify.com/sites/helm-merge/deploys). Example:
 
 ```
 12:45:31 PM: htmltest started at 12:45:30 on app
@@ -99,8 +145,12 @@ To resolve this, you need to check your content for internal links.
 * anchor links need to reflect the translated `id` value
 * internal page links need to be fixed
 
-For internal pages that do not exist _(or have not been translated yet)_, the site will not build until a correction is made. As a fallback, the url can point to another language where that content _does_ exist as follows:
+For internal pages that do not exist _(or have not been translated yet)_, the
+site will not build until a correction is made. As a fallback, the url can point
+to another language where that content _does_ exist as follows:
 
 `< relref path="/docs/topics/library_charts.md" lang="en" >`
 
-See the [Hugo Docs on cross references between languages](https://gohugo.io/content-management/cross-references/#link-to-another-language-version) for more info.
+See the [Hugo Docs on cross references between
+languages](https://gohugo.io/content-management/cross-references/#link-to-another-language-version)
+for more info.

--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -5,8 +5,8 @@ weight: 3
 aliases: ["/docs/related/"]
 ---
 
-The Helm community has produced many extra tools, plugins, and documentation about Helm. We love to
-hear about these projects.
+The Helm community has produced many extra tools, plugins, and documentation
+about Helm. We love to hear about these projects.
 
 If you have anything you'd like to add to this list, please open an
 [issue](https://github.com/helm/helm-www/issues) or [pull
@@ -14,62 +14,75 @@ request](https://github.com/helm/helm-www/pulls).
 
 ## Helm Plugins
 
-- [Helm Diff](https://github.com/databus23/helm-diff) - Preview `helm upgrade` as a coloured diff
-- [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories on Google Cloud
-  Storage
-- [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - Plugin to monitor a release
-  and rollback based on Prometheus/ElasticSearch query
-- [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm Charts from hiera using
-  k8comp
-- [helm-unittest](https://github.com/lrills/helm-unittest) - Plugin for unit testing chart locally
-  with YAML
-- [hc-unit](https://github.com/xchapter7x/hcunit) - Plugin for unit testing charts locally using OPA
-  (Open Policy Agent) & Rego
-- [helm-s3](https://github.com/hypnoglow/helm-s3) - Helm plugin that allows to use AWS S3 as a
-  [private] chart repository
-- [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) - Helm Plugin that generates
-  values yaml schema for your Helm 3 charts
-- [helm-secrets](https://github.com/jkroepke/helm-secrets) - Plugin to manage and store secrets safely (based on [sops](https://github.com/mozilla/sops)) 
+- [Helm Diff](https://github.com/databus23/helm-diff) - Preview `helm upgrade`
+  as a coloured diff
+- [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories
+  on Google Cloud Storage
+- [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - Plugin to
+  monitor a release and rollback based on Prometheus/ElasticSearch query
+- [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm
+  Charts from hiera using k8comp
+- [helm-unittest](https://github.com/lrills/helm-unittest) - Plugin for unit
+  testing chart locally with YAML
+- [hc-unit](https://github.com/xchapter7x/hcunit) - Plugin for unit testing
+  charts locally using OPA (Open Policy Agent) & Rego
+- [helm-s3](https://github.com/hypnoglow/helm-s3) - Helm plugin that allows to
+  use AWS S3 as a [private] chart repository
+- [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) - Helm
+  Plugin that generates values yaml schema for your Helm 3 charts
+- [helm-secrets](https://github.com/jkroepke/helm-secrets) - Plugin to manage
+  and store secrets safely (based on [sops](https://github.com/mozilla/sops)) 
 
 We also encourage GitHub authors to use the
-[helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories) tag on their plugin
-repositories.
+[helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories)
+tag on their plugin repositories.
 
 ## Additional Tools
 
 Tools layered on top of Helm.
 
-- [Chartify](https://github.com/appscode/chartify) - Generate Helm charts from existing Kubernetes
-  resources.
-- [VIM-Kubernetes](https://github.com/andrewstuart/vim-kubernetes) - VIM plugin for Kubernetes and
-  Helm
-- [Landscaper](https://github.com/Eneco/landscaper/) - "Landscaper takes a set of Helm Chart
-  references with values (a desired state), and realizes this in a Kubernetes cluster."
-- [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative spec for deploying helm
-  charts
-- [Helmsman](https://github.com/Praqma/helmsman) - Helmsman is a helm-charts-as-code tool which
-  enables installing/upgrading/protecting/moving/deleting releases from version controlled desired
-  state files (described in a simple TOML format)
-- [Terraform Helm Provider](https://github.com/hashicorp/terraform-provider-helm) - The Helm provider for HashiCorp Terraform enables lifecycle management of Helm Charts with a declarative infrastructure-as-code syntax.  The Helm provider is often paired the other Terraform providers, like the Kubernetes provider, to create a common workflow across all infrastructure services.
-- [Monocular](https://github.com/helm/monocular) - Web UI for Helm Chart repositories
-- [Armada](https://airshipit.readthedocs.io/projects/armada/en/latest/) - Manage prefixed releases
-  throughout various Kubernetes namespaces, and removes completed jobs for complex deployments
-- [ChartMuseum](https://github.com/helm/chartmuseum) - Helm Chart Repository with support for Amazon
-  S3 and Google Cloud Storage
-- [Codefresh](https://codefresh.io) - Kubernetes native CI/CD and management platform with UI
-  dashboards for managing Helm charts and releases
-- [Captain](https://github.com/alauda/captain) - A Helm3 Controller using HelmRequest and Release
-  CRD
-- [chart-registry](https://github.com/hangyan/chart-registry) - Helm Charts Hosts on OCI Registry
+- [Chartify](https://github.com/appscode/chartify) - Generate Helm charts from
+  existing Kubernetes resources.
+- [VIM-Kubernetes](https://github.com/andrewstuart/vim-kubernetes) - VIM plugin
+  for Kubernetes and Helm
+- [Landscaper](https://github.com/Eneco/landscaper/) - "Landscaper takes a set
+  of Helm Chart references with values (a desired state), and realizes this in a
+  Kubernetes cluster."
+- [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative
+  spec for deploying helm charts
+- [Helmsman](https://github.com/Praqma/helmsman) - Helmsman is a
+  helm-charts-as-code tool which enables
+  installing/upgrading/protecting/moving/deleting releases from version
+  controlled desired state files (described in a simple TOML format)
+- [Terraform Helm
+  Provider](https://github.com/hashicorp/terraform-provider-helm) - The Helm
+  provider for HashiCorp Terraform enables lifecycle management of Helm Charts
+  with a declarative infrastructure-as-code syntax.  The Helm provider is often
+  paired the other Terraform providers, like the Kubernetes provider, to create
+  a common workflow across all infrastructure services.
+- [Monocular](https://github.com/helm/monocular) - Web UI for Helm Chart
+  repositories
+- [Armada](https://airshipit.readthedocs.io/projects/armada/en/latest/) - Manage
+  prefixed releases throughout various Kubernetes namespaces, and removes
+  completed jobs for complex deployments
+- [ChartMuseum](https://github.com/helm/chartmuseum) - Helm Chart Repository
+  with support for Amazon S3 and Google Cloud Storage
+- [Codefresh](https://codefresh.io) - Kubernetes native CI/CD and management
+  platform with UI dashboards for managing Helm charts and releases
+- [Captain](https://github.com/alauda/captain) - A Helm3 Controller using
+  HelmRequest and Release CRD
+- [chart-registry](https://github.com/hangyan/chart-registry) - Helm Charts
+  Hosts on OCI Registry
 
 ## Helm Included
 
 Platforms, distributions, and services that include Helm support.
 
 - [Kubernetic](https://kubernetic.com/) - Kubernetes Desktop Client
-- [Jenkins X](https://jenkins-x.io/) - open source automated CI/CD for Kubernetes which uses Helm
-  for [promoting](https://jenkins-x.io/docs/getting-started/promotion/) applications through
-  environments via GitOps
+- [Jenkins X](https://jenkins-x.io/) - open source automated CI/CD for
+  Kubernetes which uses Helm for
+  [promoting](https://jenkins-x.io/docs/getting-started/promotion/) applications
+  through environments via GitOps
 
 ## Misc
 

--- a/content/en/docs/community/release_checklist.md
+++ b/content/en/docs/community/release_checklist.md
@@ -112,7 +112,8 @@ git cherry-pick -x <commit-id>
 ```
 
 After the commits have been cherry picked the release branch needs to be pushed
-which will cause the tests to run. Make sure they pass prior to creating the tag.
+which will cause the tests to run. Make sure they pass prior to creating the
+tag.
 
 ```shell
 git push upstream $RELEASE_BRANCH_NAME
@@ -127,8 +128,8 @@ git push upstream "$RELEASE_NAME"
 
 This new tag is going to be the base for the patch release.
 
-Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) to
-see that the release passed CI before proceeding.
+Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) to see
+that the release passed CI before proceeding.
 
 ## 2. Change the Version Number in Git
 
@@ -195,8 +196,8 @@ upstream and start the test process.
 git push upstream $RELEASE_BRANCH_NAME
 ```
 
-Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) to
-see that the release passed CI before proceeding.
+Make sure to check [helm on CircleCI](https://circleci.com/gh/helm/helm) to see
+that the release passed CI before proceeding.
 
 If anyone is available, let others peer-review the branch before continuing to
 ensure that all the proper changes have been made and all of the commits for the
@@ -310,7 +311,8 @@ make sign
 This will generate ascii armored signature files for each of the files pushed by
 CI.
 
-All of the signature files (`*.asc`) need to be uploaded to the release on GitHub.
+All of the signature files (`*.asc`) need to be uploaded to the release on
+GitHub.
 
 ## 8. Write the Release Notes
 
@@ -368,18 +370,22 @@ The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will g
 - fix circle not building tags f4f932fabd197f7e6d608c8672b33a483b4b76fa (Matthew Fisher)
 ```
 
-A partially completed set of release notes including the changelog can be created by running the following command:
+A partially completed set of release notes including the changelog can be
+created by running the following command:
 
 ```shell
 export PREVIOUS_RELEASE=vX.Y.Z
 make release-notes
 ```
 
-This will create a good baseline set of release notes to which you should just need to fill out the **Notable Changes** and **What's next** sections.
+This will create a good baseline set of release notes to which you should just
+need to fill out the **Notable Changes** and **What's next** sections.
 
-Feel free to add your voice to the release notes; it's nice for people to think we're not all robots.
+Feel free to add your voice to the release notes; it's nice for people to think
+we're not all robots.
 
-You should also double check the URLs and checksums are correct in the auto-generated release notes.
+You should also double check the URLs and checksums are correct in the
+auto-generated release notes.
 
 Once finished, go into GitHub and edit the release notes for the tagged release
 with the notes written here.
@@ -393,7 +399,11 @@ When you are ready to go, hit `publish`.
 
 ## 9. Update Docs Site
 
-The [Helm website docs section](https://helm.sh/docs) lists the Helm versions for the docs. The minor and patch information needs to be updated on the site. To do that create a pull request against the [helm-www repository](https://github.com/helm/helm-www). In the `config.toml` file find the proper `params.versions` section and updated the Helm version.
+The [Helm website docs section](https://helm.sh/docs) lists the Helm versions
+for the docs. The minor and patch information needs to be updated on the site.
+To do that create a pull request against the [helm-www
+repository](https://github.com/helm/helm-www). In the `config.toml` file find
+the proper `params.versions` section and updated the Helm version.
 
 ## 10. Evangelize
 

--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -180,25 +180,37 @@ somewhere. In Helm 2, this was stored in the same namespace as Tiller. In
 practice, this meant that once a name was used by a release, no other release
 could use that same name, even if it was deployed in a different namespace.
 
-In Helm 3, information about a particular release is now stored in the
-same namespace as the release itself. This means that users can now `helm
-install wordpress stable/wordpress` in two separate namespaces, and each can be
-referred with `helm list` by changing the current namespace context (e.g. `helm
-list --namespace foo`).
+In Helm 3, information about a particular release is now stored in the same
+namespace as the release itself. This means that users can now `helm install
+wordpress stable/wordpress` in two separate namespaces, and each can be referred
+with `helm list` by changing the current namespace context (e.g. `helm list
+--namespace foo`).
 
-With this greater alignment to native cluster namespaces, the `helm list` command
-no longer lists all releases by default. Instead, it will list only the releases
-in the namespace of your current kubernetes context (i.e. the namespace shown
-when you run `kubectl config view --minify`). It also means you must supply the
-`--all-namespaces` flag to `helm list` to get behaviour similar to Helm 2.
+With this greater alignment to native cluster namespaces, the `helm list`
+command no longer lists all releases by default. Instead, it will list only the
+releases in the namespace of your current kubernetes context (i.e. the namespace
+shown when you run `kubectl config view --minify`). It also means you must
+supply the `--all-namespaces` flag to `helm list` to get behaviour similar to
+Helm 2.
 
 ### Secrets as the default storage driver
 
-In Helm 3, Secrets are now used as the [default storage driver](/docs/topics/advanced/#storage-backends). Helm 2 used ConfigMaps by default to store release information. In Helm 2.7.0, a new storage backend that uses Secrets for storing release information was implemented, and it is now the default starting in Helm 3.
+In Helm 3, Secrets are now used as the [default storage
+driver](/docs/topics/advanced/#storage-backends). Helm 2 used ConfigMaps by
+default to store release information. In Helm 2.7.0, a new storage backend that
+uses Secrets for storing release information was implemented, and it is now the
+default starting in Helm 3.
 
-Changing to Secrets as the Helm 3 default allows for additional security in protecting charts in conjunction with the release of Secret encryption in Kubernetes.
+Changing to Secrets as the Helm 3 default allows for additional security in
+protecting charts in conjunction with the release of Secret encryption in
+Kubernetes.
 
-[Encrypting secrets at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) became available as an alpha feature in Kubernetes 1.7 and became stable as of Kubernetes 1.13. This allows users to encrypt Helm release metadata at rest, and so it is a good starting point that can be expanded later into using something like Vault.
+[Encrypting secrets at
+rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) became
+available as an alpha feature in Kubernetes 1.7 and became stable as of
+Kubernetes 1.13. This allows users to encrypt Helm release metadata at rest, and
+so it is a good starting point that can be expanded later into using something
+like Vault.
 
 ### Go import path changes
 
@@ -432,10 +444,10 @@ we'd love it.
 
 ### Why do you provide a `curl ...|bash` script?
 
-There is a script in our repository (`scripts/get-helm-3`) that can be executed as a
-`curl ..|bash` script. The transfers are all protected by HTTPS, and the script
-does some auditing of the packages it fetches. However, the script has all the
-usual dangers of any shell script.
+There is a script in our repository (`scripts/get-helm-3`) that can be executed
+as a `curl ..|bash` script. The transfers are all protected by HTTPS, and the
+script does some auditing of the packages it fetches. However, the script has
+all the usual dangers of any shell script.
 
 We provide it because it is useful, but we suggest that users carefully read the
 script first. What we'd really like, though, are better packaged releases of
@@ -502,10 +514,10 @@ It is likely that you have missed the fact that Helm 3 now uses cluster
 namespaces throughout to scope releases. This means that for all commands
 referencing a release you must either:
 
-* rely on the current namespace in the active kubernetes context (as
-  described by the `kubectl config view --minify` command),
+* rely on the current namespace in the active kubernetes context (as described
+  by the `kubectl config view --minify` command),
 * specify the correct namespace using the `--namespace`/`-n` flag, or
 * for the `helm list` command, specify the `--all-namespaces`/`-A` flag
 
-This applies to `helm ls`, `helm uninstall`, and all other `helm`
-commands referencing a release.
+This applies to `helm ls`, `helm uninstall`, and all other `helm` commands
+referencing a release.

--- a/content/en/docs/howto/chart_repository_sync_example.md
+++ b/content/en/docs/howto/chart_repository_sync_example.md
@@ -17,8 +17,9 @@ which serves a chart repository.*
   on your GCS bucket in case you accidentally delete something._
 
 ## Set up a local chart repository directory
-Create a local directory like we did in [the chart repository
-guide]({{< ref "/docs/topics/chart_repository.md" >}}), and place your packaged charts in that directory.
+Create a local directory like we did in [the chart repository guide]({{< ref
+"/docs/topics/chart_repository.md" >}}), and place your packaged charts in that
+directory.
 
 For example:
 ```console

--- a/content/en/docs/howto/charts_tips_and_tricks.md
+++ b/content/en/docs/howto/charts_tips_and_tricks.md
@@ -91,11 +91,11 @@ context.
 
 Go provides a way for setting template options to control behavior when a map is
 indexed with a key that's not present in the map. This is typically set with
-`template.Options("missingkey=option")`, where `option` can be `default`, `zero`, or
-`error`. While setting this option to error will stop execution with an error,
-this would apply to every missing key in the map. There may be situations where
-a chart developer wants to enforce this behavior for select values in the
-`values.yaml` file.
+`template.Options("missingkey=option")`, where `option` can be `default`,
+`zero`, or `error`. While setting this option to error will stop execution with
+an error, this would apply to every missing key in the map. There may be
+situations where a chart developer wants to enforce this behavior for select
+values in the `values.yaml` file.
 
 The `required` function gives developers the ability to declare a value entry as
 required for template rendering. If the entry is empty in `values.yaml`, the
@@ -108,14 +108,14 @@ For example:
 {{ required "A valid foo is required!" .Values.foo }}
 ```
 
-The above will render the template when `.Values.foo` is defined, but will fail to
-render and exit when `.Values.foo` is undefined.
+The above will render the template when `.Values.foo` is defined, but will fail
+to render and exit when `.Values.foo` is undefined.
 
 ## Using the 'tpl' Function
 
-The `tpl` function allows developers to evaluate strings as templates inside a template.
-This is useful to pass a template string as a value to a chart or render external configuration files.
-Syntax: `{{ tpl TEMPLATE_STRING VALUES }}`
+The `tpl` function allows developers to evaluate strings as templates inside a
+template. This is useful to pass a template string as a value to a chart or
+render external configuration files. Syntax: `{{ tpl TEMPLATE_STRING VALUES }}`
 
 Examples:
 
@@ -247,11 +247,12 @@ metadata:
 
 (Quotation marks are required)
 
-The annotation `"helm.sh/resource-policy": keep` instructs Helm to skip deleting this
-resource when a helm operation (such as `helm uninstall`, `helm upgrade` or `helm rollback`) 
-would result in its deletion. _However_, this resource becomes orphaned. Helm will no longer 
-manage it in any way. This can lead to problems if using `helm install --replace` on a release 
-that has already been uninstalled, but has kept resources.
+The annotation `"helm.sh/resource-policy": keep` instructs Helm to skip deleting
+this resource when a helm operation (such as `helm uninstall`, `helm upgrade` or
+`helm rollback`) would result in its deletion. _However_, this resource becomes
+orphaned. Helm will no longer manage it in any way. This can lead to problems if
+using `helm install --replace` on a release that has already been uninstalled,
+but has kept resources.
 
 ## Using "Partials" and Template Includes
 

--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -12,8 +12,8 @@ source, or from pre-built binary releases.
 
 The Helm project provides two ways to fetch and install Helm. These are the
 official methods to get Helm releases. In addition to that, the Helm community
-provides methods to install Helm through different package managers. Installation
-through those methods can be found below the official methods.
+provides methods to install Helm through different package managers.
+Installation through those methods can be found below the official methods.
 
 ### From the Binary Releases
 
@@ -26,11 +26,13 @@ and installed.
 3. Find the `helm` binary in the unpacked directory, and move it to its desired
    destination (`mv linux-amd64/helm /usr/local/bin/helm`)
 
-From there, you should be able to run the client and [add the stable repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository): `helm help`.
+From there, you should be able to run the client and [add the stable
+repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository):
+`helm help`.
 
-**Note:** Helm automated tests are performed for Linux AMD64 only during CircleCi
-builds and releases. Testing of other OSes are the responsibility of the community
-requesting Helm for the OS in question. 
+**Note:** Helm automated tests are performed for Linux AMD64 only during
+CircleCi builds and releases. Testing of other OSes are the responsibility of
+the community requesting Helm for the OS in question. 
 
 ### From Script
 
@@ -54,13 +56,13 @@ you want to live on the edge.
 ## Through Package Managers
 
 The Helm community provides the ability to install Helm through operating system
-package managers. These are not supported by the Helm project and are not considered
-trusted 3rd parties.
+package managers. These are not supported by the Helm project and are not
+considered trusted 3rd parties.
 
 ### From Homebrew (macOS)
 
-Members of the Helm community have contributed a Helm formula build to
-Homebrew. This formula is generally up to date.
+Members of the Helm community have contributed a Helm formula build to Homebrew.
+This formula is generally up to date.
 
 ```console
 brew install helm
@@ -81,7 +83,8 @@ choco install kubernetes-helm
 ### From Apt (Debian/Ubuntu)
 
 Members of the Helm community have contributed a [Helm
-package](https://helm.baltorepo.com/stable/debian/) for Apt. This package is generally up to date.
+package](https://helm.baltorepo.com/stable/debian/) for Apt. This package is
+generally up to date.
 
 ```console
 curl https://helm.baltorepo.com/organization/signing.asc | sudo apt-key add -
@@ -93,8 +96,8 @@ sudo apt-get install helm
 
 ### From Snap
 
-The [Snapcrafters](https://github.com/snapcrafters) community maintains the
-Snap version of the [Helm package](https://snapcraft.io/helm):
+The [Snapcrafters](https://github.com/snapcrafters) community maintains the Snap
+version of the [Helm package](https://snapcraft.io/helm):
 
 ```console
 sudo snap install helm --classic
@@ -102,7 +105,8 @@ sudo snap install helm --classic
 
 ### Development Builds
 
-In addition to releases you can download or install development snapshots of Helm.
+In addition to releases you can download or install development snapshots of
+Helm.
 
 ### From Canary Builds
 
@@ -131,8 +135,8 @@ $ cd helm
 $ make
 ```
 
-If required, it will fetch the dependencies and cache them, and
-validate configuration. It will then compile `helm` and place it in `bin/helm`.
+If required, it will fetch the dependencies and cache them, and validate
+configuration. It will then compile `helm` and place it in `bin/helm`.
 
 ## Conclusion
 
@@ -141,4 +145,5 @@ This document covers additional cases for those who want to do more
 sophisticated things with Helm.
 
 Once you have the Helm Client successfully installed, you can move on to using
-Helm to manage charts and [add the stable repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository).
+Helm to manage charts and [add the stable
+repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository).

--- a/content/en/docs/intro/quickstart.md
+++ b/content/en/docs/intro/quickstart.md
@@ -31,8 +31,8 @@ access controls (RBAC).
 Download a binary release of the Helm client. You can use tools like `homebrew`,
 or look at [the official releases page](https://github.com/helm/helm/releases).
 
-For more details, or for other options, see [the installation
-guide]({{< ref "install.md" >}}).
+For more details, or for other options, see [the installation guide]({{< ref
+"install.md" >}}).
 
 ## Initialize a Helm Chart Repository
 
@@ -70,16 +70,17 @@ Released smiling-penguin
 In the example above, the `stable/mysql` chart was released, and the name of our
 new release is `smiling-penguin`.
 
-You get a simple idea of the features of this MySQL chart by running 
-`helm show chart stable/mysql`. Or you could run `helm show all stable/mysql` 
-to get all information about the chart.
+You get a simple idea of the features of this MySQL chart by running `helm show
+chart stable/mysql`. Or you could run `helm show all stable/mysql` to get all
+information about the chart.
 
 Whenever you install a chart, a new release is created. So one chart can be
 installed multiple times into the same cluster. And each can be independently
 managed and upgraded.
 
 The `helm install` command is a very powerful command with many capabilities. To
-learn more about it, check out the [Using Helm Guide]({{< ref "using_helm.md" >}})
+learn more about it, check out the [Using Helm Guide]({{< ref "using_helm.md"
+>}})
 
 ## Learn About Releases
 
@@ -105,7 +106,7 @@ Removed smiling-penguin
 This will uninstall `smiling-penguin` from Kubernetes, which will remove all
 resources associated with the release as well as the release history.
 
-If the flag `--keep-history` is provided, release history will be kept. You will 
+If the flag `--keep-history` is provided, release history will be kept. You will
 be able to request information about that release:
 
 ```console

--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -5,12 +5,12 @@ weight: 3
 ---
 
 This guide explains the basics of using Helm to manage packages on your
-Kubernetes cluster. It assumes that you have already [installed]({{< ref "install.md" >}}) the
-Helm client.
+Kubernetes cluster. It assumes that you have already [installed]({{< ref
+"install.md" >}}) the Helm client.
 
 If you are simply interested in running a few quick commands, you may wish to
-begin with the [Quickstart Guide]({{< ref "quickstart.md" >}}). This chapter covers the
-particulars of Helm commands, and explains how to use Helm.
+begin with the [Quickstart Guide]({{< ref "quickstart.md" >}}). This chapter
+covers the particulars of Helm commands, and explains how to use Helm.
 
 ## Three Big Concepts
 
@@ -36,50 +36,52 @@ installation. And to find new charts, you can search Helm chart _repositories_.
 
 ## 'helm search': Finding Charts
 
-Helm comes with a powerful search command. It can be used to search two different
-types of source:
+Helm comes with a powerful search command. It can be used to search two
+different types of source:
 
-- `helm search hub` searches [the Helm Hub](https://hub.helm.sh), which comprises
-  helm charts from dozens of different repositories.
+- `helm search hub` searches [the Helm Hub](https://hub.helm.sh), which
+  comprises helm charts from dozens of different repositories.
 - `helm search repo` searches the repositories that you have added to your local
-  helm client (with `helm repo add`). This search is done over local data, and no
-  public network connection is needed.
+  helm client (with `helm repo add`). This search is done over local data, and
+  no public network connection is needed.
 
 You can find publicly available charts by running `helm search hub`:
 
 ```console
 $ helm search hub wordpress
-URL                                               	CHART VERSION	APP VERSION	DESCRIPTION
-https://hub.helm.sh/charts/bitnami/wordpress      	7.6.7        	5.2.4      	Web publishing platform for building blogs and ...
-https://hub.helm.sh/charts/presslabs/wordpress-...	v0.6.3       	v0.6.3     	Presslabs WordPress Operator Helm Chart
-https://hub.helm.sh/charts/presslabs/wordpress-...	v0.7.1       	v0.7.1     	A Helm chart for deploying a WordPress site on ...
+URL                                                 CHART VERSION APP VERSION DESCRIPTION
+https://hub.helm.sh/charts/bitnami/wordpress        7.6.7         5.2.4       Web publishing platform for building blogs and ...
+https://hub.helm.sh/charts/presslabs/wordpress-...  v0.6.3        v0.6.3      Presslabs WordPress Operator Helm Chart
+https://hub.helm.sh/charts/presslabs/wordpress-...  v0.7.1        v0.7.1      A Helm chart for deploying a WordPress site on ...
 ```
 
 The above searches for all `wordpress` charts on Helm Hub.
 
 With no filter, `helm search hub` shows you all of the available charts.
 
-Using `helm search repo`, you can find the names of the charts in repositories you have already added:
+Using `helm search repo`, you can find the names of the charts in repositories
+you have already added:
 
 ```console
 $ helm repo add brigade https://brigadecore.github.io/charts
 "brigade" has been added to your repositories
 $ helm search repo brigade
-NAME                        	CHART VERSION	APP VERSION	DESCRIPTION
-brigade/brigade             	1.3.2        	v1.2.1     	Brigade provides event-driven scripting of Kube...
-brigade/brigade-github-app  	0.4.1        	v0.2.1     	The Brigade GitHub App, an advanced gateway for...
-brigade/brigade-github-oauth	0.2.0        	v0.20.0    	The legacy OAuth GitHub Gateway for Brigade
-brigade/brigade-k8s-gateway 	0.1.0        	           	A Helm chart for Kubernetes
-brigade/brigade-project     	1.0.0        	v1.0.0     	Create a Brigade project
-brigade/kashti              	0.4.0        	v0.4.0     	A Helm chart for Kubernetes
+NAME                          CHART VERSION APP VERSION DESCRIPTION
+brigade/brigade               1.3.2         v1.2.1      Brigade provides event-driven scripting of Kube...
+brigade/brigade-github-app    0.4.1         v0.2.1      The Brigade GitHub App, an advanced gateway for...
+brigade/brigade-github-oauth  0.2.0         v0.20.0     The legacy OAuth GitHub Gateway for Brigade
+brigade/brigade-k8s-gateway   0.1.0                     A Helm chart for Kubernetes
+brigade/brigade-project       1.0.0         v1.0.0      Create a Brigade project
+brigade/kashti                0.4.0         v0.4.0      A Helm chart for Kubernetes
 ```
 
-Helm search uses a fuzzy string matching algorithm, so you can type parts of words or phrases:
+Helm search uses a fuzzy string matching algorithm, so you can type parts of
+words or phrases:
 
 ```console
 $ helm search repo kash
-NAME          	CHART VERSION	APP VERSION	DESCRIPTION
-brigade/kashti	0.4.0        	v0.4.0     	A Helm chart for Kubernetes
+NAME            CHART VERSION APP VERSION DESCRIPTION
+brigade/kashti  0.4.0         v0.4.0      A Helm chart for Kubernetes
 ```
 
 Search is a good way to find available packages. Once you have found a package
@@ -88,7 +90,8 @@ you want to install, you can use `helm install` to install it.
 ## 'helm install': Installing a Package
 
 To install a new package, use the `helm install` command. At its simplest, it
-takes two arguments: A release name that you pick, and the name of the chart you want to install.
+takes two arguments: A release name that you pick, and the name of the chart you
+want to install.
 
 ```console
 $ helm install happy-panda stable/mariadb
@@ -137,8 +140,8 @@ To upgrade this helm chart:
 ```
 
 Now the `mariadb` chart is installed. Note that installing a chart creates a new
-_release_ object. The release above is named `happy-panda`. (If you want Helm to generate
-a name for you, leave off the release name and use `--generate-name`.)
+_release_ object. The release above is named `happy-panda`. (If you want Helm to
+generate a name for you, leave off the release name and use `--generate-name`.)
 
 During installation, the `helm` client will print useful information about which
 resources were created, what the state of the release is, and also whether there
@@ -417,8 +420,8 @@ not a full list of cli flags. To see a description of all flags, just run `helm
 
 ## 'helm uninstall': Uninstalling a Release
 
-When it is time to uninstall a release from the cluster, use the
-`helm uninstall` command:
+When it is time to uninstall a release from the cluster, use the `helm
+uninstall` command:
 
 ```console
 $ helm uninstall happy-panda
@@ -438,12 +441,13 @@ uninstalled.
 
 In previous versions of Helm, when a release was deleted, a record of its
 deletion would remain. In Helm 3, deletion removes the release record as well.
-If you wish to keep a deletion release record, use `helm uninstall --keep-history`.
-Using `helm list --uninstalled` will only show releases that where uninstalled
-with the `--keep-history` flag.
+If you wish to keep a deletion release record, use `helm uninstall
+--keep-history`. Using `helm list --uninstalled` will only show releases that
+where uninstalled with the `--keep-history` flag.
 
-The `helm list --all` flag will show you all release records that Helm has retained,
-including records for failed or deleted items (if `--keep-history` was specified):
+The `helm list --all` flag will show you all release records that Helm has
+retained, including records for failed or deleted items (if `--keep-history` was
+specified):
 
 ```console
 $  helm list --all
@@ -453,8 +457,8 @@ inky-cat        1       Wed Sep 28 12:59:46 2016        DEPLOYED        alpine-0
 kindred-angelf  2       Tue Sep 27 16:16:10 2016        UNINSTALLED     alpine-0.1.0
 ```
 
-Note that because releases are now deleted by default, it is no longer possible to
-rollback an uninstalled resource.
+Note that because releases are now deleted by default, it is no longer possible
+to rollback an uninstalled resource.
 
 ## 'helm repo': Working with Repositories
 
@@ -483,8 +487,9 @@ Repositories can be removed with `helm repo remove`.
 
 ## Creating Your Own Charts
 
-The [Chart Development Guide]({{< ref "/docs/topics/charts.md" >}}) explains how to develop your own
-charts. But you can get started quickly by using the `helm create` command:
+The [Chart Development Guide]({{< ref "/docs/topics/charts.md" >}}) explains how
+to develop your own charts. But you can get started quickly by using the `helm
+create` command:
 
 ```console
 $ helm create deis-workflow
@@ -494,8 +499,8 @@ Creating deis-workflow
 Now there is a chart in `./deis-workflow`. You can edit it and create your own
 templates.
 
-As you edit your chart, you can validate that it is well-formed by running
-`helm lint`.
+As you edit your chart, you can validate that it is well-formed by running `helm
+lint`.
 
 When it's time to package the chart up for distribution, you can run the `helm
 package` command:

--- a/content/en/docs/topics/advanced.md
+++ b/content/en/docs/topics/advanced.md
@@ -29,8 +29,8 @@ the manifests before deployment.
 ### Usage
 A post-renderer can be any executable that accepts rendered Kubernetes manifests
 on STDIN and returns valid Kubernetes manifests on STDOUT. It should return an
-non-0 exit code in the event of a failure. This is the only "API" between the two
-components. It allows for great flexibility in what you can do with your
+non-0 exit code in the event of a failure. This is the only "API" between the
+two components. It allows for great flexibility in what you can do with your
 post-render process.
 
 A post renderer can be used with `install`, `upgrade`, and `template`. To use a
@@ -83,8 +83,9 @@ For more information on using the Go SDK, See the [Go SDK section](#go-sdk)
 ## Go SDK
 Helm 3 debuted a completely restructured Go SDK for a better experience when
 building software and tools that leverage Helm. Full documentation can be found
-at [https://pkg.go.dev/helm.sh/helm/v3](https://pkg.go.dev/helm.sh/helm/v3), but a brief overview of some of the most
-common packages and a simple example follow below.
+at [https://pkg.go.dev/helm.sh/helm/v3](https://pkg.go.dev/helm.sh/helm/v3), but
+a brief overview of some of the most common packages and a simple example follow
+below.
 
 ### Package overview
 This is a list of the most commonly used packages with a simple explanation
@@ -147,11 +148,12 @@ func main() {
 
 ## Storage backends
 
-Helm 3 changed the default release information storage to Secrets in the namespace
-of the release. Helm 2 by default stores release information as ConfigMaps in the
-namespace of the Tiller instance. The subsections which follow show how to
-configure different backends. This configuration is based on the `HELM_DRIVER` 
-environment variable. It can be set to one of the values: `[configmap, secret]`.
+Helm 3 changed the default release information storage to Secrets in the
+namespace of the release. Helm 2 by default stores release information as
+ConfigMaps in the namespace of the Tiller instance. The subsections which follow
+show how to configure different backends. This configuration is based on the
+`HELM_DRIVER` environment variable. It can be set to one of the values:
+`[configmap, secret]`.
 
 ### ConfigMap storage backend
 
@@ -164,22 +166,23 @@ You can set it in a shell as follows:
 export HELM_DRIVER=configmap
 ```
 
-If you want to switch from the default backend to the ConfigMap
-backend, you'll have to do the migration for this on your own. You can retrieve
-release information with the following command:
+If you want to switch from the default backend to the ConfigMap backend, you'll
+have to do the migration for this on your own. You can retrieve release
+information with the following command:
 
 ```shell
 kubectl get secret --all-namespaces -l "owner=helm"
 ```
 
-**PRODUCTION NOTES**: The release information might contain sensitive data
-(like passwords, private keys, and other credentials) that needs to be protected
-from unauthorized access. When managing Kubernetes authorization, for instance with 
-[RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), it
-is possible to grant broader access to ConfigMap resources, while restricting
-access to Secret resources. For instance, the default
-[user-facing role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
-"view" grants access to most resources, but not to Secrets. Furthermore, secrets data can be
-configured for [encrypted storage](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+**PRODUCTION NOTES**: The release information might contain sensitive data (like
+passwords, private keys, and other credentials) that needs to be protected from
+unauthorized access. When managing Kubernetes authorization, for instance with
+[RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), it is
+possible to grant broader access to ConfigMap resources, while restricting
+access to Secret resources. For instance, the default [user-facing
+role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
+"view" grants access to most resources, but not to Secrets. Furthermore, secrets
+data can be configured for [encrypted
+storage](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 Please keep that in mind if you decide to switch to the ConfigMap backend, as it
 could expose your application's sensitive data.

--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -205,17 +205,17 @@ charts inside of that folder.
 
 ### ChartMuseum Repository Server
 
-ChartMuseum is an open-source Helm Chart Repository server written in Go (Golang),
-with support for cloud storage backends, including
-[Google Cloud Storage](https://cloud.google.com/storage/),
-[Amazon S3](https://aws.amazon.com/s3/),
-[Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/),
-[Alibaba Cloud OSS Storage](https://www.alibabacloud.com/product/oss),
-[Openstack Object Storage](https://developer.openstack.org/api-ref/object-store/),
-[Oracle Cloud Infrastructure Object Storage](https://cloud.oracle.com/storage),
-[Baidu Cloud BOS Storage](https://cloud.baidu.com/product/bos.html),
-[Tencent Cloud Object Storage](https://intl.cloud.tencent.com/product/cos),
-[DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/),
+ChartMuseum is an open-source Helm Chart Repository server written in Go
+(Golang), with support for cloud storage backends, including [Google Cloud
+Storage](https://cloud.google.com/storage/), [Amazon
+S3](https://aws.amazon.com/s3/), [Microsoft Azure Blob
+Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), [Alibaba
+Cloud OSS Storage](https://www.alibabacloud.com/product/oss), [Openstack Object
+Storage](https://developer.openstack.org/api-ref/object-store/), [Oracle Cloud
+Infrastructure Object Storage](https://cloud.oracle.com/storage), [Baidu Cloud
+BOS Storage](https://cloud.baidu.com/product/bos.html), [Tencent Cloud Object
+Storage](https://intl.cloud.tencent.com/product/cos), [DigitalOcean
+Spaces](https://www.digitalocean.com/products/spaces/),
 [Minio](https://min.io/), and [etcd](https://etcd.io/).
 
 You can also use the
@@ -256,8 +256,9 @@ the given directory path.
 
 Now you can upload the chart and the index file to your chart repository using a
 sync tool or manually. If you're using Google Cloud Storage, check out this
-[example workflow]({{< ref "/docs/howto/chart_repository_sync_example.md" >}}) using the gsutil client.
-For GitHub, you can simply put the charts in the appropriate destination branch.
+[example workflow]({{< ref "/docs/howto/chart_repository_sync_example.md" >}})
+using the gsutil client. For GitHub, you can simply put the charts in the
+appropriate destination branch.
 
 ### Add new charts to an existing repository
 
@@ -297,8 +298,9 @@ fantastic-charts    https://fantastic-charts.storage.googleapis.com
 ```
 
 **Note:** A repository will not be added if it does not contain a valid
-`index.yaml`.
-**Note:** If your helm repository is e.g. using a self signed certificate, you can use `help repo add --insecure-skip-tls-verify ...` in order to skip the CA verification.
+`index.yaml`. **Note:** If your helm repository is e.g. using a self signed
+certificate, you can use `help repo add --insecure-skip-tls-verify ...` in order
+to skip the CA verification.
 
 After that, your users will be able to search through your charts. After you've
 updated the repository, they can use the `helm repo update` command to get the

--- a/content/en/docs/topics/chart_tests.md
+++ b/content/en/docs/topics/chart_tests.md
@@ -17,17 +17,22 @@ definition must contain the helm test hook annotation: `helm.sh/hook: test`.
 
 Example tests:
 
-- Validate that your configuration from the values.yaml file was properly injected.
+- Validate that your configuration from the values.yaml file was properly
+  injected.
   - Make sure your username and password work correctly
   - Make sure an incorrect username and password does not work
 - Assert that your services are up and correctly load balancing
 - etc.
 
-You can run the pre-defined tests in Helm on a release using the command `helm test <RELEASE_NAME>`. For a chart consumer, this is a great way to check that their release of a chart (or application) works as expected.
+You can run the pre-defined tests in Helm on a release using the command `helm
+test <RELEASE_NAME>`. For a chart consumer, this is a great way to check that
+their release of a chart (or application) works as expected.
 
 ## Example Test
 
-Here is an example of a helm test pod definition in the [bitnami wordpress chart](https://hub.helm.sh/charts/bitnami/wordpress). If you download a copy of the chart, you can look at the files locally:
+Here is an example of a helm test pod definition in the [bitnami wordpress
+chart](https://hub.helm.sh/charts/bitnami/wordpress). If you download a copy of
+the chart, you can look at the files locally:
 
 ```console
 $ helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -44,7 +49,8 @@ wordpress/
   templates/tests/test-mariadb-connection.yaml
 ```
 
-In `wordpress/templates/tests/test-mariadb-connection.yaml`, you'll see a test you can try:
+In `wordpress/templates/tests/test-mariadb-connection.yaml`, you'll see a test
+you can try:
 
 ```yaml
 {{- if .Values.mariadb.enabled }}
@@ -126,5 +132,6 @@ Phase:          Succeeded
   across several yaml files in the `templates/` directory.
 - You are welcome to nest your test suite under a `tests/` directory like
   `<chart-name>/templates/tests/` for more isolation.
-- A test is a [Helm hook](/docs/charts_hooks/), so annotations like `helm.sh/hook-weight`
-  and `helm.sh/hook-delete-policy` may be used with test resources.
+- A test is a [Helm hook](/docs/charts_hooks/), so annotations like
+  `helm.sh/hook-weight` and `helm.sh/hook-delete-policy` may be used with test
+  resources.

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -13,11 +13,11 @@ that describe a related set of Kubernetes resources. A single chart might be
 used to deploy something simple, like a memcached pod, or something complex,
 like a full web app stack with HTTP servers, databases, caches, and so on.
 
-Charts are created as files laid out in a particular directory tree. They
-can be packaged into versioned archives to be deployed.
+Charts are created as files laid out in a particular directory tree. They can be
+packaged into versioned archives to be deployed.
 
-If you want to download and look at the files for a published chart, without installing
-it, you can do so with `helm pull chartrepo/chartname`.
+If you want to download and look at the files for a published chart, without
+installing it, you can do so with `helm pull chartrepo/chartname`.
 
 This document explains the chart format, and provides basic guidance for
 building charts with Helm.
@@ -90,9 +90,9 @@ Other fields will be silently ignored.
 ### Charts and Versioning
 
 Every chart must have a version number. A version must follow the [SemVer
-2](https://semver.org/spec/v2.0.0.html) standard. Unlike Helm Classic, Helm v2 and later uses
-version numbers as release markers. Packages in repositories are identified by
-name plus version.
+2](https://semver.org/spec/v2.0.0.html) standard. Unlike Helm Classic, Helm v2
+and later uses version numbers as release markers. Packages in repositories are
+identified by name plus version.
 
 For example, an `nginx` chart whose version field is set to `version: 1.2.3`
 will be named:
@@ -119,17 +119,17 @@ will cause an error.
 
 ### The `apiVersion` Field
 
-The `apiVersion` field should be `v2` for Helm charts that require at least
-Helm 3. Charts supporting previous Helm versions have an `apiVersion` set
-to `v1` and are still installable by Helm 3.
+The `apiVersion` field should be `v2` for Helm charts that require at least Helm
+3. Charts supporting previous Helm versions have an `apiVersion` set to `v1` and
+are still installable by Helm 3.
 
 Changes from `v1` to `v2`:
 
 - A `dependencies` field defining chart dependencies, which were located in a
-  separate `requirements.yaml` file for `v1` charts
-  (see [Chart Dependencies](#chart-dependencies)).
-- The `type` field, discriminating application and library charts
-  (see [Chart Types](#chart-types)).
+  separate `requirements.yaml` file for `v1` charts (see [Chart
+  Dependencies](#chart-dependencies)).
+- The `type` field, discriminating application and library charts (see [Chart
+  Types](#chart-types)).
 
 ### The `appVersion` Field
 
@@ -149,24 +149,25 @@ Version constraints may comprise space separated AND comparisons such as
 ```
 >= 1.13.0 < 1.15.0
 ```
-which themselves can be combined with the OR `||` operator like in the
-following example
+which themselves can be combined with the OR `||` operator like in the following
+example
 ```
 >= 1.13.0 < 1.14.0 || >= 1.14.1 < 1.15.0
 ```
 In this example the version `1.14.0` is excluded, which can make sense if a bug
 in certain versions is known to prevent the chart from running properly.
 
-Apart from version constrains employing operators
-`=` `!=` `>` `<` `>=` `<=` the following shorthand notations are supported
+Apart from version constrains employing operators `=` `!=` `>` `<` `>=` `<=` the
+following shorthand notations are supported
 
- * hyphen ranges for closed intervals,
-  where `1.1 - 2.3.4` is equivalent to `>= 1.1 <= 2.3.4`.
- * wildcards `x`, `X` and `*`, where `1.2.x` is equivalent to `>= 1.2.0 < 1.3.0`.
- * tilde ranges (patch version changes allowed),
- where `~1.2.3` is equivalent to `>= 1.2.3 < 1.3.0`.
- * caret ranges (major version changes allowed),
- where `^1.2.3` is equivalent to `>= 1.2.3 < 2.0.0`.
+ * hyphen ranges for closed intervals, where `1.1 - 2.3.4` is equivalent to `>=
+   1.1 <= 2.3.4`.
+ * wildcards `x`, `X` and `*`, where `1.2.x` is equivalent to `>= 1.2.0 <
+   1.3.0`.
+ * tilde ranges (patch version changes allowed), where `~1.2.3` is equivalent to
+   `>= 1.2.3 < 1.3.0`.
+ * caret ranges (major version changes allowed), where `^1.2.3` is equivalent to
+   `>= 1.2.3 < 2.0.0`.
 
 For a detailed explanation of supported semver constraints see
 [Masterminds/semver](https://github.com/Masterminds/semver).
@@ -182,7 +183,7 @@ that is not marked as deprecated. The workflow for deprecating charts, as
 followed by the [kubernetes/charts](https://github.com/helm/charts) project is:
 
 1. Update chart's `Chart.yaml` to mark the chart as deprecated, bumping the
-  version
+   version
 2. Release the new chart version in the Chart Repository
 3. Remove the chart from the source repository (e.g. git)
 
@@ -190,11 +191,10 @@ followed by the [kubernetes/charts](https://github.com/helm/charts) project is:
 
 The `type` field defines the type of chart. There are two types: `application`
 and `library`. Application is the default type and it is the standard chart
-which can be operated on fully.
-The [library chart]({{< ref "/docs/topics/library_charts.md" >}}) provides
-utilities or functions for the chart builder. A library chart differs from an
-application chart because it is not installable and usually doesn't contain any
-resource objects.
+which can be operated on fully. The [library chart]({{< ref
+"/docs/topics/library_charts.md" >}}) provides utilities or functions for the
+chart builder. A library chart differs from an application chart because it is
+not installable and usually doesn't contain any resource objects.
 
 **Note:** An application chart can be used as a library chart. This is enabled
 by setting the type to `library`. The chart will then be rendered as a library
@@ -221,8 +221,8 @@ generally contain:
 - Any other information that may be relevant to the installation or
   configuration of the chart
 
-When hubs and other user interfaces display details about a chart that detail
-is pulled from the content in the `README.md` file.
+When hubs and other user interfaces display details about a chart that detail is
+pulled from the content in the `README.md` file.
 
 The chart can also contain a short plain text `templates/NOTES.txt` file that
 will be printed out after installation, and when viewing the status of a
@@ -391,9 +391,9 @@ since the `subchart1.enabled` path evaluates to 'true' in the parent's values,
 the condition will override the `front-end` tag and `subchart1` will be enabled.
 
 Since `subchart2` is tagged with `back-end` and that tag evaluates to `true`,
-`subchart2` will be enabled. Also note that although `subchart2` has a
-condition specified, there is no corresponding path and value in the parent's
-values so that condition has no effect.
+`subchart2` will be enabled. Also note that although `subchart2` has a condition
+specified, there is no corresponding path and value in the parent's values so
+that condition has no effect.
 
 ##### Using the CLI with Tags and Conditions
 
@@ -618,8 +618,8 @@ Values for the templates are supplied two ways:
 
 - Chart developers may supply a file called `values.yaml` inside of a chart.
   This file can contain default values.
-- Chart users may supply a YAML file that contains values. This can be
-  provided on the command line with `helm install`.
+- Chart users may supply a YAML file that contains values. This can be provided
+  on the command line with `helm install`.
 
 When a user supplies custom values, these values will override the values in the
 chart's `values.yaml` file.
@@ -697,17 +697,17 @@ cannot be overridden. As with all values, the names are _case sensitive_.
 - `Files`: A map-like object containing all non-special files in the chart. This
   will not give you access to templates, but will give you access to additional
   files that are present (unless they are excluded using `.helmignore`). Files
-  can be accessed using `{{ index .Files "file.name" }}` or using the `{{
-  .Files.Get name }}` function. You can also
-  access the contents of the file as `[]byte` using `{{ .Files.GetBytes }}`
+  can be accessed using `{{ index .Files "file.name" }}` or using the
+  `{{.Files.Get name }}` function. You can also access the contents of the file
+  as `[]byte` using `{{ .Files.GetBytes }}`
 - `Capabilities`: A map-like object that contains information about the versions
   of Kubernetes (`{{ .Capabilities.KubeVersion }}` and the supported Kubernetes
   API versions (`{{ .Capabilities.APIVersions.Has "batch/v1" }}`)
 
 **NOTE:** Any unknown `Chart.yaml` fields will be dropped. They will not be
-accessible inside of the `Chart` object. Thus, `Chart.yaml` cannot be used to pass
-arbitrarily structured data into the template. The values file can be used for
-that, though.
+accessible inside of the `Chart` object. Thus, `Chart.yaml` cannot be used to
+pass arbitrarily structured data into the template. The values file can be used
+for that, though.
 
 ### Values files
 
@@ -755,8 +755,8 @@ Note that only the last field was overridden.
 values are simply converted to YAML on the client side.
 
 **NOTE:** If any required entries in the values file exist, they can be declared
-as required in the chart template by using the ['required'
-function]({{< ref "/docs/howto/charts_tips_and_tricks.md" >}})
+as required in the chart template by using the ['required' function]({{< ref
+"/docs/howto/charts_tips_and_tricks.md" >}})
 
 Any of these values are then accessible inside of templates using the `.Values`
 object:
@@ -843,9 +843,9 @@ apache:
 The above adds a `global` section with the value `app: MyWordPress`. This value
 is available to _all_ charts as `.Values.global.app`.
 
-For example, the `mysql` templates may access `app` as `{{ .Values.global.app
-}}`, and so can the `apache` chart. Effectively, the values file above is
-regenerated like this:
+For example, the `mysql` templates may access `app` as `{{
+.Values.global.app}}`, and so can the `apache` chart. Effectively, the values
+file above is regenerated like this:
 
 ```yaml
 title: "My WordPress Site" # Sent to the WordPress template
@@ -1089,9 +1089,9 @@ While `helm` can be used to manage local chart directories, when it comes to
 sharing charts, the preferred mechanism is a chart repository.
 
 Any HTTP server that can serve YAML files and tar files and can answer GET
-requests can be used as a repository server.
-The Helm team has tested some servers, including Google Cloud Storage with
-website mode enabled, and S3 with website mode enabled.
+requests can be used as a repository server. The Helm team has tested some
+servers, including Google Cloud Storage with website mode enabled, and S3 with
+website mode enabled.
 
 A repository is characterized primarily by the presence of a special file called
 `index.yaml` that has a list of all of the packages supplied by the repository,

--- a/content/en/docs/topics/charts_hooks.md
+++ b/content/en/docs/topics/charts_hooks.md
@@ -34,7 +34,8 @@ The following hooks are defined:
 | `post-rollback`  | Executes on a rollback request after all resources have been modified                                 |
 | `test`           | Executes when the Helm test subcommand is invoked ([view test docs](/docs/chart_tests/))              |
 
-_Note that the `crd-install` hook has been removed in favor of the `crds/` directory in Helm 3._
+_Note that the `crd-install` hook has been removed in favor of the `crds/`
+directory in Helm 3._
 
 ## Hooks and the Release Lifecycle
 
@@ -90,17 +91,18 @@ not important.
 ### Hook resources are not managed with corresponding releases
 
 The resources that a hook creates are currently not tracked or managed as part
-of the release. Once Helm verifies that the hook has reached its ready state,
-it will leave the hook resource alone. Garbage collection of hook resources when
-the corresponding release is deleted may be added to Helm 3 in the future, so any
-hook resources that must never be deleted should be annotated with
+of the release. Once Helm verifies that the hook has reached its ready state, it
+will leave the hook resource alone. Garbage collection of hook resources when
+the corresponding release is deleted may be added to Helm 3 in the future, so
+any hook resources that must never be deleted should be annotated with
 `helm.sh/resource-policy: keep`.
 
 Practically speaking, this means that if you create resources in a hook, you
 cannot rely upon `helm uninstall` to remove the resources. To destroy such
-resources, you need to either [add a custom `helm.sh/hook-delete-policy` annotation](#hook-deletion-policies)
-to the hook template file, or [set the time to live (TTL) field of a
-Job resource](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).
+resources, you need to either [add a custom `helm.sh/hook-delete-policy`
+annotation](#hook-deletion-policies) to the hook template file, or [set the time
+to live (TTL) field of a Job
+resource](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).
 
 ## Writing a Hook
 
@@ -181,8 +183,9 @@ will sort those hooks in ascending order.
 
 ### Hook deletion policies
 
-It is possible to define policies that determine when to delete corresponding hook
-resources. Hook deletion policies are defined using the following annotation:
+It is possible to define policies that determine when to delete corresponding
+hook resources. Hook deletion policies are defined using the following
+annotation:
 
 ```yaml
 annotations:
@@ -197,4 +200,5 @@ You can choose one or more defined annotation values:
 | `hook-succeeded`       | Delete the resource after the hook is successfully executed          |
 | `hook-failed`          | Delete the resource if the hook failed during execution              |
 
-If no hook deletion policy annotation is specified, the `before-hook-creation` behavior applies by default.
+If no hook deletion policy annotation is specified, the `before-hook-creation`
+behavior applies by default.

--- a/content/en/docs/topics/kubernetes_apis.md
+++ b/content/en/docs/topics/kubernetes_apis.md
@@ -4,40 +4,44 @@ description: "Explains deprecated Kubernetes APIs in Helm"
 aliases: ["docs/k8s_apis/"]
 ---
 
-Kubernetes is an API-driven system and the API evolves over time to reflect
-the evolving understanding of the problem space. This is common practice
-across systems and their APIs. An important part of evolving APIs is a good
-deprecation policy and process to inform users of how changes to APIs are
-implemented. In other words, consumers of your API need to know in advance and
-in what release an API will be removed or changed. This removes the element of
-surprise and breaking changes to consumers.
+Kubernetes is an API-driven system and the API evolves over time to reflect the
+evolving understanding of the problem space. This is common practice across
+systems and their APIs. An important part of evolving APIs is a good deprecation
+policy and process to inform users of how changes to APIs are implemented. In
+other words, consumers of your API need to know in advance and in what release
+an API will be removed or changed. This removes the element of surprise and
+breaking changes to consumers.
 
-The [Kubernetes deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
-documents how Kubernetes handles the changes to its API versions. The policy
-for deprecation states the timeframe that API versions will be supported following
-a deprecation announcement. It is therefore important to be aware of deprecation
+The [Kubernetes deprecation
+policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+documents how Kubernetes handles the changes to its API versions. The policy for
+deprecation states the timeframe that API versions will be supported following a
+deprecation announcement. It is therefore important to be aware of deprecation
 announcements and know when API versions will be removed, to help minimize the
 effect.
 
-This is an example of an announcement [for the removal of deprecated API versions in Kubernetes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)
-and was advertised a few months prior to the release. These API versions would
-have been announced for deprecation prior to this again. This shows that there
-is a good policy in place which informs consumers of API version support. 
+This is an example of an announcement [for the removal of deprecated API
+versions in Kubernetes
+1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) and was
+advertised a few months prior to the release. These API versions would have been
+announced for deprecation prior to this again. This shows that there is a good
+policy in place which informs consumers of API version support. 
 
-Helm templates specify a [Kubernetes API group](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups)
+Helm templates specify a [Kubernetes API
+group](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups)
 when defining a Kubernetes object, similar to a Kubernetes manifest file. It is
 specified in the `apiVersion` field of the template and it identifies the API
-version of the Kubernetes object. This means that Helm users and chart maintainers
-need to be aware when Kubernetes API versions have been deprecated and in what
-Kubernetes version they will be removed.
+version of the Kubernetes object. This means that Helm users and chart
+maintainers need to be aware when Kubernetes API versions have been deprecated
+and in what Kubernetes version they will be removed.
 
 ## Chart Maintainers
 
 You should audit your charts checking for Kubernetes API versions that are
-deprecated or are removed in a Kubernetes version. The API versions found as
-due to be or that are now out of support, should be updated to the supported
-version and a new version of the chart released. The API version is defined by
-the `kind` and `apiVersion` fields. For example, here is a removed `Deployment`
+deprecated or are removed in a Kubernetes version. The API versions found as due
+to be or that are now out of support, should be updated to the supported version
+and a new version of the chart released. The API version is defined by the
+`kind` and `apiVersion` fields. For example, here is a removed `Deployment`
 object API version in Kubernetes 1.16:
 
 ```yaml
@@ -47,11 +51,11 @@ kind: Deployment
 
 ## Helm Users
 
-You should audit the charts that you use (similar to [chart maintainers](#chart-maintainers))
-and identify any charts where API versions are deprecated or removed in a
-Kubernetes version. For the charts identified, you need to check for the latest
-version of the chart (which has supported API versions) or update the chart
-yourself.
+You should audit the charts that you use (similar to [chart
+maintainers](#chart-maintainers)) and identify any charts where API versions are
+deprecated or removed in a Kubernetes version. For the charts identified, you
+need to check for the latest version of the chart (which has supported API
+versions) or update the chart yourself.
 
 Additionally, you also need to audit any charts deployed (i.e. Helm releases)
 checking again for any deprecated or removed API versions. This can be done by
@@ -61,22 +65,22 @@ The means for updating a Helm release to supported APIs depends on your findings
 as follows:
 
 1. If you find deprecated API versions only then:
-  - Perform a `helm upgrade` with a version of the chart with supported Kubernetes
-  API versions
+  - Perform a `helm upgrade` with a version of the chart with supported
+    Kubernetes API versions
   - Add a description in the upgrade, something along the lines to not perform a
-  rollback to a Helm version prior to this current version
+    rollback to a Helm version prior to this current version
 2.  If you find any API version(s) that is/are removed in a Kubernetes version
-then:
+    then:
   - If you are running a Kubernetes version where the API version(s) are still
-  available (for example, you are on Kubernetes 1.15 and found you use APIs that
-  will be removed in Kubernetes 1.16):
+    available (for example, you are on Kubernetes 1.15 and found you use APIs
+    that will be removed in Kubernetes 1.16):
     - Follow the step 1 procedure
   - Otherwise (for example, you are already running a Kubernetes version where
-  some API versions reported by `helm get manifest` are no longer available):
+    some API versions reported by `helm get manifest` are no longer available):
     - You need to edit the release manifest that is stored in the cluster to
-    update the API versions to supported APIs. See
-    [Updating API Versions of a Release Manifest](#updating-api-versions-of-a-release-manifest)
-    for more details
+      update the API versions to supported APIs. See [Updating API Versions of a
+      Release Manifest](#updating-api-versions-of-a-release-manifest) for more
+      details
 
 > Note: In all cases of updating a Helm release with supported APIs, you should
 never rollback the release to a version prior to the release version with the
@@ -87,8 +91,8 @@ versions to supported API versions, prior to upgrading to a kubernetes cluster
 that removes those API versions. 
 
 If you don't update a release as suggested previously, you will have an error
-similar to the following when trying to upgrade a release in a Kubernetes version
-where its API version(s) is/are removed:
+similar to the following when trying to upgrade a release in a Kubernetes
+version where its API version(s) is/are removed:
 
 ```
 Error: UPGRADE FAILED: current release manifest contains removed kubernetes api(s)
@@ -98,23 +102,23 @@ no matches for kind "Deployment" in version "apps/v1beta1"
 ```
 
 Helm fails in this scenario because it attempts to create a diff patch between
-the current deployed release (which contains the Kubernetes APIs that are removed
-in this Kubernetes version) against the chart you are passing with the
+the current deployed release (which contains the Kubernetes APIs that are
+removed in this Kubernetes version) against the chart you are passing with the
 updated/supported API versions. The underlying reason for failure is that when
-Kubernetes removes an API version, the Kubernetes Go client library can no longer
-parse the deprecated objects and Helm therefore fails when calling the library.
-Helm unfortunately is unable to recover from this situation and is no longer able
-to manage such a release.
-See [Updating API Versions of a Release Manifest](#updating-api-versions-of-a-release-manifest)
-for more details on how to recover from this scenario.
+Kubernetes removes an API version, the Kubernetes Go client library can no
+longer parse the deprecated objects and Helm therefore fails when calling the
+library. Helm unfortunately is unable to recover from this situation and is no
+longer able to manage such a release. See [Updating API Versions of a Release
+Manifest](#updating-api-versions-of-a-release-manifest) for more details on how
+to recover from this scenario.
 
 ## Updating API Versions of a Release Manifest
 
-The manifest is a property of the Helm release object which is stored in the data
-field of a Secret (default) or ConfigMap in the cluster. The data field contains
-a gzipped object which is base 64 encoded (there is an additional base 64
-encoding for a Secret). There is a Secret/ConfigMap per release version/revision
-in the namespace of the release.
+The manifest is a property of the Helm release object which is stored in the
+data field of a Secret (default) or ConfigMap in the cluster. The data field
+contains a gzipped object which is base 64 encoded (there is an additional base
+64 encoding for a Secret). There is a Secret/ConfigMap per release
+version/revision in the namespace of the release.
 
 You can use the Helm [mapkubeapis](https://github.com/hickeyma/helm-mapkubeapis)
 plugin to perform the update of a release to supported APIs. Check out the
@@ -124,28 +128,39 @@ Alternatively, you can follow these manual steps to perform an update of the API
 versions of a release manifest. Depending on your configuration you will follow
 the steps for the Secret or ConfigMap backend.
 
-- Get the name of the Secret or Configmap associated with the latest deployed release:
-  - Secrets backend: `kubectl get secret -l owner=helm,status=deployed,name=<release_name> --namespace <release_namespace> | awk '{print $1}' | grep -v NAME`
-  - ConfigMap backend: `kubectl get configmap -l owner=helm,status=deployed,name=<release_name> --namespace <release_namespace> | awk '{print $1}' | grep -v NAME`
+- Get the name of the Secret or Configmap associated with the latest deployed
+  release:
+  - Secrets backend: `kubectl get secret -l
+    owner=helm,status=deployed,name=<release_name> --namespace
+    <release_namespace> | awk '{print $1}' | grep -v NAME`
+  - ConfigMap backend: `kubectl get configmap -l
+    owner=helm,status=deployed,name=<release_name> --namespace
+    <release_namespace> | awk '{print $1}' | grep -v NAME`
 - Get latest deployed release details:
-  - Secrets backend: `kubectl get secret <release_secret_name> -n <release_namespace> -o yaml > release.yaml`
-  - ConfigMap backend: `kubectl get configmap <release_configmap_name> -n <release_namespace> -o yaml > release.yaml`
+  - Secrets backend: `kubectl get secret <release_secret_name> -n
+    <release_namespace> -o yaml > release.yaml`
+  - ConfigMap backend: `kubectl get configmap <release_configmap_name> -n
+    <release_namespace> -o yaml > release.yaml`
 - Backup the release in case you need to restore if something goes wrong:
   - `cp release.yaml release.bak`
-  - In case of emergency, restore: `kubectl apply -f release.bak -n <release_namespace>`
+  - In case of emergency, restore: `kubectl apply -f release.bak -n
+    <release_namespace>`
 - Decode the release object: 
-  - Secrets backend:`cat release.yaml | grep -oP '(?<=release: ).*' | base64 -d | base64 -d | gzip -d > release.data.decoded`
-  - ConfigMap backend: `cat release.yaml | grep -oP '(?<=release: ).*' | base64 -d | gzip -d > release.data.decoded`
+  - Secrets backend:`cat release.yaml | grep -oP '(?<=release: ).*' | base64 -d
+    | base64 -d | gzip -d > release.data.decoded`
+  - ConfigMap backend: `cat release.yaml | grep -oP '(?<=release: ).*' | base64
+    -d | gzip -d > release.data.decoded`
 - Change API versions of the manifests. Can use any tool (e.g. editor) to make
-the changes. This is in the `manifest` field of your decoded release
-object (`release.data.decoded`)
+  the changes. This is in the `manifest` field of your decoded release object
+  (`release.data.decoded`)
 - Encode the release object:
   - Secrets backend: `cat release.data.decoded | gzip | base64 | base64`
   - ConfigMap backend: `cat release.data.decoded | gzip | base64`
-- Replace `data.release` property value in the deployed release file (`release.yaml`)
-with the new encoded release object
-- Apply file to namespace: `kubectl apply -f release.yaml -n <release_namespace>`
+- Replace `data.release` property value in the deployed release file
+  (`release.yaml`) with the new encoded release object
+- Apply file to namespace: `kubectl apply -f release.yaml -n
+  <release_namespace>`
 - Perform a `helm upgrade` with a version of the chart with supported Kubernetes
-API versions
+  API versions
 - Add a description in the upgrade, something along the lines to not perform a
-rollback to a Helm version prior to this current version
+  rollback to a Helm version prior to this current version

--- a/content/en/docs/topics/kubernetes_distros.md
+++ b/content/en/docs/topics/kubernetes_distros.md
@@ -50,8 +50,8 @@ Helm works in clusters that are set up by KubeOne without caveats.
 ## Kubermatic
 
 Helm works in user clusters that are created by Kubermatic without caveats.
-Since seed cluster can be set up in different ways Helm support depends on
-their configuration.
+Since seed cluster can be set up in different ways Helm support depends on their
+configuration.
 
 ## MicroK8s
 

--- a/content/en/docs/topics/library_charts.md
+++ b/content/en/docs/topics/library_charts.md
@@ -5,25 +5,38 @@ aliases: ["docs/library_charts/"]
 weight: 4
 ---
 
-A library chart is a type of [Helm chart]({{< ref "/docs/topics/charts.md" >}}) that defines chart primitives or definitions which can be shared by Helm templates in other charts. This allows users to share snippets of code that can be re-used across charts, avoiding repetition and keeping charts [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
+A library chart is a type of [Helm chart]({{< ref "/docs/topics/charts.md" >}})
+that defines chart primitives or definitions which can be shared by Helm
+templates in other charts. This allows users to share snippets of code that can
+be re-used across charts, avoiding repetition and keeping charts
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
-The library chart was introduced in Helm 3 to formally recognize common or helper charts that have been used by chart maintainers since Helm 2. By including it as a chart type, it provides:
+The library chart was introduced in Helm 3 to formally recognize common or
+helper charts that have been used by chart maintainers since Helm 2. By
+including it as a chart type, it provides:
 - A means to explicitly distinguish between common and application charts 
 - Logic to prevent installation of a common chart
-- No rendering of templates in a common chart which may contain release artifacts 
+- No rendering of templates in a common chart which may contain release
+  artifacts 
 
-A chart maintainer can define a common chart as a library chart and now be confident that Helm will handle the chart in a standard consistent fashion. It also means that definitions in an application chart can be shared by changing the chart type.
+A chart maintainer can define a common chart as a library chart and now be
+confident that Helm will handle the chart in a standard consistent fashion. It
+also means that definitions in an application chart can be shared by changing
+the chart type.
 
 ## Create a Simple Library Chart
 
-As mentioned previously, a library chart is a type of [Helm chart]({{< ref "/docs/topics/charts.md" >}}). This means that you can start off by creating a scaffold chart:
+As mentioned previously, a library chart is a type of [Helm chart]({{< ref
+"/docs/topics/charts.md" >}}). This means that you can start off by creating a
+scaffold chart:
 
 ```console
 $ helm create mylibchart
 Creating mylibchart
 ```
 
-You will first remove all the files in `templates` directory as we will create our own templates definitions in this example.
+You will first remove all the files in `templates` directory as we will create
+our own templates definitions in this example.
 
 ```console
 $ rm -rf mylibchart/templates/*
@@ -35,9 +48,17 @@ The values file will not be required either.
 $ rm -f mylibchart/values.yaml 
 ```
 
-Before we jump into creating common code, lets do a quick review of some relevant Helm concepts. A [named template]({{< ref "/docs/chart_template_guide/named_templates.md" >}}) (sometimes called a partial or a subtemplate) is simply a template defined inside of a file, and given a name.  In the `templates/` directory, any file that begins with an underscore(_) is not expected to output a Kubernetes manifest file. So by convention, helper templates and partials are placed in a `_*.tpl` or `_*.yaml` files. 
+Before we jump into creating common code, lets do a quick review of some
+relevant Helm concepts. A [named template]({{< ref
+"/docs/chart_template_guide/named_templates.md" >}}) (sometimes called a partial
+or a subtemplate) is simply a template defined inside of a file, and given a
+name.  In the `templates/` directory, any file that begins with an underscore(_)
+is not expected to output a Kubernetes manifest file. So by convention, helper
+templates and partials are placed in a `_*.tpl` or `_*.yaml` files. 
 
-In this example, we will code a common ConfigMap which creates an empty ConfigMap resource. We will define the common ConfigMap in file `mylibchart/templates/_configmap.yaml` as follows:
+In this example, we will code a common ConfigMap which creates an empty
+ConfigMap resource. We will define the common ConfigMap in file
+`mylibchart/templates/_configmap.yaml` as follows:
 
 ```yaml
 {{- define "mylibchart.configmap.tpl" -}}
@@ -52,9 +73,17 @@ data: {}
 {{- end -}}
 ```
 
-The ConfigMap construct is defined in named template `mylibchart.configmap.tpl`. It is a simple ConfigMap with an empty resource, `data`. Within this file there is another named template called `mylibchart.configmap`. This named template includes another named template `mylibchart.util.merge` which will take 2 named templates as arguments, the template calling `mylibchart.configmap` and `mylibchart.configmap.tpl`.
+The ConfigMap construct is defined in named template `mylibchart.configmap.tpl`.
+It is a simple ConfigMap with an empty resource, `data`. Within this file there
+is another named template called `mylibchart.configmap`. This named template
+includes another named template `mylibchart.util.merge` which will take 2 named
+templates as arguments, the template calling `mylibchart.configmap` and
+`mylibchart.configmap.tpl`.
 
-The helper function `mylibchart.util.merge` is a named template in `mylibchart/templates/_util.yaml`. It is a handy util from [The Common Helm Helper Chart](#the-common-helm-helper-chart) because it merges the 2 templates and overrides any common parts in both:
+The helper function `mylibchart.util.merge` is a named template in
+`mylibchart/templates/_util.yaml`. It is a handy util from [The Common Helm
+Helper Chart](#the-common-helm-helper-chart) because it merges the 2 templates
+and overrides any common parts in both:
 
 ```yaml
 {{- /*
@@ -72,9 +101,11 @@ This takes an array of three values:
 {{- end -}}
 ```
 
-This is important when a chart wants to use common code that it needs to customize with its configuration.
+This is important when a chart wants to use common code that it needs to
+customize with its configuration.
 
-Finally, lets change the chart type to `library`. This requires editing `mylibchart/Chart.yaml` as follows:
+Finally, lets change the chart type to `library`. This requires editing
+`mylibchart/Chart.yaml` as follows:
 
 ```yaml
 apiVersion: v2
@@ -101,9 +132,11 @@ version: 0.1.0
 appVersion: 1.16.0
 ```
 
-The library chart is now ready to be shared and its ConfigMap definition to be re-used.
+The library chart is now ready to be shared and its ConfigMap definition to be
+re-used.
 
-Before moving on, it is worth checking if Helm recognizes the chart as a library chart:
+Before moving on, it is worth checking if Helm recognizes the chart as a library
+chart:
 
 ```console
 $ helm install mylibchart mylibchart/
@@ -125,7 +158,8 @@ Lets clean out the template files again as we want to create a ConfigMap only:
 $ rm -rf mychart/templates/*
 ```
 
-When we want to create a simple ConfigMap in a Helm template, it could look similar to the following:
+When we want to create a simple ConfigMap in a Helm template, it could look
+similar to the following:
 
 ```yaml
 apiVersion: v1
@@ -136,7 +170,9 @@ data:
   myvalue: "Hello World"
 ```
 
-We are however going to re-use the common code already created in `mylibchart`. The ConfigMap can be created in the file `mychart/templates/configmap.yaml` as follows:
+We are however going to re-use the common code already created in `mylibchart`.
+The ConfigMap can be created in the file `mychart/templates/configmap.yaml` as
+follows:
 
 ```yaml
 {{- include "mylibchart.configmap" (list . "mychart.configmap") -}}
@@ -146,9 +182,15 @@ data:
 {{- end -}}
 ```
 
-You can see that it simplifies the work we have to do by inheriting the common ConfigMap definition which adds standard properties for ConfigMap. In our template we add the configuration, in this case the data key `myvalue` and its value. The configuration override the empty resource of the common ConfigMap. This is feasible because of the helper function `mylibchart.util.merge` we mentioned in the previous section.
+You can see that it simplifies the work we have to do by inheriting the common
+ConfigMap definition which adds standard properties for ConfigMap. In our
+template we add the configuration, in this case the data key `myvalue` and its
+value. The configuration override the empty resource of the common ConfigMap.
+This is feasible because of the helper function `mylibchart.util.merge` we
+mentioned in the previous section.
 
-To be able to use the common code, we need to add `mylibchart` as a dependency. Add the following to the end of the file `mychart/Chart.yaml`:
+To be able to use the common code, we need to add `mylibchart` as a dependency.
+Add the following to the end of the file `mychart/Chart.yaml`:
 
 ```yaml
 # My common code in my library chart
@@ -158,7 +200,10 @@ dependencies:
   repository: file://../mylibchart
 ```
 
-This includes the library chart as a dynamic dependency from the filesystem which is at the same parent path as our application chart. As we are including the library chart as a dynamic dependency, we need to run `helm dependency update`. It will copy the library chart into your `charts/` directory.
+This includes the library chart as a dynamic dependency from the filesystem
+which is at the same parent path as our application chart. As we are including
+the library chart as a dynamic dependency, we need to run `helm dependency
+update`. It will copy the library chart into your `charts/` directory.
 
 ```console
 $ helm dependency update mychart/
@@ -169,7 +214,8 @@ Saving 1 charts
 Deleting outdated charts
 ```
 
-We are now ready to deploy our chart. Before installing, it is worth checking the rendered template first.
+We are now ready to deploy our chart. Before installing, it is worth checking
+the rendered template first.
 
 ```console
 $ helm install mydemo mychart/ --debug --dry-run
@@ -232,7 +278,8 @@ metadata:
   name: mychart-mydemo
 ```
 
-This looks like the ConfigMap we want with data override of `myvalue: Hello World`. Lets install it:
+This looks like the ConfigMap we want with data override of `myvalue: Hello
+World`. Lets install it:
 
 ```console
 $ helm install mydemo mychart/
@@ -264,9 +311,14 @@ metadata:
 
 ## The Common Helm Helper Chart
 
-Bit of a mouth full of a title but this [chart](https://github.com/helm/charts/tree/master/incubator/common) is the original pattern for common charts. It provides utilities that reflect best practices of Kubernetes chart development. Best of all it can be used off the bat by you when developing your charts to give you handy shared code.
+Bit of a mouth full of a title but this
+[chart](https://github.com/helm/charts/tree/master/incubator/common) is the
+original pattern for common charts. It provides utilities that reflect best
+practices of Kubernetes chart development. Best of all it can be used off the
+bat by you when developing your charts to give you handy shared code.
 
-Here is a quick way to use it. For more details, have a look at the [README](https://github.com/helm/charts/blob/master/incubator/common/README.md).
+Here is a quick way to use it. For more details, have a look at the
+[README](https://github.com/helm/charts/blob/master/incubator/common/README.md).
 
 Create a scaffold chart again:
 
@@ -275,7 +327,8 @@ $ helm create demo
 Creating demo
 ```
 
-Lets use the common code from the helper chart. First, edit deployment `demo/templates/deployment.yaml` as follows:
+Lets use the common code from the helper chart. First, edit deployment
+`demo/templates/deployment.yaml` as follows:
 
 ```yaml
 {{- template "common.deployment" (list . "demo.deployment") -}}
@@ -301,9 +354,12 @@ And now the service file, `demo/templates/service.yaml` as follows:
 {{- end -}}
 ```
 
-These templates show how inheriting the common code from the helper chart simplifies your coding down to your configuration or customization of the resources.
+These templates show how inheriting the common code from the helper chart
+simplifies your coding down to your configuration or customization of the
+resources.
 
-To be able to use the common code, we need to add `common` as a dependency. Add the following to the end of the file `demo/Chart.yaml`:
+To be able to use the common code, we need to add `common` as a dependency. Add
+the following to the end of the file `demo/Chart.yaml`:
 
 ```yaml
 dependencies:
@@ -312,11 +368,15 @@ dependencies:
   repository: "https://kubernetes-charts-incubator.storage.googleapis.com/"
 ```
 
-Note: You will need to add the `incubator` repo to the Helm repository list (`helm repo add`).
+Note: You will need to add the `incubator` repo to the Helm repository list
+(`helm repo add`).
 
-As we are including the chart as a dynamic dependency, we need to run `helm dependency update`. It will copy the helper chart into your `charts/` directory.
+As we are including the chart as a dynamic dependency, we need to run `helm
+dependency update`. It will copy the helper chart into your `charts/` directory.
 
-As helper chart is using some Helm 2 constructs, you will need to add the following to `demo/values.yaml` to enable the `nginx` image to be loaded as this was updated in Helm 3 scaffold chart:
+As helper chart is using some Helm 2 constructs, you will need to add the
+following to `demo/values.yaml` to enable the `nginx` image to be loaded as this
+was updated in Helm 3 scaffold chart:
 
 ```yaml
 image:

--- a/content/en/docs/topics/permissions_sql_storage_backend.md
+++ b/content/en/docs/topics/permissions_sql_storage_backend.md
@@ -4,24 +4,39 @@ description: "Get to know how to setup permissions when using SQL storage backen
 aliases: ["/docs/permissions_sql_storage_backend/"]
 ---
 
-This document aims to provide guidance to users for setting up and managing permissions when using the SQL storage backend.
+This document aims to provide guidance to users for setting up and managing
+permissions when using the SQL storage backend.
 
 ## Introduction
 
-To handle permissions, Helm leverages the RBAC feature of Kubernetes. When using the SQL storage backend, Kubernetes' roles can't be used to determine whether or not an user can access a given resource. This document shows how to create and manage these permissions.
+To handle permissions, Helm leverages the RBAC feature of Kubernetes. When using
+the SQL storage backend, Kubernetes' roles can't be used to determine whether or
+not an user can access a given resource. This document shows how to create and
+manage these permissions.
 
 ## Initialization
 
-The first time the Helm CLI will make connect to your database, the client will make sure that it was previously initialized. If it is not, it will take care of the necessary setup automatically. This initialization requires admin privileges on the public schema, or at least to be able to:
+The first time the Helm CLI will make connect to your database, the client will
+make sure that it was previously initialized. If it is not, it will take care of
+the necessary setup automatically. This initialization requires admin privileges
+on the public schema, or at least to be able to:
 
 * create a table
 * grant privileges on the public schema
 
-After the migration was run against your database, all the other roles can use the client.
+After the migration was run against your database, all the other roles can use
+the client.
 
 ## Grant privileges to a non admin user in PostgreSQL
 
-To manage permissions, the SQL backend driver leverages the [RLS](https://www.postgresql.org/docs/9.5/ddl-rowsecurity.html)(Row Security Level) feature of PostgreSQL. RLS allows all users to be able to read/write from/to the same table, without being able to manipulate the same rows if they are not explicitly allowed to. By default, any role that has not been explicitely granted with the right privileges will always return an empty list when running `helm list` and will not be able to retrieve or modify any resource in the cluster.
+To manage permissions, the SQL backend driver leverages the
+[RLS](https://www.postgresql.org/docs/9.5/ddl-rowsecurity.html)(Row Security
+Level) feature of PostgreSQL. RLS allows all users to be able to read/write
+from/to the same table, without being able to manipulate the same rows if they
+are not explicitly allowed to. By default, any role that has not been
+explicitely granted with the right privileges will always return an empty list
+when running `helm list` and will not be able to retrieve or modify any resource
+in the cluster.
 
 Let's see how to grant a given role access to specific namespaces:
 
@@ -29,9 +44,14 @@ Let's see how to grant a given role access to specific namespaces:
 CREATE POLICY <name> ON releases_v1 FOR ALL TO <role> USING (namespace = 'default');
 ```
 
-This command will grant the permissions to read and write all resources that meet the `namespace = 'default'` condition to the role `role`. After creating this policy, the user being connected to the database on the behalf of the role `role` will therefore be able to see all the releases living in the `default` namespace when running `helm list`, and to modify and delete them.
+This command will grant the permissions to read and write all resources that
+meet the `namespace = 'default'` condition to the role `role`. After creating
+this policy, the user being connected to the database on the behalf of the role
+`role` will therefore be able to see all the releases living in the `default`
+namespace when running `helm list`, and to modify and delete them.
 
-Privileges can be managed granularly with RLS, and one might be interested in restraining access given the different columns of the table:
+Privileges can be managed granularly with RLS, and one might be interested in
+restraining access given the different columns of the table:
 * key
 * type
 * body

--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -8,8 +8,8 @@ weight: 12
 A Helm plugin is a tool that can be accessed through the `helm` CLI, but which
 is not part of the built-in Helm codebase.
 
-Existing plugins can be found on [related]({{< ref "related.md#helm-plugins" >}}) section or
-by searching
+Existing plugins can be found on [related]({{< ref "related.md#helm-plugins"
+>}}) section or by searching
 [GitHub](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories).
 
 This guide explains how to use and create plugins.
@@ -91,8 +91,8 @@ platformCommand:
     command: "$HELM_BIN list --short --max 1 --date -r"
 ```
 
-The `name` is the name of the plugin. When Helm executes this plugin, this is the
-name it will use (e.g. `helm NAME` will invoke this plugin).
+The `name` is the name of the plugin. When Helm executes this plugin, this is
+the name it will use (e.g. `helm NAME` will invoke this plugin).
 
 _`name` should match the directory name._ In our example above, that means the
 plugin with `name: keybase` should be contained in a directory named `keybase`.
@@ -222,13 +222,13 @@ other cases, plugins may use flags as appropriate.
 
 ## Providing shell auto-completion
 
-As of Helm 3.2, a plugin can optionally provide support for shell auto-completion
-as part of Helm's existing auto-completion mechanism.
+As of Helm 3.2, a plugin can optionally provide support for shell
+auto-completion as part of Helm's existing auto-completion mechanism.
 
 ### Static auto-completion
 
-If a plugin provides its own flags and/or sub-commands, it can inform Helm of them
-by having a `completion.yaml` file located in the plugin's root directory.
+If a plugin provides its own flags and/or sub-commands, it can inform Helm of
+them by having a `completion.yaml` file located in the plugin's root directory.
 The `completion.yaml` file has the form:
 
 ```yaml
@@ -254,26 +254,30 @@ commands:
 Notes:
 1. All sections are optional but should be provided if applicable.
 1. Flags should not include the `-` or `--` prefix.
-1. Both short and long flags can and should be specified. A short flag need not be
-associated with its corresponding long form, but both forms should be listed.
-1. Flags need not be ordered in any way, but need to be listed at the correct point
-in the sub-command hierarchy of the file.
-1. Helm's existing global flags are already handled by Helm's auto-completion mechanism,
-therefore plugins need not specify the following flags `--debug`, `--namespace` or `-n`,
-`--kube-context`, and `--kubeconfig`, or any other global flag.
-1. The `validArgs` list provides a static list of possible completions for the first
-parameter following a sub-command.  It is not always possible to provide such a list in
-advance (see the [Dynamic Completion](#dynamic-completion) section below), in which case
-the `validArgs` section can be omitted.
+1. Both short and long flags can and should be specified. A short flag need not
+   be associated with its corresponding long form, but both forms should be
+   listed.
+1. Flags need not be ordered in any way, but need to be listed at the correct
+   point in the sub-command hierarchy of the file.
+1. Helm's existing global flags are already handled by Helm's auto-completion
+   mechanism, therefore plugins need not specify the following flags `--debug`,
+   `--namespace` or `-n`, `--kube-context`, and `--kubeconfig`, or any other
+   global flag.
+1. The `validArgs` list provides a static list of possible completions for the
+   first parameter following a sub-command.  It is not always possible to
+   provide such a list in advance (see the [Dynamic
+   Completion](#dynamic-completion) section below), in which case the
+   `validArgs` section can be omitted.
 
-The `completion.yaml` file is entirely optional.  If it is not provided, Helm will simply
-not provide shell auto-completion for the plugin (unless
-[Dynamic Completion](#dynamic-completion) is supported by the plugin).  Also, adding a
-`completion.yaml` file is backwards-compatible and will not impact the behavior of the
-plugin when using older helm versions.
+The `completion.yaml` file is entirely optional.  If it is not provided, Helm
+will simply not provide shell auto-completion for the plugin (unless [Dynamic
+Completion](#dynamic-completion) is supported by the plugin).  Also, adding a
+`completion.yaml` file is backwards-compatible and will not impact the behavior
+of the plugin when using older helm versions.
 
-As an example, for the [`fullstatus plugin`](https://github.com/marckhouzam/helm-fullstatus)
-which has no sub-commands but accepts the same flags as the `helm status` command, the
+As an example, for the [`fullstatus
+plugin`](https://github.com/marckhouzam/helm-fullstatus) which has no
+sub-commands but accepts the same flags as the `helm status` command, the
 `completion.yaml` file is:
 
 ```yaml
@@ -284,8 +288,8 @@ flags:
 - revision
 ```
 
-A more intricate example for the [`2to3 plugin`](https://github.com/helm/helm-2to3),
-has a `completion.yaml` file of:
+A more intricate example for the [`2to3
+plugin`](https://github.com/helm/helm-2to3), has a `completion.yaml` file of:
 
 ```yaml
 name: 2to3
@@ -324,24 +328,26 @@ commands:
 
 ### Dynamic completion
 
-Also starting with Helm 3.2, plugins can provide their own dynamic shell auto-completion.
-Dynamic shell auto-completion is the completion of parameter values or flag values that
-cannot be defined in advance.  For example, completion of the names of helm releases
-currently available on the cluster.
+Also starting with Helm 3.2, plugins can provide their own dynamic shell
+auto-completion. Dynamic shell auto-completion is the completion of parameter
+values or flag values that cannot be defined in advance.  For example,
+completion of the names of helm releases currently available on the cluster.
 
-For the plugin to support dynamic auto-completion, it must provide an **executable** file
-called `plugin.complete` in its root directory. When the Helm completion script requires
-dynamic completions for the plugin, it will execute the `plugin.complete` file, passing it
-the command-line that needs to be completed.  The `plugin.complete` executable will need
-to have the logic to determine what the proper completion choices are and output them to
-standard output to be consumed by the Helm completion script.
+For the plugin to support dynamic auto-completion, it must provide an
+**executable** file called `plugin.complete` in its root directory. When the
+Helm completion script requires dynamic completions for the plugin, it will
+execute the `plugin.complete` file, passing it the command-line that needs to be
+completed.  The `plugin.complete` executable will need to have the logic to
+determine what the proper completion choices are and output them to standard
+output to be consumed by the Helm completion script.
 
-The `plugin.complete` file is entirely optional.  If it is not provided, Helm will simply
-not provide dynamic auto-completion for the plugin.  Also, adding a `plugin.complete`
-file is backwards-compatible and will not impact the behavior of the plugin when using
-older helm versions.
+The `plugin.complete` file is entirely optional.  If it is not provided, Helm
+will simply not provide dynamic auto-completion for the plugin.  Also, adding a
+`plugin.complete` file is backwards-compatible and will not impact the behavior
+of the plugin when using older helm versions.
 
-The output of the `plugin.complete` script should be a new-line separated list such as:
+The output of the `plugin.complete` script should be a new-line separated list
+such as:
 
 ```
 rel1
@@ -349,26 +355,27 @@ rel2
 rel3
 ```
 
-When `plugin.complete` is called, the plugin environment is set just like when the
-plugin's main script is called. Therefore, the variables `$HELM_NAMESPACE`,
-`$HELM_KUBECONTEXT`, and all other plugin variables will already be set, and their
-corresponding global flags will be removed.
+When `plugin.complete` is called, the plugin environment is set just like when
+the plugin's main script is called. Therefore, the variables `$HELM_NAMESPACE`,
+`$HELM_KUBECONTEXT`, and all other plugin variables will already be set, and
+their corresponding global flags will be removed.
 
-The `plugin.complete` file can be in any executable form; it can be a shell script,
-a Go program, or any other type of program that Helm can execute.
-The `plugin.complete` file ***must*** have executable permissions for the user.
-The `plugin.complete` file ***must*** exit with a success code (value 0).
+The `plugin.complete` file can be in any executable form; it can be a shell
+script, a Go program, or any other type of program that Helm can execute. The
+`plugin.complete` file ***must*** have executable permissions for the user. The
+`plugin.complete` file ***must*** exit with a success code (value 0).
 
-In some cases, dynamic completion will require to obtain information from the Kubernetes
-cluster.  For example, the `helm fullstatus` plugin requires a release name as input.
-In the `fullstatus` plugin, for its `plugin.complete` script to provide completion for
-current release names, it can simply run `helm list -q` and output the result.
+In some cases, dynamic completion will require to obtain information from the
+Kubernetes cluster.  For example, the `helm fullstatus` plugin requires a
+release name as input. In the `fullstatus` plugin, for its `plugin.complete`
+script to provide completion for current release names, it can simply run `helm
+list -q` and output the result.
 
-If it is desired to use the same executable for plugin execution and for plugin completion,
-the `plugin.complete` script can be made to call the main plugin executable with some
-special parameter or flag; when the main plugin executable detects the special parameter
-or flag, it will know to run the completion. In our example, `plugin.complete` could be
-implemented like this:
+If it is desired to use the same executable for plugin execution and for plugin
+completion, the `plugin.complete` script can be made to call the main plugin
+executable with some special parameter or flag; when the main plugin executable
+detects the special parameter or flag, it will know to run the completion. In
+our example, `plugin.complete` could be implemented like this:
 
 ```sh
 #!/usr/bin/env sh
@@ -378,22 +385,24 @@ implemented like this:
 $HELM_PLUGIN_DIR/status.sh --complete "$@"
 ```
 
-The `fullstatus` plugin's real script (`status.sh`) must then look for the `--complete`
-flag and if found, printout the proper completions.
+The `fullstatus` plugin's real script (`status.sh`) must then look for the
+`--complete` flag and if found, printout the proper completions.
 
 ### Tips and tricks
 
-1. The shell will automatically filter out completion choices that don't match user input.
-A plugin can therefore return all relevant completions without removing the ones that don't
-match the user input.  For example, if the command-line is `helm fullstatus ngin<TAB>`, the
-`plugin.complete` script can print *all* release names (of the `default` namespace), not
-just the ones starting with `ngin`; the shell will only retain the ones starting with `ngin`.
-1. To simplify dynamic completion support, especially if you have a complex plugin, you can
-have your  `plugin.complete` script call your main plugin script and request completion
-choices.  See the [Dynamic Completion](#dynamic-completion) section above for an example.
-1. To debug dynamic completion and the `plugin.complete` file, one can run the following
-to see the completion results :
+1. The shell will automatically filter out completion choices that don't match
+   user input. A plugin can therefore return all relevant completions without
+   removing the ones that don't match the user input.  For example, if the
+   command-line is `helm fullstatus ngin<TAB>`, the `plugin.complete` script can
+   print *all* release names (of the `default` namespace), not just the ones
+   starting with `ngin`; the shell will only retain the ones starting with
+   `ngin`.
+1. To simplify dynamic completion support, especially if you have a complex
+   plugin, you can have your  `plugin.complete` script call your main plugin
+   script and request completion choices.  See the [Dynamic
+   Completion](#dynamic-completion) section above for an example.
+1. To debug dynamic completion and the `plugin.complete` file, one can run the
+   following to see the completion results :
     - `helm __complete <pluginName> <arguments to complete>`.  For example:
     - `helm __complete fullstatus --output js<ENTER>`,
     - `helm __complete fullstatus -o json ""<ENTER>`
-

--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -49,7 +49,9 @@ corresponding private key:
 $ helm package --sign --key 'John Smith' --keyring path/to/keyring.secret mychart
 ```
 
-**Note:** The value of the `--key` argument must be a substring of the desired key's `uid` (in the output of `gpg --list-keys`), for example the name or email. **The fingerprint _cannot_ be used.**
+**Note:** The value of the `--key` argument must be a substring of the desired
+key's `uid` (in the output of `gpg --list-keys`), for example the name or email.
+**The fingerprint _cannot_ be used.**
 
 **TIP:** for GnuPG users, your secret keyring is in `~/.gnupg/secring.gpg`. You
 can use `gpg --list-secret-keys` to list the keys you have.
@@ -85,9 +87,9 @@ To verify during an install, use the `--verify` flag.
 $ helm install --verify mychart-0.1.0.tgz
 ```
 
-If the keyring containing the public key associated with the signed chart is
-not in the default location, you may need to point to the keyring with
-`--keyring PATH` as in the `helm package` example.
+If the keyring containing the public key associated with the signed chart is not
+in the default location, you may need to point to the keyring with `--keyring
+PATH` as in the `helm package` example.
 
 If verification fails, the install will be aborted before the chart is even
 rendered.
@@ -191,10 +193,11 @@ generated.
 
 The following pieces of provenance data are added:
 
-* The chart file (`Chart.yaml`) is included to give both humans and tools an easy
-  view into the contents of the chart.
-* The signature (SHA256, just like Docker) of the chart package (the `.tgz` file)
-  is included, and may be used to verify the integrity of the chart package.
+* The chart file (`Chart.yaml`) is included to give both humans and tools an
+  easy view into the contents of the chart.
+* The signature (SHA256, just like Docker) of the chart package (the `.tgz`
+  file) is included, and may be used to verify the integrity of the chart
+  package.
 * The entire body is signed using the algorithm used by OpenPGP (see
   [https://keybase.io] for an emerging way of making crypto signing and
   verification easy).
@@ -232,8 +235,8 @@ qtgooNdohoyGSzR5oapd7fEvauRQswJxOA0m0V+u9/eyLR0+JcYB8Udi1prnWf8=
 ```
 
 Note that the YAML section contains two documents (separated by `...\n`). The
-first file is the content of `Chart.yaml`. The second is the checksums, a map
-of filenames to SHA-256 digests of that file's content at packaging time.
+first file is the content of `Chart.yaml`. The second is the checksums, a map of
+filenames to SHA-256 digests of that file's content at packaging time.
 
 The signature block is a standard PGP signature, which provides [tamper
 resistance](https://www.rossde.com/PGP/pgp_signatures.html).
@@ -262,13 +265,13 @@ establish the authority of a signer. Or, to put this plainly, the system above
 hinges on the fact that you trust the person who signed the chart. That, in
 turn, means you need to trust the public key of the signer.
 
-One of the design decisions with Helm has been that the Helm project
-would not insert itself into the chain of trust as a necessary party. We don't
-want to be "the certificate authority" for all chart signers. Instead, we
-strongly favor a decentralized model, which is part of the reason we chose
-OpenPGP as our foundational technology. So when it comes to establishing
-authority, we have left this step more-or-less undefined in Helm 2 (a decision
-carried forward in Helm 3).
+One of the design decisions with Helm has been that the Helm project would not
+insert itself into the chain of trust as a necessary party. We don't want to be
+"the certificate authority" for all chart signers. Instead, we strongly favor a
+decentralized model, which is part of the reason we chose OpenPGP as our
+foundational technology. So when it comes to establishing authority, we have
+left this step more-or-less undefined in Helm 2 (a decision carried forward in
+Helm 3).
 
 However, we have some pointers and recommendations for those interested in using
 the provenance system:
@@ -279,8 +282,8 @@ the provenance system:
   - Keybase also has fabulous documentation available
   - While we haven't tested it, Keybase's "secure website" feature could be used
     to serve Helm charts.
-- The [official Helm Charts project](https://github.com/helm/charts) is
-  trying to solve this problem for the official chart repository.
+- The [official Helm Charts project](https://github.com/helm/charts) is trying
+  to solve this problem for the official chart repository.
   - There is a long issue there [detailing the current
     thoughts](https://github.com/helm/charts/issues/23).
   - The basic idea is that an official "chart reviewer" signs charts with her or

--- a/content/en/docs/topics/registries.md
+++ b/content/en/docs/topics/registries.md
@@ -240,4 +240,5 @@ The `dependencies` array of `Chart.yaml` supports OCI registry URLs. This means
 that the `helm dep` commands support declared OCI dependencies **if experimental
 support is enabled**.
 
-For more details see [the documentation on dependencies](/docs/topics/chart_best_practices/dependencies/).
+For more details see [the documentation on
+dependencies](/docs/topics/chart_best_practices/dependencies/).

--- a/content/en/docs/topics/v2_v3_migration.md
+++ b/content/en/docs/topics/v2_v3_migration.md
@@ -48,7 +48,8 @@ during migration:
    - `crd-install` hook removed and replaced with `crds` directory in chart
      where all CRDs defined in it will be installed before any rendering of the
      chart
-   - `test-failure` hook annotation value removed, and `test-success` deprecated. Use `test` instead
+   - `test-failure` hook annotation value removed, and `test-success`
+     deprecated. Use `test` instead
    - Commands removed/replaced/added:
        - delete --> uninstall : removes all release history by default
          (previously needed `--purge`)
@@ -60,8 +61,8 @@ during migration:
        - reset (removed)
        - serve (removed)
        - template: `-x`/`--execute` argument renamed to `-s`/`--show-only`
-       - upgrade: Added argument `--history-max` which limits the maximum number of
-         revisions saved per release (0 for no limit)
+       - upgrade: Added argument `--history-max` which limits the maximum number
+         of revisions saved per release (0 for no limit)
    - Helm 3 Go library has undergone a lot of changes and is incompatible with
      the Helm 2 library
    - Release binaries are now hosted on `get.helm.sh`
@@ -77,10 +78,10 @@ The migration use cases are as follows:
      deployed releases are updated/removed by v2 only
    - Helm v2 and v3 can quite happily manage the same cluster. The Helm versions
      can be installed on the same or separate systems
-   - If installing Helm v3 on the same system, you need to perform an
-     additional step to ensure that both client versions can co-exist until
-     ready to remove Helm v2 client. Rename or put the Helm v3 binary in a
-     different folder to avoid conflict
+   - If installing Helm v3 on the same system, you need to perform an additional
+     step to ensure that both client versions can co-exist until ready to remove
+     Helm v2 client. Rename or put the Helm v3 binary in a different folder to
+     avoid conflict
    - Otherwise there are no conflicts between both versions because of the
      following distinctions:
      - v2 and v3 release (history) storage are independent of each other. The

--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -3,36 +3,46 @@ title: "Helm Version Support Policy"
 description: "Describes Helm's patch release policy as well as the maximum version skew supported between Helm and Kubernetes."
 ---
 
-This document describes the maximum version skew supported between Helm and Kubernetes.
+This document describes the maximum version skew supported between Helm and
+Kubernetes.
 
 ## Supported Versions
 
-Helm versions are expressed as `x.y.z`, where `x` is the major version, `y` is the minor version, and z is the patch
-version, following [Semantic Versioning](https://semver.org/spec/v2.0.0.html) terminology.
+Helm versions are expressed as `x.y.z`, where `x` is the major version, `y` is
+the minor version, and z is the patch version, following [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) terminology.
 
-The Helm project maintains a release branch for the most recent minor release. Applicable fixes, including security
-fixes, are cherry-picked into the release branch, depending on severity and feasibility. Patch releases are cut from
-that branch as needed. This decision is owned by the release maintainer.
+The Helm project maintains a release branch for the most recent minor release.
+Applicable fixes, including security fixes, are cherry-picked into the release
+branch, depending on severity and feasibility. Patch releases are cut from that
+branch as needed. This decision is owned by the release maintainer.
 
 ## Supported Version Skew
 
-When a new version of Helm is released, it is compiled against a particular minor version of Kubernetes. For example,
-Helm 3.0.0 interacts with Kubernetes using the Kubernetes 1.16.2 client, so it is compatible with Kubernetes 1.16.
+When a new version of Helm is released, it is compiled against a particular
+minor version of Kubernetes. For example, Helm 3.0.0 interacts with Kubernetes
+using the Kubernetes 1.16.2 client, so it is compatible with Kubernetes 1.16.
 
-As of Helm 3, Helm is assumed to be compatible with `n-3` versions of Kubernetes it was compiled against. Due to
-Kubernetes' changes between minor versions, Helm 2's support policy is slightly stricter, assuming to be compatible
-with `n-1` versions of Kubernetes.
+As of Helm 3, Helm is assumed to be compatible with `n-3` versions of Kubernetes
+it was compiled against. Due to Kubernetes' changes between minor versions, Helm
+2's support policy is slightly stricter, assuming to be compatible with `n-1`
+versions of Kubernetes.
 
-For example, if you are using a version of Helm 3 that was compiled against the Kubernetes 1.17 client APIs, then it
-should be safe to use with Kubernetes 1.17, 1.16, 1.15, and 1.14. If you are using a version of Helm 2 that was
-compiled against the Kubernetes 1.16 client APIs, then it should be safe to use with Kubernetes 1.16 and 1.15.
+For example, if you are using a version of Helm 3 that was compiled against the
+Kubernetes 1.17 client APIs, then it should be safe to use with Kubernetes 1.17,
+1.16, 1.15, and 1.14. If you are using a version of Helm 2 that was compiled
+against the Kubernetes 1.16 client APIs, then it should be safe to use with
+Kubernetes 1.16 and 1.15.
 
-It is not recommended to use Helm with a version of Kubernetes that is newer than the version it was compiled against,
-as Helm does not make any forward compatiblility guarantees.
+It is not recommended to use Helm with a version of Kubernetes that is newer
+than the version it was compiled against, as Helm does not make any forward
+compatiblility guarantees.
 
-If you choose to use Helm with a version of Kubernetes that it does not support, you are using it at your own risk.
+If you choose to use Helm with a version of Kubernetes that it does not support,
+you are using it at your own risk.
 
-Please refer to the table below to determine what version of Helm is compatible with your cluster.
+Please refer to the table below to determine what version of Helm is compatible
+with your cluster.
 
 | Helm Version | Supported Kubernetes Versions |
 |--------------|-------------------------------|


### PR DESCRIPTION
follow-up from #732.

Using markdownlint, we can codify common conventions used across the documentation to keep the styling similar.

All of the defaults are used with a few exceptions:

- trailing punctuation in headings are accepted (used commonly in the FAQ)
- commands prefixed with terminal PS1's ($) without log output is accepted
- multiple top-level headings in the same document is accepted (to workaround issues with markdownlint and hugo)
- inline HTML is accepted
- code blocks and table output does not need to word wrap at 80 characters for improved readability

This PR introduces .markdownlint.json and word wraps the english documentation at 80 characters. I did not address the other issues raised in #732 to keep this simpler to review. I'm unsure if the hard word wrap may affect the korean and chinese translations or not, so I avoided editing those sections.

EDIT: re-formatting the blog was removed upon request.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>