### PR TITLE
Add helm-external-val to the list of helm plugins

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -43,6 +43,7 @@ request](https://github.com/helm/helm-www/pulls).
   testing chart locally with YAML
 - [helm-val](https://github.com/HamzaZo/helm-val) - A plugin to get
   values from a previous release.
+- [helm-external-val](https://github.com/kuuji/helm-external-val) - A plugin that fetches helm values from external sources (configMaps, Secrets, etc)
 
 We also encourage GitHub authors to use the
 [helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories)


### PR DESCRIPTION
Hey there 👋 

I recently wrote a plugin that allows to fetch values from external sources. Currently it supports fetching values from kubernetes configMaps and secrets  but I'm planning on adding support for more in the future.
I have examples on how to use it with argocd in the Readme.

Adding it here to get more visibility in case the helm community is interested.