### PR TITLE
Document dependencies from OCI registry

### DIFF
--- a/content/en/docs/topics/registries.md
+++ b/content/en/docs/topics/registries.md
@@ -169,6 +169,20 @@ version: 0.1.0
 Status: Downloaded newer chart for localhost:5000/myrepo/mychart:2.7.0
 ```
 
+## Specifying dependencies
+
+Dependencies of a chart can be pulled from a registry using the `dependency update` subcommand.
+
+To successfully pull dependencies, the image name in the registry must match the chart name and the tag must match the chart version. The repository entry in `Chart.yaml` is specified as the repository name on the registry without the image name.
+
+```
+dependencies:
+  - name: mychart
+    version: "2.7.0"
+    repository: "oci://localhost:5000/myrepo"
+```
+This will fetch `localhost:5000/myrepo/mychart:2.7.0` when `dependency update` is executed.
+
 ## Where are my charts?
 
 Charts stored using the commands above will be cached on the filesystem.


### PR DESCRIPTION
Document how to specify dependencies in Chart.yaml so that depencency update can pull them.

This resolves a confusion I had in https://github.com/helm/helm/issues/9267.