### PR TITLE
Update supported versions

### DIFF
--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -46,6 +46,7 @@ with your cluster.
 
 | Helm Version | Supported Kubernetes Versions |
 |--------------|-------------------------------|
+| 3.4.x        | 1.19.x - 1.16.x               |
 | 3.3.x        | 1.18.x - 1.15.x               |
 | 3.2.x        | 1.18.x - 1.15.x               |
 | 3.1.x        | 1.17.x - 1.14.x               |


### PR DESCRIPTION
_What is this PR for?_
When Helm starts supporting k8s 1.19 as noted in https://github.com/helm/helm/pull/8807, we should note that in the version skew doc: https://helm.sh/docs/topics/version_skew/

_When do we merge this?_
This should be merged after the release of 3.4.0.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>