### PR TITLE
Adding maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 maintainers:
+  - angellk
   - bacongobbler
   - bridgetkromhout
   - flynnduism


### PR DESCRIPTION
As she has been voted in by a supermajority of the current helm-www OWNERS I am adding @angellk to the file here.

Still to do (requires access, and perhaps can be handled by whomever approves this PR):

- [x] add her to the web team: https://github.com/orgs/helm/teams/web
- [x] add her to mailing list(s)
- [x] add her to maintainer chat

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>