### PR TITLE
Added details on library chart differences from application charts

### DIFF
--- a/content/en/docs/chart_template_guide/accessing_files.md
+++ b/content/en/docs/chart_template_guide/accessing_files.md
@@ -21,6 +21,8 @@ this works:
   security reasons.
   - Files in `templates/` cannot be accessed.
   - Files excluded using `.helmignore` cannot be accessed.
+  - Files outside of a helm application [subchart]({{< ref
+"/docs/chart_template_guide/subcharts_and_globals.md" >}}), including those of the parent, cannot be accessed
 - Charts do not preserve UNIX mode information, so file-level permissions will
   have no impact on the availability of a file when it comes to the `.Files`
   object.

--- a/content/en/docs/chart_template_guide/subcharts_and_globals.md
+++ b/content/en/docs/chart_template_guide/subcharts_and_globals.md
@@ -9,14 +9,16 @@ dependencies, called _subcharts_, that also have their own values and templates.
 In this section we will create a subchart and see the different ways we can
 access values from within templates.
 
-Before we dive into the code, there are a few important details to learn about
-subcharts.
+Before we dive into the code, there are a few important details to learn about application subcharts.
 
 1. A subchart is considered "stand-alone", which means a subchart can never
    explicitly depend on its parent chart.
 2. For that reason, a subchart cannot access the values of its parent.
 3. A parent chart can override values for subcharts.
 4. Helm has a concept of _global values_ that can be accessed by all charts.
+
+> These limitations do not all necessarily apply to [library charts]({{< ref
+"/docs/topics/library_charts.md" >}}), which are designed to provide standardized helper functionality.
 
 As we walk through the examples in this section, many of these concepts will
 become clearer.

--- a/content/en/docs/topics/library_charts.md
+++ b/content/en/docs/topics/library_charts.md
@@ -14,10 +14,11 @@ be re-used across charts, avoiding repetition and keeping charts
 The library chart was introduced in Helm 3 to formally recognize common or
 helper charts that have been used by chart maintainers since Helm 2. By
 including it as a chart type, it provides:
-- A means to explicitly distinguish between common and application charts 
+- A means to explicitly distinguish between common and application charts
 - Logic to prevent installation of a common chart
 - No rendering of templates in a common chart which may contain release
-  artifacts 
+  artifacts
+- Allow for dependent charts to use the importer's context
 
 A chart maintainer can define a common chart as a library chart and now be
 confident that Helm will handle the chart in a standard consistent fashion. It
@@ -45,7 +46,7 @@ $ rm -rf mylibchart/templates/*
 The values file will not be required either.
 
 ```console
-$ rm -f mylibchart/values.yaml 
+$ rm -f mylibchart/values.yaml
 ```
 
 Before we jump into creating common code, lets do a quick review of some
@@ -54,7 +55,7 @@ relevant Helm concepts. A [named template]({{< ref
 or a subtemplate) is simply a template defined inside of a file, and given a
 name.  In the `templates/` directory, any file that begins with an underscore(_)
 is not expected to output a Kubernetes manifest file. So by convention, helper
-templates and partials are placed in a `_*.tpl` or `_*.yaml` files. 
+templates and partials are placed in a `_*.tpl` or `_*.yaml` files.
 
 In this example, we will code a common ConfigMap which creates an empty
 ConfigMap resource. We will define the common ConfigMap in file
@@ -309,10 +310,17 @@ metadata:
   name: mychart-mydemo
   ```
 
+## Library Chart Benefits
+Because of their inability to act as standalone charts, library charts can leverage the following functionality:
+- The `.Files` object references the file paths on the parent chart, rather than the path local to the library chart
+- The `.Values` object is the same as the parent chart, in contrast to application [subcharts]({{< ref
+"/docs/chart_template_guide/subcharts_and_globals.md" >}}) which receive the section of values configured under their header in the parent.
+
+
 ## The Common Helm Helper Chart
 
 ```markdown
-Note: The Common Helm Helper Chart repo on Github is no longer actively maintained, and the repo has been deprecated and archived. 
+Note: The Common Helm Helper Chart repo on Github is no longer actively maintained, and the repo has been deprecated and archived.
 ```
 
 This [chart](https://github.com/helm/charts/tree/master/incubator/common) was


### PR DESCRIPTION
Signed-off-by: Miles Wilson <wilson.mil@icloud.com>

In general, there is confusion around the use case for accessing files between subcharts and parent charts, exemplified through https://github.com/helm/helm/issues/1892.

The goal of this commit is to shed more light on the benefits of using library charts. As far as I can tell, these differences are not explicit the official docs, and many people seem to think that there is very little benefit in using library charts beyond extracting code to be used in multiple charts. Through experimentation, I have found the two peices of functionality documented in this commit very useful:

- Accessing the entire .Values dict from the parent chart, not just the slice with the subchart header
- Being able to access the parent chart's files from a library chart.

In particular, the second piece has allowed for extremely versatile chart development, and I think more advertisement of the chart features could lead to increased adoption of library charts and less confusion around file access. I have attempted to update the library charts page itself as well as add caveats for absolute statements that seem to only apply to application charts (presumably leftover from before library charts existed). Thanks for your time, I'm happy to add/edit details as needed. 