### PR TITLE
add: examples for --set with [] and null in the using_helm docs.

### DIFF
--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -301,6 +301,23 @@ name:
   - c
 ```
 
+Certain name/key can be set to be `null` or to be an empty array `[]`. For example, `--set name=[],a=null` translates
+
+```yaml
+name:
+  - a
+  - b
+  - c
+a: b
+```
+
+to
+
+```yaml
+name: []
+a: null
+```
+
 As of Helm 2.5.0, it is possible to access list items using an array index
 syntax. For example, `--set servers[0].port=80` becomes:
 


### PR DESCRIPTION
resolves https://github.com/helm/helm/issues/10598

tested using:
```bash
$ helm version
version.BuildInfo{Version:"v3.8.2", GitCommit:"6e3701edea09e5d55a8ca2aae03a68917630e91b", GitTreeState:"clean", GoVersion:"go1.17.5"}

$ kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.5", GitCommit:"6b1d87acf3c8253c123756b9e61dac642678305f", GitTreeState:"clean", BuildDate:"2021-03-18T01:10:43Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.2", GitCommit:"092fbfbf53427de67cac1e9fa54aaa09a28371d7", GitTreeState:"clean", BuildDate:"2021-06-16T12:53:14Z", GoVersion:"go1.16.5", Compiler:"gc", Platform:"linux/amd64"}

$ minikube version
minikube version: v1.22.0
commit: a03fbcf166e6f74ef224d4a63be4277d017bb62e
```

on --set with empty array `[]`
```bash
helm install redis-local bitnami/redis --set disableCommands=[]
```
&
on --set with `null`
https://stackoverflow.com/a/64462925/6905674
```bash
helm install redis-local bitnami/redis --set disableCommands=null
```
both work on this example chart of [redis](https://github.com/bitnami/charts/blob/5277d698528bc4a78389f83c7e6fa4c42a6e63ad/bitnami/redis/values.yaml#L511).

This is my first ever PR to helm org. tried my best with git signoff on commit, but couldn't figure out CLA. please guide me on making this PR better to suit org standards. :pray: 