### PR TITLE
Fix multi-conditon example

### DIFF
--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -365,7 +365,7 @@ dependencies:
   - name: subchart1
     repository: http://localhost:10191
     version: 0.1.0
-    condition: subchart1.enabled, global.subchart1.enabled
+    condition: subchart1.enabled,global.subchart1.enabled
     tags:
       - front-end
       - subchart1


### PR DESCRIPTION
Fixes the multi-condition example as the syntax `condition1, failoverCondition` is not supported by Helm (it stops evaluating at the space and includes the dependency).
The working syntax is `condition1,failoverCondition`.