### PR TITLE
Bump version for 3.3.4

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,7 +42,7 @@ jsFiles = [
 ]
 
 [[params.versions]]
-version = "v3.3.3"
+version = "v3.3.4"
 patch = "stable"
 url = "https://helm.sh/docs"
 primary = true


### PR DESCRIPTION
While going through the release check-list I noticed the version in `config.toml` wasn't up to date.

I don't know what impact that has, but here is the fix.