### PR TITLE
Update references to appVersion

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -136,7 +136,9 @@ Note that the `appVersion` field is not related to the `version` field. It is a
 way of specifying the version of the application. For example, the `drupal`
 chart may have an `appVersion: "8.2.1"`, indicating that the version of Drupal
 included in the chart (by default) is `8.2.1`. This field is informational, and
-has no impact on chart version calculations. Wrapping the version in quotes is recommended; not wrapping it in quotes can lead to issues in some cases. As of Helm v3.5.0, `helm create` generates the sample chart with `appVersion: "1.16.0"`.
+has no impact on chart version calculations. Wrapping the version in quotes is highly recommended. It forces the YAML parser to treat the version number as a string. Leaving it unquoted can lead to parsing issues in some cases. For example, YAML interprets `1.0` as a floating point value, and a git commit SHA like `1234e10` as scientific notation.
+
+As of Helm v3.5.0, `helm create` wraps the default `appVersion` field in quotes.
 
 ### The `kubeVersion` Field
 

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -78,7 +78,7 @@ maintainers: # (optional)
     email: The maintainers email (optional for each maintainer)
     url: A URL for the maintainer (optional for each maintainer)
 icon: A URL to an SVG or PNG image to be used as an icon (optional).
-appVersion: The version of the app that this contains (optional). This needn't be SemVer.
+appVersion: The version of the app that this contains (optional). Needn't be SemVer. Quotes recommended.
 deprecated: Whether this chart is deprecated (optional, boolean)
 annotations:
   example: A list of annotations keyed by name (optional).
@@ -134,9 +134,9 @@ Changes from `v1` to `v2`:
 
 Note that the `appVersion` field is not related to the `version` field. It is a
 way of specifying the version of the application. For example, the `drupal`
-chart may have an `appVersion: 8.2.1`, indicating that the version of Drupal
+chart may have an `appVersion: "8.2.1"`, indicating that the version of Drupal
 included in the chart (by default) is `8.2.1`. This field is informational, and
-has no impact on chart version calculations.
+has no impact on chart version calculations. Wrapping the version in quotes is recommended; not wrapping it in quotes can lead to issues in some cases. As of Helm v3.5.0, `helm create` generates the sample chart with `appVersion: "1.16.0"`.
 
 ### The `kubeVersion` Field
 

--- a/content/en/docs/topics/library_charts.md
+++ b/content/en/docs/topics/library_charts.md
@@ -128,8 +128,8 @@ type: library
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.16.0
+# incremented each time you make changes to the application and it is recommended to use it with quotes.
+appVersion: "1.16.0"
 ```
 
 The library chart is now ready to be shared and its ConfigMap definition to be

--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -213,7 +213,7 @@ The format of the file looks something like this:
 Hash: SHA512
 
 apiVersion: v2
-appVersion: 1.16.0
+appVersion: "1.16.0"
 description: Sample chart
 name: mychart
 type: application


### PR DESCRIPTION
Updated doc references to appVersion to reflect recommendation of quote-wrapped version.

This change took affect in Helm v3.5.0.

For context, refer to: 
- https://github.com/helm/helm/issues/9083
- https://github.com/helm/helm/pull/9084
