### PR TITLE
Clarifying where CLI docs are edited.

### DIFF
--- a/content/en/docs/community/developers.md
+++ b/content/en/docs/community/developers.md
@@ -76,6 +76,11 @@ Since Helm 3, documentation has been moved to its own repository. When writing
 new features, please write accompanying documentation and submit it to the
 [helm-www](https://github.com/helm/helm-www) repository.
 
+One exception: [Helm CLI output (in English)](https://helm.sh/docs/helm/) is
+generated from the `helm` binary itself. See [Updating the Helm CLI Reference Docs](https://github.com/helm/helm-www#updating-the-helm-cli-reference-docs)
+for instructions on how to generate this output. When translated, the CLI
+output is not generated and can be found in `/content/<lang>/docs/helm`.
+
 ### Git Conventions
 
 We use Git for our version control system. The `master` branch is the home of


### PR DESCRIPTION
Clarifying where CLI docs are edited, based on feedback in https://github.com/helm/helm-www/pull/1069#issuecomment-819933254.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>