### PR TITLE
oci blog post: remove syntax highlighting

### DIFF
--- a/content/en/blog/2022-02-28-storing-charts-in-oci.md
+++ b/content/en/blog/2022-02-28-storing-charts-in-oci.md
@@ -23,7 +23,7 @@ Since OCI artifacts now makes it possible to store more than container images, y
 
 The combination of OCI artifact support in a registry and new functionality within Helm provides the capability to pull and push charts to and from a registry. You can also specify charts stored in OCI as a dependency in any `Chart.yaml` file. The following example illustrates logging into a registry and pushing a chart:
 
-```console
+```
 $ helm create demo
 Creating demo
 

--- a/content/en/blog/2022-02-28-storing-charts-in-oci.md
+++ b/content/en/blog/2022-02-28-storing-charts-in-oci.md
@@ -23,7 +23,7 @@ Since OCI artifacts now makes it possible to store more than container images, y
 
 The combination of OCI artifact support in a registry and new functionality within Helm provides the capability to pull and push charts to and from a registry. You can also specify charts stored in OCI as a dependency in any `Chart.yaml` file. The following example illustrates logging into a registry and pushing a chart:
 
-```
+```text
 $ helm create demo
 Creating demo
 


### PR DESCRIPTION
On the site, the formatting of this is a little odd. Remove the `console` annotation to make this plain text

Related to #1284

cc @scottrigby @mattfarina 