### PR TITLE
Doc : typo in online documentation

### DIFF
--- a/content/en/docs/chart_template_guide/control_structures.md
+++ b/content/en/docs/chart_template_guide/control_structures.md
@@ -164,7 +164,7 @@ data:
 ```
 
 Notice that we received a few empty lines in our YAML. Why? When the template
-engine runs, it _removes_ the contents inside of `{{` and `}}`, but it leaves
+engine runs, it _removes_ the contents inside of `{{` end `}}`, but it leaves
 the remaining whitespace exactly as is.
 
 YAML ascribes meaning to whitespace, so managing the whitespace becomes pretty

--- a/content/ko/docs/chart_template_guide/control_structures.md
+++ b/content/ko/docs/chart_template_guide/control_structures.md
@@ -164,7 +164,7 @@ data:
 ```
 
 Notice that we received a few empty lines in our YAML. Why? When the template
-engine runs, it _removes_ the contents inside of `{{` and `}}`, but it leaves
+engine runs, it _removes_ the contents inside of `{{` end `}}`, but it leaves
 the remaining whitespace exactly as is.
 
 YAML ascribes meaning to whitespace, so managing the whitespace becomes pretty


### PR DESCRIPTION
I feel like there is a typo in this example :

https://helm.sh/docs/chart_template_guide/control_structures/#controlling-whitespace

![image](https://user-images.githubusercontent.com/10053686/195535284-bc1d5725-36b3-4054-85d7-467064f7e21b.png)

This is my first time contributing so I'm not sure about the process to fix it even though I've read the contributing guidelines. 
Let me know if there's anything that need to be done in order to merge this PR.

Signed-off-by: William Le Pommelet <w.lepommelet@gmail.com>