### PR TITLE
Add backticks around .Values.who

### DIFF
--- a/content/en/docs/howto/charts_tips_and_tricks.md
+++ b/content/en/docs/howto/charts_tips_and_tricks.md
@@ -33,7 +33,7 @@ required for template rendering.  If the value is empty, the template rendering
 will fail with a user submitted error message.
 
 The following example of the `required` function declares an entry for
-.Values.who is required, and will print an error message when that entry is
+`.Values.who` is required, and will print an error message when that entry is
 missing:
 
 ```yaml


### PR DESCRIPTION
It is confusing to see a variable reference without backticks around it, especially when the first `.` can be misinterpreted as an end of sentence.

I had an issue with generating the markdown: after running `helm docs --type markdown --generate-headers`, all markdown files that originally referenced `~` were replaced with my actual home directory (`/home/myname`). I don't want to commit that, and I assume you guys don't want me to either, so I've reverted that change. I haven't created a new issue, as https://github.com/helm/helm-www/issues/487 already exists. 

Before:
![image](https://user-images.githubusercontent.com/25968054/116931109-9bf61180-ac2e-11eb-86f9-50ef66b5c1ed.png)

After:
![image](https://user-images.githubusercontent.com/25968054/116931536-1888f000-ac2f-11eb-89ec-3ea58468898b.png)


Signed-off-by: Steven Pitts <makusu2@gmail.com>