### PR TITLE
Docs: explain conditional behaviour of 'with'

### DIFF
--- a/content/en/docs/chart_template_guide/control_structures.md
+++ b/content/en/docs/chart_template_guide/control_structures.md
@@ -285,7 +285,9 @@ data:
   {{- end }}
 ```
 
-(Note that we removed the `if` conditional from the previous exercise)
+Note that we removed the `if` conditional from the previous exercise
+because it is now unnecessary - the block after `with` only executes
+if the value of `PIPELINE` is not empty.
 
 Notice that now we can reference `.drink` and `.food` without qualifying them.
 That is because the `with` statement sets `.` to point to `.Values.favorite`.


### PR DESCRIPTION
I have seen (and, in fact, written) plenty of templates that use this behaviour, but couldn't find it documented within helm.

I did, however, find it documented here https://pkg.go.dev/text/template#hdr-Actions.