### PR TITLE
Add Kubernetes API doc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,7 @@ gulp.task('clone', function(cb) {
     return gulp.src([
         'source/docs/quickstart.md',
         'source/docs/install.md',
+        'source/docs/kubernetes_apis.md',
         'source/docs/kubernetes_distros.md',
         'source/docs/install_faq.md',
         'source/docs/using_helm.md',


### PR DESCRIPTION
Follow on from Kubernetes API doc which was added in https://github.com/helm/helm/pull/8135/. This PR adds the hook to render the doc for the web docs.