### PR TITLE
Add example of --template usage

### DIFF
--- a/content/en/docs/helm/helm_version.md
+++ b/content/en/docs/helm/helm_version.md
@@ -30,6 +30,7 @@ the template:
 - .GitTreeState is the state of the git tree when Helm was built
 - .GoVersion contains the version of Go that Helm was compiled with
 
+For example, `--template '{{.Version}}'` outputs `v3.5.4`. See `version` [unit test](https://github.com/helm/helm/blob/main/cmd/helm/version_test.go) for further examples.
 
 ```
 helm version [flags]


### PR DESCRIPTION
Current documentation list all available template vars, but does not provide an example of a template string that demonstrates template substitution. I had to look it out in the unit test.