### PR TITLE
Minor formatting fix

### DIFF
--- a/content/en/docs/chart_template_guide/builtin_objects.md
+++ b/content/en/docs/chart_template_guide/builtin_objects.md
@@ -39,7 +39,8 @@ access in your templates.
     "/docs/topics/charts.md#the-chartyaml-file" >}})
 - `Files`: This provides access to all non-special files in a chart. While you
   cannot use it to access templates, you can use it to access other files in the
-  chart. See the section _Accessing Files_ for more.
+  chart. See the section [Accessing Files]({{< ref
+    "/docs/chart_template_guide/accessing_files.md" >}}) for more.
   - `Files.Get` is a function for getting a file by name (`.Files.Get
     config.ini`)
   - `Files.GetBytes` is a function for getting the contents of a file as an

--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -168,7 +168,7 @@ data:
 ```
 
 The big change comes in the value of the `name:` field, which is now
-`{{.Release.Name }}-configmap`.
+`{{ .Release.Name }}-configmap`.
 
 > A template directive is enclosed in `{{` and `}}` blocks.
 


### PR DESCRIPTION
Single space added in the template directive to maintain consistency in the documentation.
`{{.Release.Name }}`  -> `{{ .Release.Name }}` 

Link added for "Accessing Files"

Signed-off-by: Jeffrey Chu <peihuachu1112@gmail.com>