### PR TITLE
Fixed command in quickstart.md

### DIFF
--- a/content/en/docs/intro/quickstart.md
+++ b/content/en/docs/intro/quickstart.md
@@ -93,12 +93,12 @@ learn more about it, check out the [Using Helm Guide]({{< ref "using_helm.md"
 It's easy to see what has been released using Helm:
 
 ```console
-$ helm ls
+$ helm list
 NAME            	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART      	APP VERSION
 mysql-1612624192	default  	1       	2021-02-06 16:09:56.283059 +0100 CET	deployed	mysql-8.3.0	8.0.23
 ```
 
-The `helm list` function will show you a list of all deployed releases.
+The `helm list` (or `helm ls`) function will show you a list of all deployed releases.
 
 ## Uninstall a Release
 


### PR DESCRIPTION
This PR changes a `helm ls` reference in the Quickstart to `helm list`. The official Helm docs make no references to the `helm ls` command, even though it is currently a valid alias for `helm list`. Additionally, the command used in the terminal snippet now matches the description underneath it, as they now both use `helm list`. 

Signed-off-by: chloe andresol <candreso@gmu.edu>