### PR TITLE
add scoop install 

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -80,6 +80,16 @@ package](https://chocolatey.org/packages/kubernetes-helm) build to
 choco install kubernetes-helm
 ```
 
+### From Scoop (Windows)
+
+Members of the Helm community have contributed a [Helm
+package](https://scoop.sh/packages/helm) build to
+[Scoop](https://scoop.sh/). This package is generally up to date.
+
+```console
+choco install helm
+```
+
 ### From Apt (Debian/Ubuntu)
 
 Members of the Helm community have contributed a [Helm


### PR DESCRIPTION
Installing 'helm' (3.7.1) [64bit]
helm-v3.7.1-windows-amd64.zip (13,4 MB) [================================================================================] 100%
Checking hash of helm-v3.7.1-windows-amd64.zip ... ok.
Extracting helm-v3.7.1-windows-amd64.zip ... done.
Linking ~\scoop\apps\helm\current => ~\scoop\apps\helm\3.7.1
Creating shim for 'helm'.
'helm' (3.7.1) was installed successfully!