### PR TITLE
Fix invalid examples of Helm template comments

### DIFF
--- a/content/en/docs/chart_best_practices/templates.md
+++ b/content/en/docs/chart_best_practices/templates.md
@@ -156,7 +156,7 @@ Template Comments:
 ```yaml
 {{- /*
 This is a comment.
-*/ -}}
+*/}}
 type: frobnitz
 ```
 
@@ -166,7 +166,7 @@ as explaining a defined template:
 ```yaml
 {{- /*
 mychart.shortname provides a 6 char truncated version of the release name.
-*/ -}}
+*/}}
 {{ define "mychart.shortname" -}}
 {{ .Release.Name | trunc 6 }}
 {{- end -}}
@@ -182,7 +182,7 @@ memory: {{ .Values.maxMem | quote }}
 ```
 
 The comment above is visible when the user runs `helm install --debug`, while
-comments specified in `{{- /* */ -}}` sections are not.
+comments specified in `{{- /* */}}` sections are not.
 
 ## Use of JSON in Templates and Template Output
 

--- a/content/en/docs/topics/library_charts.md
+++ b/content/en/docs/topics/library_charts.md
@@ -92,7 +92,7 @@ This takes an array of three values:
 - the top context
 - the template name of the overrides (destination)
 - the template name of the base (source)
-*/ -}}
+*/}}
 {{- define "mylibchart.util.merge" -}}
 {{- $top := first . -}}
 {{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}

--- a/content/ko/docs/chart_best_practices/templates.md
+++ b/content/ko/docs/chart_best_practices/templates.md
@@ -155,7 +155,7 @@ type: sprocket
 ```yaml
 {{- /*
 This is a comment.
-*/ -}}
+*/}}
 type: frobnitz
 ```
 
@@ -165,7 +165,7 @@ type: frobnitz
 ```yaml
 {{- /*
 mychart.shortname 은 릴리스 이름에서 6자만 자른 것을 제공한다.
-*/ -}}
+*/}}
 {{ define "mychart.shortname" -}}
 {{ .Release.Name | trunc 6 }}
 {{- end -}}

--- a/content/ko/docs/topics/library_charts.md
+++ b/content/ko/docs/topics/library_charts.md
@@ -91,7 +91,7 @@ This takes an array of three values:
 - the top context
 - the template name of the overrides (destination)
 - the template name of the base (source)
-*/ -}}
+*/}}
 {{- define "mylibchart.util.merge" -}}
 {{- $top := first . -}}
 {{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}


### PR DESCRIPTION
- The comment examples previosly shown are unusable because they produce
 this error:
"error converting YAML to JSON: yaml: line X: did not find expected key"
- See also https://github.com/helm/helm/issues/4191

Signed-off-by: Shannon Carey <rehevkor5@gmail.com>