### PR TITLE
Document stricter YAML parsing

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -84,7 +84,9 @@ annotations:
   example: A list of annotations keyed by name (optional).
 ```
 
-Other fields will be silently ignored.
+As of [v3.3.2](https://github.com/helm/helm/releases/tag/v3.3.2), additional
+fields are not allowed.
+The recommended approach is to add custom metadata in `annotations`.
 
 ### Charts and Versioning
 


### PR DESCRIPTION
This topic came up in today's Helm dev call for a completely different reason.

I seemed to remember this note in the docs, which is no longer true - checked, and it's still there. Small update so this is more accurate. For more context, see release notes on https://github.com/helm/helm/releases/tag/v3.3.2.

To cover our bases, I also searched the docs for keywords like `yaml` and `fields`. One question about the note below – it seems to still be accurate, but does anyone know of a reason why we should update this with more detail as well?

>**NOTE:** Any unknown `Chart.yaml` fields will be dropped. They will not be
>accessible inside of the `Chart` object. Thus, `Chart.yaml` cannot be used to
>pass arbitrarily structured data into the template. The values file can be used
>for that, though.