### PR TITLE
Removing current banner that has been up for past 9 months

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -18,7 +18,7 @@ other = "Copy"
 
 ## site-wide banner about versioning
 [banner_1]
-other = "[Racism is unacceptable, is incompatible with the Helm project goals, and has no place in our open source community. #BlackLivesMatter](https://docs.google.com/document/d/1a-lzdtxOlWuzYNGqwlYwxMWADtZ6vJGCpKhtJHHrS54/preview?pru=AAABcqVvUdo*ducxvc88kzBetsUXsohi7A)"
+other = ""
 
 ## footer
 [footer_support_title]

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -18,7 +18,7 @@ other = "コピー"
 
 ## site-wide banner about versioning
 [banner_1]
-other = "[人種差別は容認できず、Helm プロジェクトの目標と互換性がなく、オープンソースコミュニティに居場所はありません。 #BlackLivesMatter](https://docs.google.com/document/d/1a-lzdtxOlWuzYNGqwlYwxMWADtZ6vJGCpKhtJHHrS54/preview?pru=AAABcqVvUdo*ducxvc88kzBetsUXsohi7A)"
+other = ""
 
 ## footer
 [footer_support_title]

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -18,7 +18,7 @@ other = "복사"
 
 ## site-wide banner about versioning
 [banner_1]
-other = "[인종 차별은 용납할 수 없고, 헬름 프로젝트의 목표에 맞지 않으며, 우리 오픈 소스 커뮤니티에 있을 수 없습니다. #BlackLivesMatter](https://docs.google.com/document/d/1a-lzdtxOlWuzYNGqwlYwxMWADtZ6vJGCpKhtJHHrS54/preview?pru=AAABcqVvUdo*ducxvc88kzBetsUXsohi7A)"
+other = ""
 
 ## footer
 [footer_support_title]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -18,7 +18,7 @@ other = "Скопировать"
 
 ## site-wide banner about versioning
 [banner_1]
-other = "[Расизм неприемлем, несовместим с целями проекта Helm и не имеет места в нашем сообществе с открытым исходным кодом. #BlackLivesMatter](https://docs.google.com/document/d/1a-lzdtxOlWuzYNGqwlYwxMWADtZ6vJGCpKhtJHHrS54/preview?pru=AAABcqVvUdo*ducxvc88kzBetsUXsohi7A)"
+other = ""
 
 ## footer
 [footer_support_title]

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -18,7 +18,7 @@ other = "复制"
 
 ## site-wide banner about versioning
 [banner_1]
-other = "[种族歧视不可接受，有悖于 Helm 的项目目标，在我们的开源社区没有立足之地。#BlackLivesMatter](https://docs.google.com/document/d/1a-lzdtxOlWuzYNGqwlYwxMWADtZ6vJGCpKhtJHHrS54/preview?pru=AAABcqVvUdo*ducxvc88kzBetsUXsohi7A)"
+other = ""
 
 ## footer
 [footer_support_title]

--- a/themes/helm/layouts/partials/banner.html
+++ b/themes/helm/layouts/partials/banner.html
@@ -1,11 +1,14 @@
+{{- $banner := T "banner_1" }}
+{{- if $banner -}}
 <div id="banner">
   <!-- viewing helm 3 version of site (desktop) -->
   <p class="center text-center is-hidden-mobile">
-    {{ T "banner_1" | markdownify }}
+    {{ markdownify $banner }}
   </p>
   
   <!-- viewing helm 3 version of site (mobile) -->
   <p class="center text-center is-hidden-tablet">
-    {{ T "banner_1" | markdownify }}
+    {{ markdownify $banner }}
   </p>
 </div>
+{{- end -}}


### PR DESCRIPTION
Note, the template has been updated so that the banner is optional
and the region only displays if a banner is present.

The banner was discussed among some org maintainers and then taken
to the org maintainers list. This change is after the normal lazy
concensus period and there was no disucssion.

Taking down the banner was raised as a question about when should
something like this happen? Is it when the problem is solved, when
another issue comes along to replace it, or some other time?

Given that other projects (e.g., Kubernetes) have removed their
banner and that Helm is not a political or activist organization
(so we don't see a next replacement banner along these lines)
now appears to be a reasonable time to remove it.

It is worth noting that the Helm community is a global community.

This is not to say that members of the Helm community do not care
about BLM.