### PR TITLE
Adjust docs to reflect Artifact Hub & helm/charts updates

### DIFF
--- a/content/en/docs/chart_template_guide/builtin_objects.md
+++ b/content/en/docs/chart_template_guide/builtin_objects.md
@@ -72,7 +72,7 @@ access in your templates.
 
 The built-in values always begin with a capital letter. This is in keeping with
 Go's naming convention. When you create your own names, you are free to use a
-convention that suits your team. Some teams, like the [Kubernetes
-Charts](https://github.com/helm/charts) team, choose to use only initial lower
-case letters in order to distinguish local names from those built-in. In this
-guide, we follow that convention.
+convention that suits your team. Some teams, like many whose charts you may see
+on [Artifact Hub](https://artifacthub.io/packages/search?kind=0), choose to use
+only initial lower case letters in order to distinguish local names from those
+built-in. In this guide, we follow that convention.

--- a/content/en/docs/chart_template_guide/wrapping_up.md
+++ b/content/en/docs/chart_template_guide/wrapping_up.md
@@ -12,9 +12,8 @@ But there are many things this guide has not covered when it comes to the
 practical day-to-day development of charts. Here are some useful pointers to
 other documentation that will help you as you create new charts:
 
-- The [Helm Charts project](https://github.com/helm/charts) is an indispensable
-  source of charts. That project also sets the standard for best practices in
-  chart development.
+- The CNCF [Artifact Hub](https://artifacthub.io/packages/search?kind=0) is an
+  indispensable source of charts.
 - The Kubernetes [Documentation](https://kubernetes.io/docs/home/) provides
   detailed examples of the various resource kinds that you can use, from
   ConfigMaps and Secrets to DaemonSets and Deployments.

--- a/content/en/docs/community/release_checklist.md
+++ b/content/en/docs/community/release_checklist.md
@@ -360,7 +360,7 @@ The community keeps growing, and we'd love to see you there!
   - `#helm-users` for questions and just to hang out
   - `#helm-dev` for discussing PRs, code, and bugs
 - Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
-- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)
+- Test, debug, and contribute charts: [Artifact Hub helm charts](https://artifacthub.io/packages/search?kind=0)
 
 ## Notable Changes
 

--- a/content/en/docs/howto/charts_tips_and_tricks.md
+++ b/content/en/docs/howto/charts_tips_and_tricks.md
@@ -270,10 +270,10 @@ templates and partials are placed in a `_helpers.tpl` file.
 
 ## Complex Charts with Many Dependencies
 
-Many of the charts in the [official charts
-repository](https://github.com/helm/charts) are "building blocks" for creating
-more advanced applications. But charts may be used to create instances of
-large-scale applications. In such cases, a single umbrella chart may have
+Many of the charts in the CNCF [Artifact
+Hub](https://artifacthub.io/packages/search?kind=0) are "building blocks" for
+creating more advanced applications. But charts may be used to create instances
+of large-scale applications. In such cases, a single umbrella chart may have
 multiple subcharts, each of which functions as a piece of the whole.
 
 The current best practice for composing a complex application from discrete

--- a/content/en/docs/intro/quickstart.md
+++ b/content/en/docs/intro/quickstart.md
@@ -35,8 +35,9 @@ For more details, or for other options, see [the installation guide]({{< ref
 
 ## Initialize a Helm Chart Repository
 
-Once you have Helm ready, you can add a chart repository. One popular starting
-location is the official Helm stable charts:
+Once you have Helm ready, you can add a chart repository. Check [Artifact
+Hub](https://artifacthub.io/packages/search?kind=0) for available Helm chart
+repositories.
 
 ```console
 $ helm repo add stable https://charts.helm.sh/stable

--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -480,11 +480,8 @@ $ helm install deis-workflow ./deis-workflow-0.1.0.tgz
 ```
 
 Charts that are packaged can be loaded into chart repositories. See the
-documentation for your chart repository server to learn how to upload.
-
-Note: The `stable` repository is managed on the [Kubernetes Charts GitHub
-repository](https://github.com/helm/charts). That project accepts chart source
-code, and (after audit) packages those for you.
+documentation for [Helm chart repositories](../docs/topics/chart_repository/)
+for more details.
 
 ## Conclusion
 

--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -480,8 +480,8 @@ $ helm install deis-workflow ./deis-workflow-0.1.0.tgz
 ```
 
 Charts that are packaged can be loaded into chart repositories. See the
-documentation for [Helm chart repositories](../docs/topics/chart_repository/)
-for more details.
+documentation for [Helm chart
+repositories]({{< ref "/docs/topics/chart_repository.md" >}}) for more details.
 
 ## Conclusion
 

--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -9,10 +9,10 @@ This section explains how to create and work with Helm chart repositories. At a
 high level, a chart repository is a location where packaged charts can be stored
 and shared.
 
-The official chart repository is maintained by the [Kubernetes
-Charts](https://github.com/helm/charts), and we welcome participation. But Helm
-also makes it easy to create and run your own chart repository. This guide
-explains how to do so.
+The distributed community Helm chart repository is located at
+[Artifact Hub](https://artifacthub.io/packages/search?kind=0) and welcomes
+participation. But Helm also makes it possible to create and run your own chart
+repository. This guide explains how to do so.
 
 ## Prerequisites
 
@@ -25,9 +25,8 @@ A _chart repository_ is an HTTP server that houses an `index.yaml` file and
 optionally some packaged charts.  When you're ready to share your charts, the
 preferred way to do so is by uploading them to a chart repository.
 
-**Note:** For Helm 2.0.0, chart repositories do not have any intrinsic
-authentication. There is an [issue tracking
-progress](https://github.com/helm/helm/issues/1038) in GitHub.
+As of Helm 2.2.0, client-side SSL auth to a repository is supported. Other
+authentication protocols may be available as plugins.
 
 Because a chart repository can be any HTTP server that can serve YAML and tar
 files and can answer GET requests, you have a plethora of options when it comes
@@ -132,13 +131,9 @@ Insert this line item to **make your bucket public**:
 
 Congratulations, now you have an empty GCS bucket ready to serve charts!
 
-You may upload your chart repository using the Google Cloud Storage command line
-tool, or using the GCS web UI. This is the technique the official Kubernetes
-Charts repository hosts its charts, so you may want to take a [peek at that
-project](https://github.com/helm/charts) if you get stuck.
-
-**Note:** A public GCS bucket can be accessed via simple HTTPS at this address
-`https://bucket-name.storage.googleapis.com/`.
+You may upload your chart repository using the Google Cloud Storage command
+line tool, or using the GCS web UI. A public GCS bucket can be accessed via
+simple HTTPS at this address: `https://bucket-name.storage.googleapis.com/`.
 
 ### JFrog Artifactory
 

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -180,8 +180,7 @@ deprecate a chart. The optional `deprecated` field in `Chart.yaml` can be used
 to mark a chart as deprecated. If the **latest** version of a chart in the
 repository is marked as deprecated, then the chart as a whole is considered to
 be deprecated. The chart name can be later reused by publishing a newer version
-that is not marked as deprecated. The workflow for deprecating charts, as
-followed by the [kubernetes/charts](https://github.com/helm/charts) project is:
+that is not marked as deprecated. The workflow for deprecating charts is:
 
 1. Update chart's `Chart.yaml` to mark the chart as deprecated, bumping the
    version
@@ -674,8 +673,8 @@ values (usually defined in a `values.yaml` file):
 All of these values are defined by the template author. Helm does not require or
 dictate parameters.
 
-To see many working charts, check out the [Kubernetes Charts
-project](https://github.com/helm/charts)
+To see many working charts, check out the CNCF [Artifact
+Hub](https://artifacthub.io/packages/search?kind=0).
 
 ### Predefined Values
 

--- a/content/en/docs/topics/library_charts.md
+++ b/content/en/docs/topics/library_charts.md
@@ -311,9 +311,8 @@ metadata:
 
 ## The Common Helm Helper Chart
 
-Bit of a mouth full of a title but this
-[chart](https://github.com/helm/charts/tree/master/incubator/common) is the
-original pattern for common charts. It provides utilities that reflect best
+This [chart](https://github.com/helm/charts/tree/master/incubator/common) was
+the original pattern for common charts. It provides utilities that reflect best
 practices of Kubernetes chart development. Best of all it can be used off the
 bat by you when developing your charts to give you handy shared code.
 

--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -282,10 +282,6 @@ the provenance system:
   - Keybase also has fabulous documentation available
   - While we haven't tested it, Keybase's "secure website" feature could be used
     to serve Helm charts.
-- The [official Helm Charts project](https://github.com/helm/charts) is trying
-  to solve this problem for the official chart repository.
-  - There is a long issue there [detailing the current
-    thoughts](https://github.com/helm/charts/issues/23).
   - The basic idea is that an official "chart reviewer" signs charts with her or
     his key, and the resulting provenance file is then uploaded to the chart
     repository.


### PR DESCRIPTION
Adjustments to docs to reflect the following changes:

- Artifact Hub, not the helm/charts repo, is where people can find charts
- There is not an active "Kubernetes Charts" project
- client-side SSL is not a work in progress anymore

There is not a new location for "common helm helper chart" and it's listed as deprecated, so that section needs overhaul, but I made a minimal change to acknowledge that it's not currently the recommendation.

While many other improvements are warranted, this is fairly low-hanging fruit to get in so the docs are more correct.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>