### PR TITLE
docs(install): Update Apt installation in readme

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -32,7 +32,7 @@ repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository)
 
 **Note:** Helm automated tests are performed for Linux AMD64 only during
 CircleCi builds and releases. Testing of other OSes are the responsibility of
-the community requesting Helm for the OS in question. 
+the community requesting Helm for the OS in question.
 
 ### From Script
 
@@ -96,9 +96,9 @@ package](https://helm.baltorepo.com/stable/debian/) for Apt. This package is
 generally up to date.
 
 ```console
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/content/es/docs/intro/install.md
+++ b/content/es/docs/intro/install.md
@@ -86,9 +86,9 @@ Los miembros de la comunidad Helm han contribuido con un
 Este paquete generalmente está actualizado.
 
 ```console
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/content/fr/docs/intro/install.md
+++ b/content/fr/docs/intro/install.md
@@ -65,9 +65,9 @@ choco install kubernetes-helm
 Les membres de la communauté Helm ont contribué à la création d'un [package Helm](https://helm.baltorepo.com/stable/debian/) for Apt. Ce package est généralement à jour.
 
 ```console
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/content/ja/docs/intro/install.md
+++ b/content/ja/docs/intro/install.md
@@ -84,9 +84,9 @@ Helm コミュニティのメンバーは、Apt の [Helm パッケージ](https
 このパッケージは一般に最新です。
 
 ```console
-curl https://helm.baltorepo.com/organization/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/content/pt/docs/intro/install.md
+++ b/content/pt/docs/intro/install.md
@@ -85,9 +85,9 @@ Membros da comunidade Helm contribuíram com um [pacote do Helm](https://helm.ba
 para o Apt. Esse pacote geralmente está atualizado.
 
 ```console
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/content/ru/docs/intro/install.md
+++ b/content/ru/docs/intro/install.md
@@ -31,7 +31,7 @@ weight: 2
 
 ### Из Скрипта
 
-У Helm теперь есть скрипт установки, которая будет автоматически загружать последнюю версию Helm и 
+У Helm теперь есть скрипт установки, которая будет автоматически загружать последнюю версию Helm и
 [устанавливать его локально](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3).
 
 Вы можете получить этот сценарий, а затем выполнить его локально.
@@ -50,7 +50,7 @@ you want to live on the edge.
 ## Через Менеджеров Пакетов
 
 Сообщество Helm предоставляет возможность установки Helm через
-менеджеры пакетов операционной системы. 
+менеджеры пакетов операционной системы.
 Они не поддерживаются проектом Helm и не считаются проверенными.
 
 ### Используя Homebrew (macOS)
@@ -80,9 +80,9 @@ choco install kubernetes-helm
 package](https://helm.baltorepo.com/stable/debian/) для Apt. Данная сборка почти всегда актуальна
 
 ```console
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/content/zh/docs/intro/install.md
+++ b/content/zh/docs/intro/install.md
@@ -66,9 +66,9 @@ choco install kubernetes-helm
 Helm社区成员贡献了针对Apt的一个[Helm包](https://helm.baltorepo.com/stable/debian/)，包通常是最新的。
 
 ```console
-curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update
 sudo apt-get install helm
 ```


### PR DESCRIPTION
The usage of apt-key is deprecated and creates a warning.

    Warning: apt-key is deprecated.

Each gpg key should only be valid for packages in its own repository.

I adapted the documentation according to the [Debian Wiki](https://wiki.debian.org/DebianRepository/UseThirdParty).

Signed-off-by: Raffael Stein <rvs@mailbox.org>