### PR TITLE
Use main branch for chartmuseum go mod

### DIFF
--- a/content/code/chartmuseum.md
+++ b/content/code/chartmuseum.md
@@ -1,5 +1,5 @@
 ---
 name: "chartmuseum"
 repoURL: "https://github.com/helm/chartmuseum"
-branch: "master"
+branch: "main"
 ---

--- a/content/en/code/chartmuseum.md
+++ b/content/en/code/chartmuseum.md
@@ -1,5 +1,5 @@
 ---
 name: "chartmuseum"
 repoURL: "https://github.com/helm/chartmuseum"
-branch: "master"
+branch: "main"
 ---


### PR DESCRIPTION
ChartMuseum has switched to use 'main' as the default branch name (vs. 'master'). This change ensures that Go projects import ChartMuseum Go libraries properly.