### PR TITLE
Add example on using auto roll deployment checksum with library chart

### DIFF
--- a/content/en/docs/howto/charts_tips_and_tricks.md
+++ b/content/en/docs/howto/charts_tips_and_tricks.md
@@ -210,6 +210,10 @@ spec:
 [...]
 ```
 
+NOTE: If you're adding this to a library chart you won't be able to access your
+file in `$.Template.BasePath`. Instead you can reference your definition with
+`{{ include ("mylibchart.configmap") . | sha256sum }}`.
+
 In the event you always want to roll your deployment, you can use a similar
 annotation step as above, instead replacing with a random string so it always
 changes and causes the deployment to roll:


### PR DESCRIPTION
Hi,

I'm new to using Helm and I really like how the docs guided you towards getting a checksum of a file to control automatically rolling out your deployments if a file changes, such as a config map or secret.

But when I transitioned to using library charts the approach in the docs no longer worked because it seems library charts aren't included in the `$.Template.BasePath` path.

This PR addresses this by adding an example that works with library charts.