### PR TITLE
Make `version` optional for dependencies

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -65,7 +65,7 @@ sources:
   - A list of URLs to source code for this project (optional)
 dependencies: # A list of the chart requirements (optional)
   - name: The name of the chart (nginx)
-    version: The version of the chart ("1.2.3")
+    version: (optional) The version of the chart ("1.2.3")
     repository: (optional) The repository URL ("https://example.com/charts") or alias ("@repo-name")
     condition: (optional) A yaml path that resolves to a boolean, used for enabling/disabling charts (e.g. subchart1.enabled )
     tags: # (optional)


### PR DESCRIPTION
This is a follow-up of https://github.com/SchemaStore/schemastore/pull/1815, where I stated my reasonings.