### PR TITLE
docs(FIX): Update helm-gcs repo link after project migration

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -18,7 +18,7 @@ request](https://github.com/helm/helm-www/pulls).
   existing k8s resources into a new generated helm chart.
 - [Helm Diff](https://github.com/databus23/helm-diff) - Preview `helm upgrade`
   as a coloured diff
-- [helm-gcs](https://github.com/nouney/helm-gcs) - Plugin to manage repositories
+- [helm-gcs](https://github.com/hayorov/helm-gcs) - Plugin to manage repositories
   on Google Cloud Storage
 - [helm-git](https://github.com/aslafy-z/helm-git) - Install charts and retrieve
   values files from your Git repositories

--- a/content/ko/docs/community/related.md
+++ b/content/ko/docs/community/related.md
@@ -15,7 +15,7 @@ weight: 3
 
 - [Helm Diff](https://github.com/databus23/helm-diff) - 컬러 diff로 `helm upgrade` 
   미리보기
-- [helm-gcs](https://github.com/nouney/helm-gcs) - Google Cloud Storage에서 
+- [helm-gcs](https://github.com/hayorov/helm-gcs) - Google Cloud Storage에서 
   저장소를 관리하는 플러그인
 - [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - 프로메테우스/엘라스틱서치 쿼리를 기반으로 
   릴리스 및 롤백을 모니터링하는 플러그인

--- a/content/zh/docs/community/related.md
+++ b/content/zh/docs/community/related.md
@@ -14,7 +14,7 @@ Helm社区已经创建了很多针对Helm的额外工具，插件和文档。我
 - [helm-adopt](https://github.com/HamzaZo/helm-adopt) - 将现有k8s资源转换成新生成的helm
 chart的helm v3插件。
 - [Helm Diff](https://github.com/databus23/helm-diff) - `helm upgrade`的彩色diff预览
-- [helm-gcs](https://github.com/nouney/helm-gcs) - 管理Google Cloud Storage中仓库的插件
+- [helm-gcs](https://github.com/hayorov/helm-gcs) - 管理Google Cloud Storage中仓库的插件
 - [helm-git](https://github.com/aslafy-z/helm-git) - 从Git仓库中安装chart并检索values文件。
 - [helm-k8comp](https://github.com/cststack/k8comp) - 使用k8comp从hiera创建Helm Charts的插件
 - [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) - 基于


### PR DESCRIPTION
Hello,

the helm-gcp project moved from preview owner to me (@hayorov) a year ago or so.
This is a link update PR.

Proof:
```
 ❯ curl https://github.com/nouney/helm-gcs                     
<html><body>You are being <a href="https://github.com/hayorov/helm-gcs">redirected</a>.</body></html>%    
```