### PR TITLE
Provide better explanations of dot context

### DIFF
--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -175,16 +175,17 @@ The big change comes in the value of the `name:` field, which is now
 > A template directive is enclosed in `{{` and `}}` blocks.
 
 The template directive `{{ .Release.Name }}` injects the release name into the
-template. The values that are passed into a template can be thought of as
-_namespaced objects_, where a dot (`.`) separates each namespaced element.
+template. The data structure that is passed into a template can be thought of as
+hierarchy of nested maps, and is represented as  `.` (aka "dot" or "context").
+Specific values in the context map can be referred to by the name of the key,
+preceded by a period, such as `.Key`. Key invocations may be chained to any
+depth: `.Key1.Key2.Key3`.
 
-The leading dot before `Release` indicates that we start with the top-most
-namespace for this scope (we'll talk about scope in a bit). So we could read
-`.Release.Name` as "start at the top namespace, find the `Release` object, then
-look inside of it for an object called `Name`".
+So, we interpret `.Release.Name` as: "in the current context, find the `Release`
+object, then look inside of it for an object called `Name`".
 
-The `Release` object is one of the built-in objects for Helm, and we'll cover it
-in more depth later. But for now, it is sufficient to say that this will display
+The `Release` object is one of the built-in objects provided by Helm, and we'll cover it
+in more depth later. But for now, it is sufficient to say that this allows us to use
 the release name that the library assigns to our release.
 
 Now when we install our resource, we'll immediately see the result of using this

--- a/content/en/docs/chart_template_guide/named_templates.md
+++ b/content/en/docs/chart_template_guide/named_templates.md
@@ -156,9 +156,9 @@ templates, it is best to name your templates with _chart specific names_. A
 popular naming convention is to prefix each defined template with the name of
 the chart: `{{ define "mychart.labels" }}`.
 
-## Setting the scope of a template
+## Setting the context of a template
 
-In the template we defined above, we did not use any objects. We just used
+In the template we defined above, we did not use any objects from the dot context `.`. We just used
 functions. Let's modify our defined template to include the chart name and chart
 version:
 
@@ -173,7 +173,7 @@ version:
 {{- end }}
 ```
 
-If we render this, we will get an error like this:
+If we render this with `template` as above, we will get an error like this:
 
 ```console
 $ helm install --dry-run moldy-jaguar ./mychart
@@ -197,17 +197,18 @@ metadata:
     version:
 ```
 
-What happened to the name and version? They weren't in the scope for our defined
-template. When a named template (created with `define`) is rendered, it will
-receive the scope passed in by the `template` call. In our example, we included
+What happened to the name and version? The value of `.` was empty while our named template was rendered.
+When a named template (created with 
+`define`) is rendered without a second parameter, its `.` is empty. In our example, we included
 the template like this:
 
 ```yaml
 {{- template "mychart.labels" }}
 ```
 
-No scope was passed in, so within the template we cannot access anything in `.`.
-This is easy enough to fix, though. We simply pass a scope to the template:
+No pipeline value was provided to its second parameter, so within the template `.` is empty.
+`$.` will therefore also be empty.
+This is easy enough to fix, though. We simply pass a pipeline value as a second parameter to `template`:
 
 ```yaml
 apiVersion: v1
@@ -218,8 +219,8 @@ metadata:
 ```
 
 Note that we pass `.` at the end of the `template` call. We could just as easily
-pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want
-is the top-level scope. In the context of the named template, `$` will refer
+pass `.Values` or `.Values.favorite` or any kind of pipeline. But in this example,
+we want to continue using the same value of `.`. In the context of the named template, `$` will refer
 to the scope you passed in and not some global scope.
 
 Now when we execute this template with `helm install --dry-run --debug
@@ -241,7 +242,26 @@ metadata:
 Now `{{ .Chart.Name }}` resolves to `mychart`, and `{{ .Chart.Version }}`
 resolves to `0.1.0`.
 
+In the earlier discussion of Flow Control and `with`, we mentioned that both `template` and `include` set `$` to the 
+same value as `.` when they start executing. For example, if we render the template as follows:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+  {{- template "mychart.labels" .Values.foo }}
+```
+
+Then we cannot refer to values such as `$.Chart.Name` within "mychart.labels",
+because `$` has been set to `.Values.foo`. If we want to render a template with
+a specific value in its context, but still allow it to access top-level objects like `Chart`,
+we can construct a custom dict and pass it to the template:
+see [Charts Tips and Tricks](../../howto/charts_tips_and_tricks/).
+
 ## The `include` function
+
+`include` behaves the same with regard to `.` and `$` as `template`. See above for more info.
 
 Say we've defined a simple template that looks like this:
 

--- a/content/en/docs/chart_template_guide/named_templates.md
+++ b/content/en/docs/chart_template_guide/named_templates.md
@@ -207,7 +207,7 @@ the template like this:
 ```
 
 No pipeline value was provided to its second parameter, so within the template `.` is empty.
-`$.` will therefore also be empty.
+`$` will therefore also be empty.
 This is easy enough to fix, though. We simply pass a pipeline value as a second parameter to `template`:
 
 ```yaml

--- a/content/en/docs/chart_template_guide/subcharts_and_globals.md
+++ b/content/en/docs/chart_template_guide/subcharts_and_globals.md
@@ -126,8 +126,9 @@ The value at the top level has now overridden the value of the subchart.
 There's an important detail to notice here. We didn't change the template of
 `mychart/charts/mysubchart/templates/configmap.yaml` to point to
 `.Values.mysubchart.dessert`. From that template's perspective, the value is
-still located at `.Values.dessert`. As the template engine passes values along,
-it sets the scope. So for the `mysubchart` templates, only values specifically
+still located at `.Values.dessert`. When the template engine renders a subchart,
+it passes an altered context object which provides the subchart Values under
+`.Values`. So, in the `mysubchart` templates, only values specifically
 for `mysubchart` will be available in `.Values`.
 
 Sometimes, though, you do want certain values to be available to all of the

--- a/content/en/docs/chart_template_guide/variables.md
+++ b/content/en/docs/chart_template_guide/variables.md
@@ -126,12 +126,12 @@ That variable will be in scope for the entire template. But in our last example,
 `$key` and `$val` will only be in scope inside of the `{{ range... }}{{ end }}`
 block.
 
-However, there is one variable that is always available - `$.` - this variable will
+However, there is one variable that is always available - `$` - this variable will
 either point to the chart or sub-chart's initial context, or to the context passed to `template` or `include`.
 This can be very useful inside control structures that change `.` when you need to use things from the initial
 context, such as the chart's release name.
 
-An example illustrating that `range` alters `.`, but `$.` provides access to the initial context:
+An example illustrating that `range` alters `.`, but `$` provides access to the initial context:
 ```yaml
 {{- range .Values.tlsSecrets }}
 ---

--- a/content/en/docs/chart_template_guide/variables.md
+++ b/content/en/docs/chart_template_guide/variables.md
@@ -19,9 +19,11 @@ In an earlier example, we saw that this code will fail:
   {{- end }}
 ```
 
-`Release.Name` is not inside of the scope that's restricted in the `with` block.
-One way to work around scoping issues is to assign objects to variables that can
-be accessed without respect to the present scope.
+`.Release.Name` does not exist in the context set by the `with` block.
+One possible alternative is to use `$.Release.Name` instead, assuming we're not inside
+one or more calls to `template` or `include` which have set `$` to a different value.
+Another alternative is to assign objects to variables that can
+be accessed without respect to the context.
 
 In Helm templates, a variable is a named reference to another object. It follows
 the form `$name`. Variables are assigned with a special assignment operator:
@@ -115,17 +117,21 @@ data:
   food: "pizza"
 ```
 
-Variables are normally not "global". They are scoped to the block in which they
-are declared. Earlier, we assigned `$relname` in the top level of the template.
+If a variable contains a map or nested maps, chaining keys works just as it does in `.`. For example, `$foo.bar.baz`.
+
+Variables are not "global". A variable's scope extends to the `end` action of the control structure
+in which it is declared, or to the end of the template if there is no such control structure. Earlier,
+we assigned `$relname` in the top level of the template.
 That variable will be in scope for the entire template. But in our last example,
 `$key` and `$val` will only be in scope inside of the `{{ range... }}{{ end }}`
 block.
 
-However, there is one variable that will always point to the root context: - `$` -.
-This can be very useful when you are looping
-in a range and you need to know the chart's release name.
+However, there is one variable that is always available - `$.` - this variable will
+either point to the chart or sub-chart's initial context, or to the context passed to `template` or `include`.
+This can be very useful inside control structures that change `.` when you need to use things from the initial
+context, such as the chart's release name.
 
-An example illustrating this:
+An example illustrating that `range` alters `.`, but `$.` provides access to the initial context:
 ```yaml
 {{- range .Values.tlsSecrets }}
 ---

--- a/content/en/docs/topics/charts.md
+++ b/content/en/docs/topics/charts.md
@@ -791,14 +791,13 @@ spec:
               value: {{ default "minio" .Values.storage }}
 ```
 
-### Scope, Dependencies, and Values
+### Context, Dependencies, and Values
 
-Values files can declare values for the top-level chart, as well as for any of
-the charts that are included in that chart's `charts/` directory. Or, to phrase
-it differently, a values file can supply values to the chart as well as to any
+Values files can declare values for the top-level chart, values for
+subcharts that are included in that chart's `charts/` directory, and to any
 of its dependencies. For example, the demonstration WordPress chart above has
 both `mysql` and `apache` as dependencies. The values file could supply values
-to all of these components:
+to each of these components:
 
 ```yaml
 title: "My WordPress Site" # Sent to the WordPress template
@@ -813,14 +812,13 @@ apache:
 
 Charts at a higher level have access to all of the variables defined beneath. So
 the WordPress chart can access the MySQL password as `.Values.mysql.password`.
-But lower level charts cannot access things in parent charts, so MySQL will not
+But lower level charts cannot access values from parent charts, so MySQL will not
 be able to access the `title` property. Nor, for that matter, can it access
 `apache.port`.
 
-Values are namespaced, but namespaces are pruned. So for the WordPress chart, it
-can access the MySQL password field as `.Values.mysql.password`. But for the
-MySQL chart, the scope of the values has been reduced and the namespace prefix
-removed, so it will see the password field simply as `.Values.password`.
+Whereas the top-level chart might refer to `.Values.mysql.password`, in the mysql
+chart `.Values.mysql` becomes just `.Values`, so it would refer to that value
+as `.Values.password` instead.
 
 #### Global Values
 
@@ -849,21 +847,22 @@ For example, the `mysql` templates may access `app` as `{{
 file above is regenerated like this:
 
 ```yaml
-title: "My WordPress Site" # Sent to the WordPress template
+# Availeble in the WordPress template as .Values.title
+title: "My WordPress Site"
 
 global:
   app: MyWordPress
 
-mysql:
+mysql: # Available in mysql templates as .Values
   global:
     app: MyWordPress
-  max_connections: 100 # Sent to MySQL
+  max_connections: 100
   password: "secret"
 
-apache:
+apache: # Available in apache templates as .Values
   global:
     app: MyWordPress
-  port: 8080 # Passed to Apache
+  port: 8080
 ```
 
 This provides a way of sharing one top-level variable with all subcharts, which


### PR DESCRIPTION
- See https://github.com/helm/helm/issues/11232 and https://github.com/helm/helm/issues/7915 for examples of confusion the current explanation/wording has caused.
- Replaced inconsistent and unexplained terminology: "root context", "root scope", "top-level scope", "parent scope".
- Go templates/gomplate, on which Helm relies, uses the words "dot" and "context", not "scope". The word "scope" is better used to explain when variables go out of scope, not to explain the value of the context variables `.` and `$`.
- Fixed inaccurate or misleading statements such as: $ "does not change", and $ "will always point to the root context".
- This sentence: "Recall that `.` is a reference to _the current scope_." is not useful - this was not explained elsewhere
- Removed vague sentences that don't add meaning, such as "Values are namespaced, but namespaces are pruned."

Signed-off-by: Shannon Carey <rehevkor5@gmail.com>