### PR TITLE
Add yxxhero as maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 maintainers:
+  - yxxhero
   - angellk
   - bacongobbler
   - bridgetkromhout


### PR DESCRIPTION
With a supermajority vote from the the current helm-www OWNERS, @yxxhero will be joining the helm-www repo as a maintainer.

Still to do (requires access, and perhaps can be handled by whomever approves this PR):

- [x] add yxxhero to the web team: https://github.com/orgs/helm/teams/web
- [x] add yxxhero to mailing list(s)
- [x] add yxxhero to maintainer chat on Keybase

Signed-off-by: Karen Chu <karen.chu@microsoft.com>

Signed-off-by: Karen Chu <karen.chu@microsoft.com>