### PR TITLE
Fix/docs empty

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -143,7 +143,7 @@ empty .Foo
 ```
 
 Note that in Go template conditionals, emptiness is calculated for you. Thus,
-you rarely need `if empty .Foo`. Instead, just use `if .Foo`.
+you rarely need `if not empty .Foo`. Instead, just use `if .Foo`.
 
 ### fail
 

--- a/content/ko/docs/chart_template_guide/function_list.md
+++ b/content/ko/docs/chart_template_guide/function_list.md
@@ -142,7 +142,7 @@ empty .Foo
 ```
 
 Go 템플릿 조건부에서는 비어 있음이 자동으로 계산된다. 
-따라서 `if empty .Foo` 는 거의 필요하지 않다. 대신 `if .Foo` 를 사용하도록 하자.
+따라서 `if not empty .Foo` 는 거의 필요하지 않다. 대신 `if .Foo` 를 사용하도록 하자.
 
 ### fail
 

--- a/content/zh/docs/chart_template_guide/function_list.md
+++ b/content/zh/docs/chart_template_guide/function_list.md
@@ -131,7 +131,7 @@ default "foo" .Bar
 empty .Foo
 ```
 
-注意在Go模板条件中，空值是为你计算出来的。这样你很少需要 `if empty .Foo` ，仅使用 `if .Foo` 即可。
+注意在Go模板条件中，空值是为你计算出来的。这样你很少需要 `if not empty .Foo` ，仅使用 `if .Foo` 即可。
 
 ### fail
 


### PR DESCRIPTION
Hi, 

I spotted this inverted sense in the `empty` documentation

I also corrected `ko` and `zh` translations, but did not spot (`grep`) others occurences...

ps: please do not hesitate to squash the 3 commits into one ;-) as I used WebIDE ...