### PR TITLE
Update using_helm.md: Dot Escape

### DIFF
--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -327,7 +327,7 @@ name: "value1,value2"
 
 Similarly, you can escape dot sequences as well, which may come in handy when
 charts use the `toYaml` function to parse annotations, labels and node
-selectors. The syntax for `--set nodeSelector."kubernetes\.io/role"=master`
+selectors. The syntax for `--set nodeSelector."kubernetes\\.io/role"=master`
 becomes:
 
 ```yaml


### PR DESCRIPTION
Is the updated dot escape two backslash characters? Seems like only two backslash characters worked in a set for me (for v3.4.1). Found in a comment here: https://github.com/cetic/helm-nifi/issues/50#issuecomment-777882683.