### PR TITLE
Add next release date as per HIP 0002

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -51,6 +51,10 @@ primary = true
 version = "v2.16.12"
 url = "https://v2.helm.sh/docs"
 
+[params.nextversion]
+version = "v3.5.0"
+date = "January 13th, 2021"
+
 [[params.quicklinks]]
 title = "Quickstart Guide"
 description = "How to install and get started with Helm including instructions for distros, FAQs, and plugins."

--- a/content/en/docs/community/release_checklist.md
+++ b/content/en/docs/community/release_checklist.md
@@ -16,12 +16,17 @@ is the minor version number and Z is the patch release number. This project
 strictly follows [semantic versioning](https://semver.org/) so following this
 step is critical.
 
+Helm announces in advance the date of its next minor release. Every effort
+should be made to respect the announced date.  Furthermore, when starting
+the release process, the date for the next release should have been selected
+as it will be used in the release process.
+
 These directions will cover initial configuration followed by the release
 process for three different kinds of releases:
 
 * Major Releases - released less frequently - have breaking changes
-* Minor Releases - released regularly - no breaking changes
-* Patch Releases - released as needed - do not require all steps in this guide
+* Minor Releases - released every 3 to 4 months - no breaking changes
+* Patch Releases - released monthly - do not require all steps in this guide
 
 [Initial Configuration](#initial-configuration)
 
@@ -340,6 +345,8 @@ If you're releasing a major/minor release, listing notable user-facing features
 is usually sufficient. For patch releases, do the same, but make note of the
 symptoms and who is affected.
 
+The release notes should include the version and planned date of the next release.
+
 An example release note for a minor release would look like this:
 
 ```markdown
@@ -377,8 +384,8 @@ The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will g
 
 ## What's Next
 
-- vX.Y.Z+1 will contain only bug fixes.
-- vX.Y+1.Z is the next feature release. This release will focus on ...
+- vX.Y.Z+1 will contain only bug fixes and is planned for <insert DATE>.
+- vX.Y+1.0 is the next feature release and is planned for <insert DATE>. This release will focus on ...
 
 ## Changelog
 
@@ -450,11 +457,14 @@ release on the front page of the [helm/helm](https://github.com/helm/helm) repo.
 
 The [Helm website docs section](https://helm.sh/docs) lists the Helm versions
 for the docs. Major, minor, and patch versions need to be updated on the site.
+The date for the next minor release is also published on the site and must be
+updated.
 To do that create a pull request against the [helm-www
 repository](https://github.com/helm/helm-www). In the `config.toml` file find
 the proper `params.versions` section and update the Helm version, like in this
 example of [updating the current
-version](https://github.com/helm/helm-www/pull/676/files).
+version](https://github.com/helm/helm-www/pull/676/files).  In the same
+`config.toml` file, update the `params.nextversion` section.
 
 Close the [helm/helm milestone](https://github.com/helm/helm/milestones) for
 the release, if applicable.

--- a/content/en/docs/topics/release_policy.md
+++ b/content/en/docs/topics/release_policy.md
@@ -1,0 +1,52 @@
+---
+title: "Release schedule policy"
+description: "Describes Helm's release schedule policy."
+---
+
+For the benefit of its users, Helm defines and announces release dates in
+advance.  This document describes the policy governing Helm's release schedule.
+
+## Semantic versioning
+
+Helm versions are expressed as `x.y.z`, where `x` is the major version, `y` is
+the minor version, and `z` is the patch version, following [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) terminology.
+
+## Patch releases
+
+Patch releases provide users with bug fixes and security fixes.  They do not
+contain new features.
+
+A new patch release relating to the latest minor/major release will normally be
+done once a month on the second Wednesday of each month.
+
+A patch release to fix a high priority regression or security issue can be done
+whenever needed.
+
+If there is no new content since the previous release, no new release will be
+done that month.
+
+## Minor releases
+
+Minor releases contain security and bug fixes as well as new features.  They
+are backwards compatible with respect to the API and the CLI usage.
+
+To align with Kubernetes releases, a minor helm release will be done every
+4 months (3 releases a year).
+
+Extra minor releases can be done if needed but will not affect the timeline of
+an announced future release, unless the announced release is less than 7 days
+away.
+
+At the same time as a release is published, the date of the next minor release
+will be announced and posted to Helm's main web page.
+
+## Major releases
+
+Major releases contain breaking changes.  Such releases are rare but are
+sometimes necessary to allow helm to continue to evolve in important new
+directions.
+
+Major releases can be difficult to plan.  With that in mind, a final release
+date will only be chosen and announced once the first beta version of such a
+release is available.

--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -9,13 +9,13 @@ Kubernetes.
 ## Supported Versions
 
 Helm versions are expressed as `x.y.z`, where `x` is the major version, `y` is
-the minor version, and z is the patch version, following [Semantic
+the minor version, and `z` is the patch version, following [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html) terminology.
 
 The Helm project maintains a release branch for the most recent minor release.
 Applicable fixes, including security fixes, are cherry-picked into the release
-branch, depending on severity and feasibility. Patch releases are cut from that
-branch as needed. This decision is owned by the release maintainer.
+branch, depending on severity and feasibility. More details can be found in 
+[Helm's release policy](release_policy.md).
 
 ## Supported Version Skew
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -114,6 +114,15 @@ other = "Join the Community"
 [community_desc]
 other = "More information about the Helm project, and how to contribute."
 
+[community_next_release]
+other = "Next Feature Release"
+
+[community_next_release_version]
+other = "__Version:__ "
+
+[community_next_release_date]
+other = "__Date:__ "
+
 [community_events_title]
 other = "Events"
 

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -4,6 +4,7 @@ Helm
 
 {{ define "main" }}
 {{ $home := site.BaseURL }}
+{{ $nextversion := site.Params.nextversion }}
 
 <div id="helm" class="page-wrapper page-home">
   <header>
@@ -152,6 +153,12 @@ Helm
     <div class="columns is-desktop community-boxes">
 
       <div class="column is-one-third-desktop">
+        <section class="box">
+          <h1 class="title">{{ T "community_next_release" }}</h1>
+          <dt>{{ T "community_next_release_version" | markdownify }} {{ $nextversion.version }}</dt>
+          <dt>{{ T "community_next_release_date" | markdownify }} {{ $nextversion.date }}</dt>
+        </section>
+
         <section class="box">
           <h1 class="title">{{ T "community_events_title" }}</h1>
           <dl>

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -155,8 +155,13 @@ Helm
       <div class="column is-one-third-desktop">
         <section class="box">
           <h1 class="title">{{ T "community_next_release" }}</h1>
-          <dt>{{ T "community_next_release_version" | markdownify }} {{ $nextversion.version }}</dt>
-          <dt>{{ T "community_next_release_date" | markdownify }} {{ $nextversion.date }}</dt>
+          <dl>
+            <dt>
+              {{ T "community_next_release_version" | markdownify }} {{ $nextversion.version }}
+              <br>
+              {{ T "community_next_release_date" | markdownify }} {{ $nextversion.date }}
+            </dt>
+          <dl>
         </section>
 
         <section class="box">


### PR DESCRIPTION
The following is a suggestion of how we could publish the next release's date.  But I don't know the site that well, so feel free to suggest a more appropriate location.

A new "Next Feature Release" section is added on the main page under the "Community" section.
The Release Checklist is also updated.
Japanese, Chinese and Korean will be shown in English until translated.

The next release is marked to be `3.5.0` for `January 13th, 2021` as suggest in the HIP review.
This PR, if approved, should only be merged once `helm 3.4.0` has been released.

This is what the new section would look like (notice the top left box):
<img width="1666" alt="NextReleaseHelm" src="https://user-images.githubusercontent.com/414402/94317694-d0954280-ff54-11ea-8d3b-ad1b02f4b5af.png">
