### PR TITLE
helm template renders the chart locally

### DIFF
--- a/content/en/docs/chart_template_guide/debugging.md
+++ b/content/en/docs/chart_template_guide/debugging.md
@@ -12,9 +12,9 @@ There are a few commands that can help you debug.
 
 - `helm lint` is your go-to tool for verifying that your chart follows best
   practices
-- `helm install --dry-run --debug` or `helm template --debug`: We've seen this
-  trick already. It's a great way to have the server render your templates, then
-  return the resulting manifest file.
+- `helm template --debug` will test rendering chart templates locally.  
+- `helm install --dry-run --debug`: We've seen this trick already. It's a great way to have the server render your templates, then
+   return the resulting manifest file.
 - `helm get manifest`: This is a good way to see what templates are installed on
   the server.
 


### PR DESCRIPTION
`helm install --dry-run --debug` interacts with kube api server, `helm template --debug` renders the chart locally

Signed-off-by: w7089 <3884662+w7089@users.noreply.github.com>