### PR TITLE
Apply '--generate-name' option to 'install' command when name is irrelevant

### DIFF
--- a/content/en/docs/chart_template_guide/subcharts_and_globals.md
+++ b/content/en/docs/chart_template_guide/subcharts_and_globals.md
@@ -64,7 +64,7 @@ Because every subchart is a _stand-alone chart_, we can test `mysubchart` on its
 own:
 
 ```console
-$ helm install --dry-run --debug mychart/charts/mysubchart
+$ helm install --generate-name --dry-run --debug mychart/charts/mysubchart
 SERVER: "localhost:44134"
 CHART PATH: /Users/mattbutcher/Code/Go/src/helm.sh/helm/_scratch/mychart/charts/mysubchart
 NAME:   newbie-elk

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -726,7 +726,7 @@ file. The Helm install command allows a user to override values by supplying
 additional YAML values:
 
 ```console
-$ helm install --values=myvals.yaml wordpress
+$ helm install --generate-name --values=myvals.yaml wordpress
 ```
 
 When values are passed in this way, they will be merged into the default values

--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -84,7 +84,7 @@ Error: sha256 sum does not match for topchart-0.1.0.tgz: "sha256:1939fbf7c1023d2
 To verify during an install, use the `--verify` flag.
 
 ```console
-$ helm install --verify mychart-0.1.0.tgz
+$ helm install --generate-name --verify mychart-0.1.0.tgz
 ```
 
 If the keyring containing the public key associated with the signed chart is not


### PR DESCRIPTION
`helm install ...` requires that a value is passed for chart instance name, else `--generate-name` option should be applied.

Examples demonstrating `helm install ...` usage should consider that requirement otherwise they are ineffective (especially for first time users).

Signed-off-by: Igwe Kalu <igwe.kalu@live.com>