### PR TITLE
Update Flux link to Helm Controller in community tools

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -68,7 +68,7 @@ Tools layered on top of Helm.
   Hosts on OCI Registry
 - [Codefresh](https://codefresh.io) - Kubernetes native CI/CD and management
   platform with UI dashboards for managing Helm charts and releases
-- [Flux](https://fluxcd.io/) -
+- [Flux](https://fluxcd.io/docs/components/helm/) -
   Continuous and progressive delivery from Git to Kubernetes.
 - [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative
   spec for deploying helm charts


### PR DESCRIPTION
Follow up to #1182 

It's more friendly for Helm users for this to link directly to the Flux Helm controller ✍️ 🙂
