### PR TITLE
Fixed docs on lookup function

### DIFF
--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -244,7 +244,7 @@ template processing will fail.
 
 Keep in mind that Helm is not supposed to contact the Kubernetes API Server
 during a `helm template` or a `helm install|update|delete|rollback --dry-run`,
-so the `lookup` function will return `nil` in such a case.
+so the `lookup` function will return an empty list (i.e. dict) in such a case.
 
 ## Operators are functions
 


### PR DESCRIPTION
The lookup docs noted that it returned nil when not connected to
a cluster. This is not true. Instead, an empty map/dict is returned.
This change corrects the docs.

Closes #863