### PR TITLE
Fix menu in Edge and Chrome on Windows

### DIFF
--- a/themes/helm/assets/js/foundation.js
+++ b/themes/helm/assets/js/foundation.js
@@ -410,7 +410,7 @@
       // or make it an empty string:
       //    Foundation.global.namespace = '';
       //
-      //
+      Foundation.global.namespace = 'helm-www';
 
       // If the namespace has not been set (is undefined), try to read it out of the meta element.
       // Otherwise use the globally defined namespace, even if it's empty ('')


### PR DESCRIPTION
This fixes an issue that prevents the menu from expanding on Chrome and Edge, reading the issue discussion it sounds like there is a goal to move away from this menu code and I'd agree that is the best long term solution. Currently it's pretty bad rendering, however this bug makes the menu completely broken on Windows Chrome & Edge and I think should be fixed before waiting for rewrite.

Fixes #914

Here is a gif showing what is broken:
![Broken on edge](https://user-images.githubusercontent.com/20361796/110723671-07e16e00-81da-11eb-8b3c-a49161c5bdff.gif)

Here are gifs showing it working in all FireFox, Edge, and Chrome on Windows:
![Works on firefox](https://user-images.githubusercontent.com/20361796/110723701-12036c80-81da-11eb-81e4-f4fdb25a551a.gif)
![Works on edge](https://user-images.githubusercontent.com/20361796/110723705-13cd3000-81da-11eb-830e-007a5a4aec59.gif)
![Works on chrome](https://user-images.githubusercontent.com/20361796/110723712-1596f380-81da-11eb-89e7-61c0f7827b52.gif)



