### PR TITLE
Fix command for enabling Helm v3 in MicroK8s

### DIFF
--- a/content/en/docs/topics/kubernetes_distros.md
+++ b/content/en/docs/topics/kubernetes_distros.md
@@ -62,7 +62,7 @@ configuration.
 ## MicroK8s
 
 Helm can be enabled in [MicroK8s](https://microk8s.io) using the command:
-`microk8s.enable helm`
+`microk8s.enable helm3`
 
 ## Minikube
 

--- a/content/ko/docs/topics/kubernetes_distros.md
+++ b/content/ko/docs/topics/kubernetes_distros.md
@@ -60,7 +60,7 @@ weight: 10
 
 ## MicroK8s
 
-[MicroK8s](https://microk8s.io) 에서는 명령어 `microk8s.enable helm`를 사용하여 헬름을 활성화할 수 있다.
+[MicroK8s](https://microk8s.io) 에서는 명령어 `microk8s.enable helm3`를 사용하여 헬름을 활성화할 수 있다.
 
 ## Minikube
 


### PR DESCRIPTION
By default MicroK8s installs older version of Helm. Version 3 available in addon `helm3` (added on 10 January 2020 in pull request https://github.com/ubuntu/microk8s/pull/882).
MicroK8s (v1.19.2) example help output:
```
$ snap info microk8s | grep installed
installed:          v1.19.2                    (1710) 214MB classic
$ microk8s.enable --help
Usage: microk8s enable ADDON...
Enable one or more ADDON included with microk8s
Example: microk8s enable dns storage
Available Addons:
  ...
  helm                 # Helm 2 - the package manager for Kubernetes
  helm3                # Helm 3 - Kubernetes package manager
  ...
```