### PR TITLE
Update README to use new --generate-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ To update these docs, you'll need to:
 
 1. Delete all plugins currently installed with `helm plugin uninstall`
 2. Navigate to `content/en/docs/helm/`
-3. Run `helm docs --type markdown` to generate the markdown docs files, replacing any prior markdown files.  **Note:** Make sure you run the version of helm you want to build the docs for (for example, by checking out the correct tag and building it)
-4. Add back the YAML front-matter to each file that was changed
+3. Run `helm docs --type markdown --generate-headers` to generate the markdown docs files, replacing any prior markdown files.  **Note:** Make sure you run the version of helm you want to build the docs for (for example, by checking out the correct tag and building it)
 5. Commit the changes and create a PR to update the website.
 
 


### PR DESCRIPTION
To generate helm command documentation, the new `--generate-headers` flag allows to avoid having to add the headers back by hand.  See https://github.com/helm/helm/pull/8961

This PR updates the doc that explains how to generate that documentation.

This new flag will be part of helm 3.5.  So we may want to wait until it is release to merge this.  However, I'm not sure the docs will need to be regenerated for helm 3.4.1 or 3.4.2, so it may be ok to merge this change now, I'm not sure. 

