### PR TITLE
Docs for template function "index" on lists

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1415,7 +1415,7 @@ Helm provides the following list functions: [append
 (mustInitial)](#initial-mustinitial), [last (mustLast)](#last-mustlast),
 [prepend (mustPrepend)](#prepend-mustprepend), [rest
 (mustRest)](#rest-mustrest), [reverse (mustReverse)](#reverse-mustreverse),
-[seq](#seq), [slice (mustSlice)](#slice-mustslice), [uniq
+[seq](#seq), [index](#index), [slice (mustSlice)](#slice-mustslice), [uniq
 (mustUniq)](#uniq-mustuniq), [until](#until), [untilStep](#untilstep), and
 [without (mustWithout)](#without-mustwithout).
 
@@ -1561,6 +1561,12 @@ $copy := compact $list
 
 `compact` panics if there is a problem and `mustCompact` returns an error to the
 template engine if there is a problem.
+
+### index
+
+To get the nth element of a list, use `index list [n]`. To index into multi-dimensional lists, use `index list [n] [m] ...`
+- `index $myList 0` returns `1`. It is the same as `myList[0]`
+- `index $myList 0 1` would be the same as `myList[0][1]`
 
 ### slice, mustSlice
 

--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1564,7 +1564,8 @@ template engine if there is a problem.
 
 ### index
 
-To get the nth element of a list, use `index list [n]`. To index into multi-dimensional lists, use `index list [n] [m] ...`
+To get the nth element of a list, use `index list [n]`. To index into 
+multi-dimensional lists, use `index list [n] [m] ...`
 - `index $myList 0` returns `1`. It is the same as `myList[0]`
 - `index $myList 0 1` would be the same as `myList[0][1]`
 


### PR DESCRIPTION
Hello, I noticed the docs for the `index` function were missing. From my usage of it and the helm/sprig source, I assume it comes from [Go templates](https://pkg.go.dev/text/template#hdr-Functions). Because it doesn't come from Sprig, it looks like there is no `mustIndex`. Thought I'd add it in spirit of this comment from https://github.com/helm/helm-www/issues/489#issuecomment-582958396 , with the main tracking issue being https://github.com/helm/helm-www/issues/706 . I am open to whatever wording changes the maintainers feel would be needed!

> We should not expect so many people to know Go templates and sprig functions.