### PR TITLE
Adding scoop package manager (windows) install instructions

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -80,6 +80,15 @@ package](https://chocolatey.org/packages/kubernetes-helm) build to
 choco install kubernetes-helm
 ```
 
+### From Scoop (Windows)
+
+Members of the Helm community have contributed a [Helm
+package](https://github.com/ScoopInstaller/Main/blob/master/bucket/helm.json) build to [Scoop](https://scoop.sh). This package is generally up to date.
+
+```console
+scoop install helm
+```
+
 ### From Apt (Debian/Ubuntu)
 
 Members of the Helm community have contributed a [Helm


### PR DESCRIPTION
Scoop is another popular package manager for windows, major difference is scoop does not require elevated privileges.

For the other languages, I feel I should add the hyperlink and the scoop commands and allow other contributors to provide correct language changes?