### PR TITLE
Link to a maintained fork of helm-unittests

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -22,7 +22,7 @@ request](https://github.com/helm/helm-www/pulls).
   monitor a release and rollback based on Prometheus/ElasticSearch query
 - [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm
   Charts from hiera using k8comp
-- [helm-unittest](https://github.com/lrills/helm-unittest) - Plugin for unit
+- [helm-unittest](https://github.com/quintush/helm-unittest/) - Plugin for unit
   testing chart locally with YAML
 - [hc-unit](https://github.com/xchapter7x/hcunit) - Plugin for unit testing
   charts locally using OPA (Open Policy Agent) & Rego

--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -22,7 +22,7 @@ request](https://github.com/helm/helm-www/pulls).
   monitor a release and rollback based on Prometheus/ElasticSearch query
 - [helm-k8comp](https://github.com/cststack/k8comp) - Plugin to create Helm
   Charts from hiera using k8comp
-- [helm-unittest](https://github.com/quintush/helm-unittest/) - Plugin for unit
+- [helm-unittest](https://github.com/quintush/helm-unittest) - Plugin for unit
   testing chart locally with YAML
 - [hc-unit](https://github.com/xchapter7x/hcunit) - Plugin for unit testing
   charts locally using OPA (Open Policy Agent) & Rego


### PR DESCRIPTION
lrills/helm-unittest does not seem to be maintained any longer: https://github.com/helm/helm/issues/5424

https://github.com/quintush/helm-unittest/ seems to be currently the most maintained version of the project.

Alternatively we could point people to [Rancher's fork](https://github.com/rancher/helm-unittest).