### PR TITLE
Updating the docs on dependencies

### DIFF
--- a/content/en/docs/chart_best_practices/dependencies.md
+++ b/content/en/docs/chart_best_practices/dependencies.md
@@ -34,10 +34,15 @@ names.
 File URLs (`file://...`) are considered a "special case" for charts that are
 assembled by a fixed deployment pipeline.
 
-When using [download plugins]({{< ref "../topics/plugins#downloader-plugins" >}})
+When using [downloader plugins]({{< ref "../topics/plugins#downloader-plugins" >}})
 the URL scheme will be specific to the plugin. Note, a user of the chart will
 need to have a plugin supporting the scheme installed to update or build the
 dependency.
+
+Helm cannot perform dependency management operations on the dependency when the
+`repository` field is left blank. In that case Helm will assume the dependency
+is in a sub-directory of the `charts` folder with the name being the same as the
+`name` property for the dependency.
 
 ## Conditions and Tags
 

--- a/content/en/docs/chart_best_practices/dependencies.md
+++ b/content/en/docs/chart_best_practices/dependencies.md
@@ -34,6 +34,11 @@ names.
 File URLs (`file://...`) are considered a "special case" for charts that are
 assembled by a fixed deployment pipeline.
 
+When using [download plugins]({{< ref "../topics/plugins#downloader-plugins" >}})
+the URL scheme will be specific to the plugin. Note, a user of the chart will
+need to have a plugin supporting the scheme installed to update or build the
+dependency.
+
 ## Conditions and Tags
 
 Conditions or tags should be added to any dependencies that _are optional_.

--- a/content/en/docs/chart_best_practices/dependencies.md
+++ b/content/en/docs/chart_best_practices/dependencies.md
@@ -32,8 +32,7 @@ name can be used as an alias of URL. Use `alias:` or `@` followed by repository
 names.
 
 File URLs (`file://...`) are considered a "special case" for charts that are
-assembled by a fixed deployment pipeline. Charts that use `file://` are not
-allowed in the official Helm repository.
+assembled by a fixed deployment pipeline.
 
 ## Conditions and Tags
 


### PR DESCRIPTION
- for when a repo isn't specified
- adding details on downloader plugins
- removing reference to the obsolete official repo