### PR TITLE
Change padding in sidebar toctree items

### DIFF
--- a/themes/helm/assets/sass/docs-sidebar.scss
+++ b/themes/helm/assets/sass/docs-sidebar.scss
@@ -82,7 +82,7 @@
           margin: 0;
 
           a {
-            padding: 0.25em 6.67% 0.25em 13.5%;
+            padding: 0.25em 0.5vw 0.25em 3vw;
             line-height: 1.4;
             color: $navyl;
             font-family: $base;


### PR DESCRIPTION
This PR closes #1032

Change padding in toctree items to effected by viewport, same as [the parent](https://github.com/helm/helm-www/blob/97a09604ba1723834164184786bdde20786a21d8/themes/helm/assets/sass/docs-sidebar.scss#L48).

Image is taken on 3840p (4k)
Before:
<img src="https://user-images.githubusercontent.com/66208081/122153887-d47c4280-ce9e-11eb-9637-a72b925a8b14.png" width="200">

After:
<img src="https://user-images.githubusercontent.com/66208081/122154180-579d9880-ce9f-11eb-878b-4836ca34d689.png" width="200">

Signed-off-by: sugardon <sugar2don@gmail.com>