### PR TITLE
Add kube supported versions for 3.5

### DIFF
--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -46,6 +46,7 @@ with your cluster.
 
 | Helm Version | Supported Kubernetes Versions |
 |--------------|-------------------------------|
+| 3.5.x        | 1.20.x - 1.17.x               |
 | 3.4.x        | 1.19.x - 1.16.x               |
 | 3.3.x        | 1.18.x - 1.15.x               |
 | 3.2.x        | 1.18.x - 1.15.x               |


### PR DESCRIPTION
The 3.5.x supported versions were missing.