### PR TITLE
Update Debian repo signing key location

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -87,7 +87,7 @@ package](https://helm.baltorepo.com/stable/debian/) for Apt. This package is
 generally up to date.
 
 ```console
-curl https://helm.baltorepo.com/organization/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
 sudo apt-get install apt-transport-https --yes
 echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update


### PR DESCRIPTION
A small update to the location of the public key for the Debian repo. Now it's served from the same CDN as the indexes and packages, for speed and reliability.

The key is still available at the old location.

Signed-off-by: Matthew Fox <matt@getbalto.com>