### PR TITLE
Add 3.6.x to version_skew doc

### DIFF
--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -46,6 +46,7 @@ with your cluster.
 
 | Helm Version | Supported Kubernetes Versions |
 |--------------|-------------------------------|
+| 3.6.x        | 1.21.x - 1.18.x               |
 | 3.5.x        | 1.20.x - 1.17.x               |
 | 3.4.x        | 1.19.x - 1.16.x               |
 | 3.3.x        | 1.18.x - 1.15.x               |


### PR DESCRIPTION
3.6.x was missing from the version_skew documentation.

I'm quite certain it is true but I haven't tested it.

I also don't know if there are other docs that needs updating