### PR TITLE
Replace the path with XDG_ prefix with helm env variables in docs

### DIFF
--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -308,5 +308,5 @@ latest chart information.
 
 *Under the hood, the `helm repo add` and `helm repo update` commands are
 fetching the index.yaml file and storing them in the
-`$XDG_CACHE_HOME/helm/repository/cache/` directory. This is where the `helm
+`$(helm env HELM_CACHE_HOME)/repository` directory. This is where the `helm
 search` function finds information about charts.*

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -1108,7 +1108,7 @@ The `helm create` command takes an optional `--starter` option that lets you
 specify a "starter chart".
 
 Starters are just regular charts, but are located in
-`$XDG_DATA_HOME/helm/starters`. As a chart developer, you may author charts that
+`$(helm env HELM_DATA_HOME)/starters`. As a chart developer, you may author charts that
 are specifically designed to be used as starters. Such charts should be designed
 with the following considerations in mind:
 
@@ -1118,6 +1118,6 @@ with the following considerations in mind:
 - All occurrences of `<CHARTNAME>` will be replaced with the specified chart
   name so that starter charts can be used as templates.
 
-Currently the only way to add a chart to `$XDG_DATA_HOME/helm/starters` is to
+Currently the only way to add a chart to `$(helm env HELM_DATA_HOME)/starters` is to
 manually copy it there. In your chart's documentation, you may want to explain
 that process.


### PR DESCRIPTION
Signed-off-by: Yuchen Cheng <rudeigerc@gmail.com>

Fixes #336 

According to helm/helm#8638, I replace the path with `XDG_` prefix with `helm env` variables in the docs.

I discovered that the cached index files were installed in `$(helm env HELM_CACHE_HOME)/repository` instead of `$XDG_CACHE_HOME/helm/repository/cache/` mentioned in the original docs, so I'm not quite sure which path is correct.
