### PR TITLE
Add link to OCI HIP from Registries page

### DIFF
--- a/content/en/docs/topics/registries.md
+++ b/content/en/docs/topics/registries.md
@@ -20,6 +20,8 @@ in the environment:
 export HELM_EXPERIMENTAL_OCI=1
 ```
 
+For more information about this feature and plans for general availability, please see the [OCI Support Helm Improvement Proposal](https://github.com/helm/community/blob/master/hips/hip-0006.md).
+
 ## Running a registry
 
 Starting a registry for test purposes is trivial. As long as you have Docker


### PR DESCRIPTION
👋🏻 Hi there! 

I personally found the [Registries ](https://helm.sh/docs/topics/registries/) page on my own and found it very helpful, but ended up shying a way a bit when I found out it was still an experimental feature. There wasn't much there that explained why that was and the OCI HIP was in the community repo. I think it prudent to add a link to the OCI HIP in helm/community to lead folks there for more info.