### PR TITLE
add adopt plugin 

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -38,6 +38,8 @@ request](https://github.com/helm/helm-www/pulls).
   rendering Tanka/Jsonnet inside Helm charts.
 - [helm-val](https://github.com/HamzaZo/helm-val) - A plugin to get 
   values from a previous release.
+- [helm-adopt](https://github.com/HamzaZo/helm-adopt) - A helm v3 plugin to adopt 
+  existing k8s resources into a new generated helm chart.  
 
 We also encourage GitHub authors to use the
 [helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories)


### PR DESCRIPTION
Hello!
This PR adds a new helm plugin called `adopt` to help user to adopt k8s existing resources into a new generated helm chart 