### PR TITLE
updates for the 3.3.0 release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,7 +42,7 @@ jsFiles = [
 ]
 
 [[params.versions]]
-version = "v3.2.4"
+version = "v3.3.0"
 patch = "stable"
 url = "https://helm.sh/docs"
 primary = true

--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -46,6 +46,7 @@ with your cluster.
 
 | Helm Version | Supported Kubernetes Versions |
 |--------------|-------------------------------|
+| 3.3.x        | 1.18.x - 1.15.x               |
 | 3.2.x        | 1.18.x - 1.15.x               |
 | 3.1.x        | 1.17.x - 1.14.x               |
 | 3.0.x        | 1.16.x - 1.13.x               |


### PR DESCRIPTION
With the 3.3.0 release we have a couple of places to update the docs.

(I believe someone with write access to helm/helm should also close out https://github.com/helm/helm/milestone/89.)

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>