### PR TITLE
Improve site for mobile screens

### DIFF
--- a/themes/helm/assets/js/app.js
+++ b/themes/helm/assets/js/app.js
@@ -69,9 +69,9 @@ if ($('.page-docs').length) {
   $(window).scroll(function() {    // this will work when your window scrolled.
       var height = $(window).scrollTop();  //getting the scrolling height of window
       if(height  > 50) {
-        $(".sidebar").addClass('is-scrolled');
+        $(".sidebar-wrapper").addClass('is-scrolled');
       } else{
-        $(".sidebar").removeClass('is-scrolled');
+        $(".sidebar-wrapper").removeClass('is-scrolled');
       }
   });
 

--- a/themes/helm/assets/sass/docs-responsive.scss
+++ b/themes/helm/assets/sass/docs-responsive.scss
@@ -1,6 +1,158 @@
+/*
+// tablet + sm desktop
+*/
+@media only screen and (min-width: 769px) and (max-width: 1023px) {
+  #banner {
+    position: relative;
 
-// mobile style
-@media only screen and (max-width: 64.063em) {
+    p {
+      font-size: 1.25vw;
+    }
+  }
+
+  .page-docs .content-docs, .page-blog .content-docs {
+    padding-left: 0;
+  }
+
+  .footer-links {
+    margin-left: 0;
+    z-index: 1620;
+  }
+  
+  // hamburger for sidebar
+  .sidebar-wrapper {
+    z-index: 1330;
+    width: 6.5rem;
+    // background: url("/img/topography.png") left 100px repeat-x;
+    background: none;
+    
+    // left border
+    &:before {
+      content: " ";
+      display: block;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 8px;
+      background: $navy;
+      position: fixed;
+      z-index: 1445;
+    }
+
+    // bottom border
+    &:after {
+      content: " ";
+      display: block;
+      bottom: 0;
+      left: 0;
+      height: 8px;
+      width: ($sidebarWidth + 2rem);
+      background: $navy;
+      position: fixed;
+      z-index: 1445;
+    }
+
+    input.hamburger-trigger {
+      display: block;
+      width: 3rem;
+      height: 3rem;
+      position: absolute;
+      top: 4.75rem;
+      left: 14rem;
+      z-index: 1450;
+      opacity: 0;
+    }
+
+    .hamburger {
+      position: fixed;
+      top: 6rem;
+      left: 15rem;
+      z-index: 1440;
+      @include transition;
+      
+      span {
+        display: block;
+        width: 33px;
+        height: 4px;
+        margin-bottom: 5px;
+        position: relative;
+        background: $navyd;
+        border-radius: 3px;
+        z-index: 1;
+        transform-origin: 4px 0px;
+        transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+                    background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
+                    opacity 0.55s ease;
+
+        &:first-child {
+          transform-origin: 0% 0%;
+        }
+
+        &:nth-last-child(2) {
+          transform-origin: 0% 100%;
+        }
+      }
+    }
+
+    &.is-scrolled {
+      .hamburger-trigger {
+        top: 1.25rem;
+      }
+      .hamburger {
+        top: 2.5rem;
+      }
+    }
+
+
+    .sidebar {
+      transform-origin: 0% 0%;
+      transform: translate(-105%, 0);
+      transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
+      position: absolute;
+      width: $sidebarWidth;
+      background: none transparent;
+      // background: url("/img/topography.png") 0 0 no-repeat;
+
+      .search-container {
+        margin: 10rem 1.5rem 0;
+      }
+
+      .sidebar-nav {
+        background: white;
+        margin-top: -2rem;
+        padding-top: 4.5rem;
+      }
+    }
+
+    // hamburger is open
+    input.hamburger-trigger:checked {
+      ~ .hamburger span {
+        opacity: 1;
+        transform: rotate(45deg) translate(-10px, -14px);
+        background: $navyl;
+
+        &:nth-last-child(3) {
+          opacity: 0;
+          transform: rotate(0deg) scale(0.2, 0.2);
+        }
+
+        &:nth-last-child(2) {
+          transform: rotate(-45deg) translate(-5px, 10px);
+        }
+      }
+
+      ~ .sidebar {
+        transform: none;
+      }
+    }
+  }
+} // end tablet
+
+
+/*
+// mobile adjustments
+*/
+@media only screen and (max-width: 768px) {
   html,
   body,
   #helm {

--- a/themes/helm/assets/sass/docs-responsive.scss
+++ b/themes/helm/assets/sass/docs-responsive.scss
@@ -59,8 +59,9 @@
       position: absolute;
       top: 4.75rem;
       left: 14rem;
-      z-index: 1450;
+      z-index: 1650;
       opacity: 0;
+      cursor: context-menu;
     }
 
     .hamburger {
@@ -185,7 +186,6 @@
 
   // .navbar-top-fixed.is-active,
   .navbar-brand,
-  .navbar-menu,
   .navbar-top.navbar-top-fixed.is-active {
     display: none !important;
   }

--- a/themes/helm/assets/sass/docs-responsive.scss
+++ b/themes/helm/assets/sass/docs-responsive.scss
@@ -18,12 +18,17 @@
     margin-left: 0;
     z-index: 1620;
   }
+
+  .sidebar,
+  .sidebar-nav,
+  .sidebar .sidebar-buttons {
+    border-right: 2px solid $navy;
+  }
   
   // hamburger for sidebar
   .sidebar-wrapper {
     z-index: 1330;
     width: 6.5rem;
-    // background: url("/img/topography.png") left 100px repeat-x;
     background: none;
     
     // left border
@@ -57,8 +62,8 @@
       width: 3rem;
       height: 3rem;
       position: absolute;
-      top: 4.75rem;
-      left: 14rem;
+      top: 1.25rem;
+      left: 12.5rem;
       z-index: 1650;
       opacity: 0;
       cursor: context-menu;
@@ -66,9 +71,9 @@
 
     .hamburger {
       position: fixed;
-      top: 6rem;
-      left: 15rem;
-      z-index: 1440;
+      top: 2.5rem;
+      left: 13.5rem;
+      z-index: 1640;
       @include transition;
       
       span {
@@ -112,7 +117,6 @@
       position: absolute;
       width: $sidebarWidth;
       background: none transparent;
-      // background: url("/img/topography.png") 0 0 no-repeat;
 
       .search-container {
         margin: 10rem 1.5rem 0;
@@ -149,6 +153,49 @@
   }
 } // end tablet
 
+// mobile and tablet combined
+@media only screen and (max-width: 1023px) {
+  section.footer-links {
+    padding-left: 10vw;
+    padding-right: 10vw;
+
+    img {
+      float: left;
+      margin: 0 0 3rem;
+    }
+
+    hr {
+      clear: both;
+    }
+    
+    dl {
+      dt {
+        margin: 0;
+      }
+      dd {
+        display: none;
+      }
+    }
+  }
+
+  section.home-intro {
+    min-height: 70vh;
+
+    img.logo {
+      top: 30vw;
+    }
+
+    h1 {
+      top: 30vw;
+    }
+    h2 {
+      top: 37.5vw;
+      bottom: auto;
+      width: 58vw;
+    }
+  }
+}
+
 
 /*
 // mobile adjustments
@@ -159,7 +206,7 @@
   #helm {
     width: 100vw !important;
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   // mobile menu
@@ -215,11 +262,11 @@
 
     img.logo {
       position: absolute;
-      top: 8rem;
+      top: 11.25rem !important;
       left: 10vw;
       right: auto;
       margin: 0;
-      width: 22.5vw;
+      width: 18.5vw;
     }
 
     .boat.boat-badge{
@@ -229,8 +276,8 @@
     h1 {
       font-size: 5vw;
       position: absolute;
-      left: 40%;
-      top: 10rem;
+      left: 38%;
+      top: 12rem !important;
       margin: 0;
       max-width: 50%;
       line-height: 1.2;
@@ -238,13 +285,13 @@
     }
 
     h2 {
-      top: 50vh;
-      left: 8vw;
-      right: 8vw;
-      font-size: 4.75vw;
+      top: 37.5vh !important;
+      left: 14vw;
+      right: 14vw;
+      font-size: 3vw;
       position: absolute;
       bottom: auto;
-      width: auto;
+      width: 70vw !important;
       padding: 1.5rem 2.5vw;
       border: none;
     }
@@ -408,11 +455,12 @@
 
     .sidebar {
       position: relative;
-      margin-top: 4rem;
+      margin-top: 2.5rem;
       width: 100vw;
       min-height: 2rem;
       padding: 0;
       border: none;
+      background: url("/img/topography.png") left 100px repeat-x;
     }
 
     &.is-active {
@@ -443,7 +491,15 @@
       display: none;
       padding: 1rem 7.5vw;
       border: 12px solid $light2;
-      margin-left: 8px;;
+      margin-left: 8px;
+      z-index: 940;
+
+      .sidebar-nav {
+        width: 80vw;
+        position: relative;
+        top: auto;
+        bottom: auto;
+      }
 
       .search-container {
         margin-top: 0;
@@ -451,11 +507,16 @@
 
       &.active {
         display: block;
+        left: 0;
+        right: 0;
+        width: 96.8%;
+        min-height: 100vh;
+        z-index: 1850;
+        background: url("/img/topography.png") left 100px repeat-x;
       }
 
       ul.sidebar-main {
         padding-bottom: 0;
-
       }
     }
   }
@@ -482,7 +543,7 @@
     padding: 2rem 5vw 3rem;
 
     h1 {
-      font-size: 7.5vw;
+      font-size: 5vw;
       padding-top: 1rem;
     }
 
@@ -497,7 +558,7 @@
     }
 
     p {
-      font-size: 4vw;
+      font-size: 3vw;
     }
 
     p, ol, ul, dl, blockquote {

--- a/themes/helm/assets/sass/docs-sidebar.scss
+++ b/themes/helm/assets/sass/docs-sidebar.scss
@@ -12,6 +12,10 @@
   padding:0;
   background: url('/img/topography.png') left top repeat;
   background-attachment: fixed;
+
+  &.is-scrolled .sidebar-nav {
+    top: 8.5rem;
+  }
 }
 
 .sidebar {
@@ -28,9 +32,6 @@
     overflow-y: scroll;
     overflow-x: hidden;
     width: $sidebarWidth;
-  }
-  &.is-scrolled .sidebar-nav {
-    top: 8.5rem;
   }
 
   a {
@@ -152,7 +153,7 @@
     z-index: 1020;
     position: relative;
     padding-top: 1rem;
-    margin: 8.5rem 1.5vw 0;
+    margin: 5rem 1.5vw 0;
     position: relative;
     @include transition;
 
@@ -188,13 +189,13 @@
   }
 }
 
-.sidebar.is-scrolled {
+.sidebar-wrapper.is-scrolled {
   ul.sidebar-main {
     padding-top: 2rem;
   }
 
   .search-container {
-    margin-top: 4.75rem;
+    margin-top: 4.125rem;
   }
 }
 

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -54,10 +54,10 @@
 
   a.navbar-item {
     color: $navy;
-    font-size: 1.125rem;
+    font-size: 1rem;
     @include ripple;
     @include klinicBold;
-    padding: 1.75rem 1.75vw;
+    padding: 1.75rem 1.5vw;
 
     &:hover {
       @include opacity(rgba($salmon, 0.5), white);

--- a/themes/helm/assets/sass/docs-topbar.scss
+++ b/themes/helm/assets/sass/docs-topbar.scss
@@ -76,7 +76,7 @@
     letter-spacing: -0.02em;
     position: absolute;
     height: 3rem !important;
-    right: 1.75vw;
+    right: 1rem;
     padding: 1rem 1.25vw;
     border: 2px solid $navyl;
     color: $navyl;
@@ -93,10 +93,10 @@
     padding: 1rem 0.5rem 0 !important;
     margin: 0 -3rem -1px !important;
     position: absolute;
-    right: 16.5vw;
+    right: 3.5rem;
 
     &.l18ner {
-      right: 25vw;
+      right: 10rem;
       
       a.versioner-trigger {
         min-width: auto;
@@ -157,9 +157,6 @@
   
     // versioning dropdown
     ul.dropdown-menu {
-      position: absolute;
-      top: 4rem;
-      right: 0;
       padding: 0;
       margin: 0 0 0 1rem;
       text-align: left;
@@ -198,6 +195,8 @@
 }
 
 .navbar-brand {
+  min-height: 0 !important;
+
   a {
     position: absolute;
     top: 5rem;
@@ -225,6 +224,15 @@
     }
   }
 
+  .docs,
+  .page-docs {
+    .navbar-top {
+      a.button {
+        display: none;
+      }
+    }
+  }
+
   .home,
   .page-blog {
     .versioner {
@@ -233,7 +241,7 @@
 
     li.versioner.l18ner {
       display: block;
-      right: 17vw;
+      right: 13.75rem;
     }
   }
 

--- a/themes/helm/layouts/partials/nav-i18n.html
+++ b/themes/helm/layouts/partials/nav-i18n.html
@@ -4,7 +4,7 @@
 
 <!-- i18n -->
 {{ if .Site.IsMultiLingual }}
-  <li class="versioner l18ner navbar-item has-dropdown is-hoverable">
+  <li class="versioner l18ner navbar-item has-dropdown is-right is-hoverable">
     <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger navbar-link">
       {{ .Language.LanguageName }} <i class="fa fa-caret-down"></i>
     </a>

--- a/themes/helm/layouts/partials/nav-versioning.html
+++ b/themes/helm/layouts/partials/nav-versioning.html
@@ -3,7 +3,7 @@
 {{ $menu      := site.Menus.main }}
 
 <!-- versioning-->
-  <li class="versioner navbar-item has-dropdown is-hoverable">
+  <li class="versioner navbar-item has-dropdown is-right is-hoverable">
     {{ with $primary }}
     <a data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="versioner-trigger navbar-link">
       {{ .version }}{{ with .patch }}{{ end }} <i class="fa fa-caret-down"></i>

--- a/themes/helm/layouts/partials/nav.html
+++ b/themes/helm/layouts/partials/nav.html
@@ -29,7 +29,7 @@
       <ul class="is-pulled-right">
         {{ partial "nav-i18n.html" . }}
         {{ partial "nav-versioning.html" . }}
-        <li>
+        <li class="">
           <a class="button not-fixed is-outlined" href="{{ T "action_get_started_link" }}">{{ T "action_get_started" }}</a>
         </li>
       </ul>

--- a/themes/helm/layouts/partials/sidebar.html
+++ b/themes/helm/layouts/partials/sidebar.html
@@ -1,6 +1,14 @@
 {{ $docsHome      := .FirstSection }}
+
+<input type="checkbox" class="hamburger-trigger" />
+<small class="hamburger">
+  <span></span>
+  <span></span>
+  <span></span>
+</small>
+
 <div class="sidebar">
-  <div class="is-visible-mobile is-hidden-desktop" id="sidebar-toggle">Browse Docs <span class="icon"><i class="mdi mdi-arrow-down"></i></span></div>
+  <div class="is-visible-mobile is-hidden-tablet" id="sidebar-toggle">Browse Docs <span class="icon"><i class="mdi mdi-arrow-down"></i></span></div>
 
   <div class="sidebar-content-wrapper">
     <div class="search-container">


### PR DESCRIPTION
This PR replaces #705 which had become rather stale (_a relic really_) - this is a reworking of the CSS that determines the layouts at different screen sizes, changing how navigation, text sizing, etc are tailored to suit mobile users / tablet users / desktop users.

* removes the _Get Started_ menu button on docs pages
* reworks the docs menu to work as a fly-out with a hamburger
* reworks the spacing of the mobile menu across the top
* text sizing and scale adjustments

Addresses #683 #741