### PR TITLE
Add Botkube to the Community Related page

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -62,6 +62,8 @@ Tools layered on top of Helm.
 - [avionix](https://github.com/zbrookle/avionix) -
   Python interface for generating Helm
   charts and Kubernetes yaml, allowing for inheritance and less duplication of code
+- [Botkube](https://botkube.io) - Run Helm commands directly from Slack,
+  Discord, Microsoft Teams, and Mattermost.
 - [Captain](https://github.com/alauda/captain) - A Helm3 Controller using
   HelmRequest and Release CRD
 - [Chartify](https://github.com/appscode/chartify) - Generate Helm charts from


### PR DESCRIPTION
This PR adds Botkube to the community/related page. We've just added a Helm plugin to Botkube that allows users to run Helm commands from their chat platforms.

Signed-off-by: Blair Rampling <brampling@users.noreply.github.com>