### PR TITLE
Clarify version skew

### DIFF
--- a/content/en/docs/intro/quickstart.md
+++ b/content/en/docs/intro/quickstart.md
@@ -23,8 +23,7 @@ use of Helm.
   second-latest minor release.
 - You should also have a local configured copy of `kubectl`.
 
-NOTE: Kubernetes versions prior to 1.6 have limited or no support for role-based
-access controls (RBAC).
+See the [Helm Version Support Policy](https://helm.sh/docs/topics/version_skew/) for the maximum version skew supported between Helm and Kubernetes.
 
 ## Install Helm
 


### PR DESCRIPTION
It appears some of the confusion in https://github.com/helm/helm/issues/6964 was caused by the mention of one specific old version of Kubernetes on an intro doc. I remove that accurate but confusing line here, and replace it with a pointer to a clarification about the version skew policy.

Hopefully this will make it more obvious what versions of Kubernetes Helm supports.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>