### PR TITLE
Add mentions of release calendar

### DIFF
--- a/content/en/docs/community/release_checklist.md
+++ b/content/en/docs/community/release_checklist.md
@@ -473,6 +473,10 @@ Update the [version
 skew](https://github.com/helm/helm-www/blob/master/content/en/docs/topics/version_skew.md)
 for major and minor releases.
 
+Update the release calendar [here](https://helm.sh/calendar/release):
+* create an entry for the next minor release with a reminder for that day at 5pm GMT
+* create an entry for the RC1 of the next minor release on the Monday of the week before the planned release, with a reminder for that day at 5pm GMT
+
 ## 11. Tell the Community
 
 Congratulations! You're done. Go grab yourself a $DRINK_OF_CHOICE. You've earned

--- a/content/en/docs/topics/release_policy.md
+++ b/content/en/docs/topics/release_policy.md
@@ -6,6 +6,9 @@ description: "Describes Helm's release schedule policy."
 For the benefit of its users, Helm defines and announces release dates in
 advance.  This document describes the policy governing Helm's release schedule.
 
+## Release calendar
+
+A public calendar showing the upcoming Helm releases can be found [here](https://helm.sh/calendar/release).
 ## Semantic versioning
 
 Helm versions are expressed as `x.y.z`, where `x` is the major version, `y` is

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -123,6 +123,9 @@ other = "__Version:__ "
 [community_next_release_date]
 other = "__Date:__ "
 
+[community_release_calendar]
+other = "[Release Calendar](https://helm.sh/calendar/release)"
+
 [community_events_title]
 other = "Events"
 

--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -160,6 +160,9 @@ Helm
               {{ T "community_next_release_version" | markdownify }} {{ $nextversion.version }}
               <br>
               {{ T "community_next_release_date" | markdownify }} {{ $nextversion.date }}
+              <br>
+              <br>
+              {{ T "community_release_calendar" | markdownify }}
             </dt>
           <dl>
         </section>


### PR DESCRIPTION
This PR:
* adds the link to the release calendar on the main page (see image below)
* adds instructions to update the calendar in the release check-list
* adds the link to the release calendar in the release schedule policy

Suggestions on formatting welcomed.

<img width="793" alt="LinkCalendar" src="https://user-images.githubusercontent.com/414402/99123566-6c931000-25ce-11eb-819b-c32d18656ad7.png">

