### PR TITLE
Add patch release cancellation conditions

### DIFF
--- a/content/en/docs/topics/release_policy.md
+++ b/content/en/docs/topics/release_policy.md
@@ -26,8 +26,10 @@ done once a month on the second Wednesday of each month.
 A patch release to fix a high priority regression or security issue can be done
 whenever needed.
 
-If there is no new content since the previous release, no new release will be
-done that month.
+A patch release will be cancelled for any of the following reasons:
+- if there is no new content since the previous release
+- if the patch release date falls within one week before the first release candidate (RC1) of an upcoming minor release
+- if the patch release date falls within four weeks following a minor release
 
 ## Minor releases
 


### PR DESCRIPTION
We have settled on a cancellation policy for patch releases now detailed in [HIP 0002](https://github.com/helm/community/blob/master/hips/hip-0002.md#cancelling-a-patch-release).
The discussion was concluded [here](https://github.com/helm/community/issues/160#issuecomment-761586180)

This PR adds the cancellation details to the web page so that it can be easily found by the community.
