### PR TITLE
Update provenance.md

### DIFF
--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -61,6 +61,7 @@ the default location  `~/.gnupg/pubring.kbx`. Please use the following command
 to convert your keyring to the legacy gpg format:
 
 ```console
+$ gpg --export >~/.gnupg/pubring.gpg
 $ gpg --export-secret-keys >~/.gnupg/secring.gpg
 ```
 


### PR DESCRIPTION
You also need also to export the pubring.gpg otherwise the 'helm verify' step fails.

[gcollis@morpheus work07]$ cat /etc/redhat-release 
Fedora release 33 (Thirty Three)
gcollis@morpheus work07]$ gpg --version
gpg (GnuPG) 2.2.25
libgcrypt 1.8.7
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: /home/gcollis/.gnupg
Supported algorithms:
Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2

/home/gcollis/.gnupg/
├── openpgp-revocs.d
│   └── 2722B192EAAF3412D30CDC4810DBA57F355F960F.rev
├── private-keys-v1.d
│   ├── 8FC27FEFEF03DB8F7346EA6E52752D0B390E134C.key
│   └── A4E2C18B175DB835C43535F6362EBC7F03709B33.key
├── pubring.gpg
├── pubring.kbx
├── pubring.kbx~
├── secring.gpg
└── trustdb.gpg