### PR TITLE
Improve homepage performance

### DIFF
--- a/themes/helm/assets/sass/helm-boat.scss
+++ b/themes/helm/assets/sass/helm-boat.scss
@@ -1,27 +1,3 @@
-@keyframes boat-bob {
-  0% {
-    bottom: 2vw;
-  }
-  50% {
-    bottom: 3.5vw;
-  }
-  100% {
-    bottom: 2vw;
-  }
-}
-
-@keyframes boat-badge-bob {
-  0% {
-    top: 0.425vw;
-  }
-  50% {
-    top: 0.75vw;
-  }
-  100% {
-    top: 0.425vw;
-  }
-}
-
 // boat full width default
 .boat {
   width: 100vw;
@@ -40,7 +16,6 @@
     bottom: 2vw;
     max-width: 15vw;
     z-index: 1060;
-    animation: boat-bob 7s ease-in-out infinite;
     @include transition;
   }
 
@@ -101,34 +76,6 @@
       @include transition;
     }
   }
-
-  .parallax > use {
-    animation: move-forever 25s ease-in-out infinite;
-  }
-  .parallax > use:nth-child(1) {
-    animation-delay: -2s;
-    animation-duration: 7s;
-  }
-  .parallax > use:nth-child(2) {
-    animation-delay: -3s;
-    animation-duration: 10s;
-  }
-  .parallax > use:nth-child(3) {
-    animation-delay: -4s;
-    animation-duration: 13s;
-  }
-  .parallax > use:nth-child(4) {
-    animation-delay: -5s;
-    animation-duration: 20s;
-  }
-  @keyframes move-forever {
-    0% {
-      transform: translate3d(-90px,0,0);
-    }
-    100% { 
-      transform: translate3d(85px,0,0);
-    }
-  }
 }
 
 // boat fixed nav 'badge' mode
@@ -154,7 +101,6 @@
     top: 0.2vw;
     z-index: 1025;
     max-width: 7vw;
-    animation: boat-badge-bob 7s ease-in-out infinite;
   }
 
   .wave-wrapper {

--- a/themes/helm/assets/sass/helm-home.scss
+++ b/themes/helm/assets/sass/helm-home.scss
@@ -24,7 +24,6 @@
 .home-intro {
   min-height: 100vh;
   background: url('/img/topography.png') left top repeat;
-  background-attachment: fixed;
   position: relative;
   margin-bottom: -16px;
 
@@ -89,7 +88,6 @@
     url('/img/topography.png') repeat top left,
     linear-gradient(180deg, darken($navy, 5%) 0%, $navy 100%);
   background-blend-mode: color-burn;
-  background-attachment: fixed;
   padding-top: 7.5rem;
   // padding-bottom: 5rem;
   min-height: 100vh;
@@ -189,7 +187,6 @@
       background: url('/img/topography.png') left top repeat;
       background-color: rgba(35,35,35,0.02);
       background-blend-mode: color-burn;
-      background-attachment: fixed;
 
       &:first-of-type {
         border-right: none;

--- a/themes/helm/assets/sass/helm-layout.scss
+++ b/themes/helm/assets/sass/helm-layout.scss
@@ -55,7 +55,6 @@ $sidebarWidth: 18.5rem;
   .navbar-top {
     padding-top: 3.5rem;
     background: url('/img/topography.png') left top repeat;
-    background-attachment: fixed;
 
     &:after {
       height: 1px;

--- a/themes/helm/layouts/partials/boat.html
+++ b/themes/helm/layouts/partials/boat.html
@@ -4,7 +4,7 @@
     <svg class="waves" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
     viewBox="0 24 150 28" preserveAspectRatio="none" shape-rendering="auto">
       <defs><path id="gentle-wave" d="M-160 44c30 0 58-18 88-18s 58 18 88 18 58-18 88-18 58 18 88 18 v44h-352z" /></defs>
-      <g class="parallax">
+      <g>
         <use xlink:href="#gentle-wave" x="48" y="0" fill="rgba(27,83,194,0.7" />
         <use xlink:href="#gentle-wave" x="48" y="3" fill="rgba(27,83,194,0.5)" />
         <use xlink:href="#gentle-wave" x="48" y="5" fill="rgba(27,83,194,0.3)" />


### PR DESCRIPTION
# Why is this change being proposed?
The homepage performance on my computer (detailed below) is not great. There are two distinct issues:

* when scrolling, the usage of `background-attachment: fixed;` makes CPU usage skyrocket
* the non-transition animations keep CPU usage high even when the window isn't being interacted with (this is essentially what #606 reports)

# Changes being proposed
* Revert to using the default behavior for `background-attachment`
* Stop the boat from bobbing on the homepage (both the header section boat and the navbar badge boat)

# Evidence of these changes' efficacy
My test/personal machine is a base model 2015 13" Macbook Pro. In other words, dated and bordering on obsolete hardware. Quantitative evidence is below. Qualitatively, the homepage went from being very stuttery to being smooth. 

## Disabling non-transition animations
Before disabling animations, just having Chrome open on the homepage results in these resource usage levels:

<img width="1680" alt="no-movement-before" src="https://user-images.githubusercontent.com/3756951/95664194-8646c080-0b13-11eb-90bd-77a476038c02.png">

After disabling animations via commit eae35a7:

<img width="1680" alt="no-movement-after" src="https://user-images.githubusercontent.com/3756951/95664196-8b0b7480-0b13-11eb-81cd-68906fe37592.png">

## Stopping background image from being fixed
From rapidly scrolling up and down on the homepage after the header section, this is the resource usage level:

<img width="657" alt="movement-before" src="https://user-images.githubusercontent.com/3756951/95664223-bd1cd680-0b13-11eb-90dd-d00d99319ea1.png">

After disabling the fixed background image via commit 8bd837e (which includes the changes made in commit eae35a7): 

<img width="657" alt="movement-after" src="https://user-images.githubusercontent.com/3756951/95664232-cd34b600-0b13-11eb-895f-4626b8654fe2.png">

## The need for these changes
On my work machine (a base model 2019 16" Macbook Pro), these changes don't make much of a difference when the machine is not under a meaningful load. Obviously when it is under a load (e.g. I'm actively running applications, writing code, and referencing documentation), lower resource usage would be very appreciated.