### PR TITLE
[1288] update site template to work with newer hugo versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rootfs/svc
 .yarnclean
 _site/*
 _site/
+.hugo_build.lock
 .ncurc.yml
 .publish/*
 .publish/

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "app"
 
 [build.environment]
-  HUGO_VERSION = "0.82.0"
+  HUGO_VERSION = "0.94.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]

--- a/themes/helm/layouts/partials/nav-i18n.html
+++ b/themes/helm/layouts/partials/nav-i18n.html
@@ -18,9 +18,9 @@
               {{ if eq $translation.Lang .Lang }}
                 {{ $selected := false }}
                 {{ if eq $pageLang .Lang}}
-                    <li class="navbar-item"><a href="{{ $translation.URL }}" class="active"><code>{{ .Lang }}</code> &nbsp; {{ .LanguageName }}</a></li>
+                    <li class="navbar-item"><a href="{{ $translation.Permalink }}" class="active"><code>{{ .Lang }}</code> &nbsp; {{ .LanguageName }}</a></li>
                 {{ else }}
-                    <li class="navbar-item"><a href="{{ $translation.URL }}"><code>{{ .Lang }}</code> &nbsp; {{ .LanguageName }}</a></li>
+                    <li class="navbar-item"><a href="{{ $translation.Permalink }}"><code>{{ .Lang }}</code> &nbsp; {{ .LanguageName }}</a></li>
                 {{ end }}
               {{ end }}
 


### PR DESCRIPTION
This was a pretty small edit to resolve the `hugo` build error documented in #1288. 

Here I replace the depricated `.URL` code and the site builds without any issue on the latest Hugo version (v0.94.0 ).

