### PR TITLE
Add Amazon EKS to helm docs topics kubernetes_distros

### DIFF
--- a/content/en/docs/topics/kubernetes_distros.md
+++ b/content/en/docs/topics/kubernetes_distros.md
@@ -16,7 +16,8 @@ alphabetically) if desired.
 
 ## AKS
 
-Helm works with [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm).
+Helm works with [Azure Kubernetes
+Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm).
 
 ## DC/OS
 
@@ -25,7 +26,9 @@ platform, and requires no additional configuration.
 
 ## EKS
 
-Helm works with Amazon Elastic Kubernetes Service (Amazon EKS): [Using Helm with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/helm.html).
+Helm works with Amazon Elastic Kubernetes Service (Amazon EKS):
+[Using Helm with Amazon
+EKS](https://docs.aws.amazon.com/eks/latest/userguide/helm.html).
 
 ## GKE
 

--- a/content/en/docs/topics/kubernetes_distros.md
+++ b/content/en/docs/topics/kubernetes_distros.md
@@ -16,13 +16,16 @@ alphabetically) if desired.
 
 ## AKS
 
-Helm works with [Azure Kubernetes
-Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm).
+Helm works with [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm).
 
 ## DC/OS
 
 Helm has been tested and is working on Mesospheres DC/OS 1.11 Kubernetes
 platform, and requires no additional configuration.
+
+## EKS
+
+Helm works with Amazon Elastic Kubernetes Service (Amazon EKS): [Using Helm with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/helm.html).
 
 ## GKE
 


### PR DESCRIPTION
Add Amazon AWS Elastic Kubernetes Service (EKS) to the list, with link to Amazon EKS documentation titled "Using Helm with Amazon EKS".
Signed-off-by: Bryan Dady <bryan@dady.us>