### PR TITLE
Language Menu Adjustments 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -122,8 +122,8 @@ weight = 5
 title = "헬름"
 description = "헬름 - 쿠버네티스 패키지 매니저"
 contentDir = "content/ko"
-languageName = "한국어 Korean"
-weight = 1
+languageName = "한국어"
+weight = 5
 
 [[languages.ko.menus.main]]
 name = "홈"
@@ -159,8 +159,8 @@ language_alternatives = ["en"]
 title = "Helm"
 description = "Helm - Kubernetes パッケージマネージャー"
 contentDir = "content/ja"
-languageName = "日本語 Japanese"
-weight = 1
+languageName = "日本語"
+weight = 4
 
 [[languages.ja.menus.main]]
 name = "ホーム"
@@ -195,8 +195,8 @@ language_alternatives = ["en"]
 title = "Helm"
 description = "Helm - Kubernetes 包管理器"
 contentDir = "content/zh"
-languageName = "中文 Chinese"
-weight = 1
+languageName = "中文"
+weight = 7
 
 [[languages.zh.menus.main]]
 name = "首页"
@@ -232,8 +232,8 @@ language_alternatives = ["en"]
 title = "Helm"
 description = "Helm – Менеджер Пакетов Kubernetes."
 contentDir = "content/ru"
-languageName = "Русский Russian"
-weight = 1
+languageName = "Русский"
+weight = 6
 
 [[languages.ru.menus.main]]
 name = "Главная"
@@ -269,8 +269,8 @@ language_alternatives = ["en"]
 title = "Helm"
 description = "Helm - Le manageur de paquets de Kubernetes."
 contentDir = "content/fr"
-languageName = "Français French"
-weight = 1
+languageName = "Français"
+weight = 3
 
 [[languages.fr.menus.main]]
 name = "Accueil"
@@ -302,8 +302,8 @@ weight = 5
 title = "Helm"
 description = "Helm - El Administrador de Paquetes de Kubernetes."
 contentDir = "content/es"
-languageName = "Español Spanish"
-weight = 1
+languageName = "Español"
+weight = 2
 
 [[languages.es.menus.main]]
 name = "Inicio"

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -112,11 +112,27 @@
       }
 
       ul.dropdown-menu {
+        padding-top: 1rem;
         li.navbar-item {
           a {
+
+            code {
+              color: $navy;
+              background-color: lighten($yellow, 25%);
+              border-radius: 50%;
+              display: inline-block;
+              line-height: 2;
+              margin-right: 0.667rem;
+            }
+            
             &.active {
               font-weight: bold;
-              border-bottom: 2px solid $green;
+              color: $dark;
+
+              code {
+                color: $dark;
+                background-color: lighten($salmon, 7.5%);
+              }
             }
           }
         }

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -28,8 +28,7 @@
   top: 0;
   left: 0;
   right: 0;
-  padding-top: 4.5rem;
-  min-height: 8.75rem;
+  min-height: 5.125rem;
   background: transparent;
   display: flex;
   justify-content: center;
@@ -110,6 +109,17 @@
         text-align: center;
         line-height: 1.75;
         margin: 0.5rem auto;
+      }
+
+      ul.dropdown-menu {
+        li.navbar-item {
+          a {
+            &.active {
+              font-weight: bold;
+              border-bottom: 2px solid $green;
+            }
+          }
+        }
       }
     }
     

--- a/themes/helm/assets/sass/helm-home.scss
+++ b/themes/helm/assets/sass/helm-home.scss
@@ -2,7 +2,6 @@
 .page-home {
   .navbar-top {
     min-height: 4.25rem;
-    padding-top: 3.5rem;
 
     .container {
       min-height: 1rem;

--- a/themes/helm/assets/sass/helm-layout.scss
+++ b/themes/helm/assets/sass/helm-layout.scss
@@ -53,7 +53,6 @@ $sidebarWidth: 18.5rem;
 .page-blog {
 
   .navbar-top {
-    padding-top: 3.5rem;
     background: url('/img/topography.png') left top repeat;
     background-attachment: fixed;
 

--- a/themes/helm/layouts/partials/nav-fixed.html
+++ b/themes/helm/layouts/partials/nav-fixed.html
@@ -42,13 +42,15 @@
             {{ $pageLang := .Page.Lang}}
             {{ range .Page.AllTranslations }}
                 {{ $translation := .}}
-                {{ range $siteLanguages }}
+                {{ range sort $siteLanguages "Weight" }}
                     {{ if eq $translation.Lang .Lang }}
                       {{ $selected := false }}
                       {{ if eq $pageLang .Lang}}
-                          <li class="navbar-item"><a href="{{ $translation.URL }}" class="active">{{ .LanguageName }}</a></li>
+                          <!-- <li class="navbar-item"><a href="{{ $translation.URL }}" class="active">{{ .LanguageName }} ({{ .Lang }})</a></li> -->
+                          {{ .Lang }} active
                       {{ else }}
-                          <li class="navbar-item"><a href="{{ $translation.URL }}">{{ .LanguageName }}</a></li>
+                          <!-- <li class="navbar-item"><a href="{{ $translation.URL }}">{{ .LanguageName }} ({{ .Lang }})</a></li> -->
+                          {{ .Lang }}
                       {{ end }}
                     {{ end }}
 

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -40,13 +40,13 @@
             {{ $pageLang := .Page.Lang}}
             {{ range .Page.AllTranslations }}
                 {{ $translation := .}}
-                {{ range $siteLanguages }}
+                {{ range sort $siteLanguages "Weight" }}
                     {{ if eq $translation.Lang .Lang }}
                       {{ $selected := false }}
                       {{ if eq $pageLang .Lang}}
-                          <li class="navbar-item"><a href="{{ $translation.URL }}" class="active">{{ .LanguageName }}</a></li>
+                          <li class="navbar-item"><a href="{{ $translation.URL }}" class="active"><code>{{ .Lang }}</code> &nbsp; {{ .LanguageName }}</a></li>
                       {{ else }}
-                          <li class="navbar-item"><a href="{{ $translation.URL }}">{{ .LanguageName }}</a></li>
+                          <li class="navbar-item"><a href="{{ $translation.URL }}"><code>{{ .Lang }}</code> &nbsp; {{ .LanguageName }}</a></li>
                       {{ end }}
                     {{ end }}
 


### PR DESCRIPTION
This PR adjusts the CSS for the top menu bar as follows:

* restores the correct spacing following banner removal (#1054)
* makes use of the active class to highlight current language

In addition, this PR changes the way the languages menu is populated, sorting them in order of the language code (`en`, `ko`, `zh` etc) and removes the English language word for each language from the title.

---

Current menu screenshot:

<img width="204" alt="Screen Shot 2021-04-16 at 1 16 27 PM" src="https://user-images.githubusercontent.com/686194/115080202-362c2a80-9eb7-11eb-89b3-5bf96446a588.png">

Proposed change screenshot:

<img width="205" alt="Screen Shot 2021-04-16 at 1 15 21 PM" src="https://user-images.githubusercontent.com/686194/115080213-3debcf00-9eb7-11eb-9280-f5c5e564920c.png">

<img width="296" alt="Screen Shot 2021-04-16 at 1 15 04 PM" src="https://user-images.githubusercontent.com/686194/115080227-40e6bf80-9eb7-11eb-91ee-ba79e3c65f3c.png">
