### PR TITLE
Add documentation for GitLab Chart Repo

### DIFF
--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -229,6 +229,10 @@ You can also use the
 [ChartMuseum](https://chartmuseum.com/docs/#using-with-local-filesystem-storage)
 server to host a chart repository from a local file system.
 
+### GitLab Package Registry
+
+With GitLab you can publish Helm charts in your project’s Package Registry.
+Read more about setting up a helm package repository with GitLab [here](https://docs.gitlab.com/ee/user/packages/helm_repository/).
 
 ## Managing Chart Repositories
 


### PR DESCRIPTION
Adds documentation providing information on using the GitLab Package Registry for Helm Charts.