### PR TITLE
Removing aliases from ja translation

### DIFF
--- a/content/ja/docs/chart_best_practices/_index.md
+++ b/content/ja/docs/chart_best_practices/_index.md
@@ -2,7 +2,6 @@
 title: "ベストプラクティス"
 sidebar: true
 weight: 4
-aliases: ["/docs/topics/chart_best_practices/"]
 ---
 
 # チャートのベストプラクティスガイド

--- a/content/ja/docs/chart_template_guide/_index.md
+++ b/content/ja/docs/chart_template_guide/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "チャートテンプレートガイド"
 weight: 5
-aliases: ["/topics/chart_template_guide/"]
 ---
 
 # チャートテンプレート開発者ガイド

--- a/content/ja/docs/intro/_index.md
+++ b/content/ja/docs/intro/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "概要"
 weight: 1
-aliases: ["/docs/using_helm/"]
 ---
 
 # Helm の概要

--- a/content/ja/docs/intro/install.md
+++ b/content/ja/docs/intro/install.md
@@ -2,7 +2,6 @@
 title: "Helm のインストール"
 description: "Helm をインストールして実行する方法を学びます。"
 weight: 2
-aliases: ["/docs/install/"]
 ---
 
 このガイドでは、Helm CLI のインストール方法を示します。Helm はソースから、またはビルド済みのバイナリリリースから

--- a/content/ja/docs/intro/quickstart.md
+++ b/content/ja/docs/intro/quickstart.md
@@ -2,7 +2,6 @@
 title: "クイックスタートガイド"
 description: "ディストリビューション、FAQ、プラグインの手順を含む、Helm のインストール方法と使用方法。"
 weight: 1
-aliases: ["/docs/quickstart/"]
 ---
 
 このガイドでは、Helm をすぐに使い始める方法について説明します。

--- a/content/ja/docs/topics/advanced.md
+++ b/content/ja/docs/topics/advanced.md
@@ -1,7 +1,6 @@
 ---
 title: "高度な Helm のテクニック"
 description: "Helm パワーユーザー向けのさまざまな高度な機能について説明します"
-aliases: ["/docs/advanced_helm_techniques"]
 weight: 9
 ---
 

--- a/content/ja/docs/topics/architecture.md
+++ b/content/ja/docs/topics/architecture.md
@@ -1,7 +1,6 @@
 ---
 title: "Helm アーキテクチャ"
 description: "Helm アーキテクチャの概要を説明します。"
-aliases: ["/docs/architecture/"]
 weight: 8
 ---
 

--- a/content/ja/docs/topics/chart_tests.md
+++ b/content/ja/docs/topics/chart_tests.md
@@ -1,7 +1,6 @@
 ---
 title: "チャートのテスト"
 description: "チャートを実行およびテストする方法について説明します。"
-aliases: ["/docs/chart_tests/"]
 weight: 3
 ---
 


### PR DESCRIPTION
Translations should not have aliases. When that happens they
override the english language aliases.

Closes #773