### PR TITLE
docs(install): clarify steps for binaries and signatures

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -21,18 +21,51 @@ Every [release](https://github.com/helm/helm/releases) of Helm provides binary
 releases for a variety of OSes. These binary versions can be manually downloaded
 and installed.
 
-1. Download your [desired version](https://github.com/helm/helm/releases)
-2. Unpack it (`tar -zxvf helm-v3.0.0-linux-amd64.tar.gz`)
-3. Find the `helm` binary in the unpacked directory, and move it to its desired
-   destination (`mv linux-amd64/helm /usr/local/bin/helm`)
+1. Search for and select your desired Helm release from the GitHub [releases](https://github.com/helm/helm/releases)
+2. Download the binary for your platform from the **Installation and Upgrading** section — note that the **Assets** attached to a release contain [archives of the source code](#from-source-linux-macos) and [`*.asc` signature files](#validating-binaries), not the platform binaries
+3. Optionally [validate the integrity and attestation of the binary](#validating-binaries)
+4. Unpack the binary (e.g. `tar -zxvf helm-v3.8.1-darwin-amd64.tar.gz`)
+5. Find the `helm` binary in the unpacked directory, and move it to its desired destinarion (e.g. `mv darwin-amd64/helm /usr/local/bin/helm`)
 
-From there, you should be able to run the client and [add the stable
-repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository):
-`helm help`.
+From there, you should be able to run the client (`helm help`) and [add the stable
+repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository).
 
 **Note:** Helm automated tests are performed for Linux AMD64 only during
 CircleCi builds and releases. Testing of other OSes are the responsibility of
-the community requesting Helm for the OS in question. 
+the community requesting Helm for the OS in question.
+
+#### Validating Binaries
+
+Helm releases include:
+
+- A sha256 checksum (`*.tar.gz.sha256sum`) to validate that the content of the download is what was generated for the release
+- ASCII-armored public keys (`*.asc`) to provide traceability of where the download came from
+
+For more information, please see the [**Release Checklist**](https://helm.sh/docs/community/release_checklist/#8-pgp-sign-the-downloads) documentation.
+
+To validate the integrity and attestation of a downloaded binary:
+
+1. Download the `*.tar.gz.sha256sum` file listed next to the binary you downloaded from the **Installation and Upgrading** section
+2. Download the `*.tar.gz.asc` and `*.tar.gz.sha256sum.asc` signature files that match the platform of your downloaded binary — these can be found in the **Assets** attached to a given [release](https://github.com/helm/helm/releases)
+3. Validate the integrity of the downloaded binary by verifying the sha256 checksum, e.g.
+
+```
+shasum -a 256 helm-v3.8.1-darwin-amd64.tar.gz
+cat helm-v3.8.1-darwin-amd64.tar.gz.sha256sum
+```
+
+4. Validate the attestation of the downloaded binary by cloning the source code repository, importing Helm's `KEYS` file into your keyring, and verifying the signatures, e.g.
+
+```
+git clone https://github.com/helm/helm.git
+gpg --import helm/KEYS
+gpg --verify helm-v3.8.1-darwin-amd64.tar.gz.asc \
+  helm-v3.8.1-darwin-amd64.tar.gz
+gpg --verify helm-v3.8.1-darwin-amd64.tar.gz.sha256sum.asc \
+  helm-v3.8.1-darwin-amd64.tar.gz.sha256sum
+```
+
+**Note:** The example commands above demonstrate the validation process on macOS. The process is similar for other platforms, but the exact tools and commands may vary slightly.
 
 ### From Script
 


### PR DESCRIPTION
Resolves https://github.com/helm/helm-www/issues/1172:

- Distinguishes between platform binaries and `*.asc` signature files
- Adds a `Validating Binaries` subsection with more detail on `*.asc` signature files

Signed-off-by: Timothy Dement <timothy.dement@gmail.com>