### PR TITLE
Add documentation for dig

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1216,7 +1216,7 @@ Unlike `list`s, `dict`s are not immutable. The `set` and `unset` functions will
 modify the contents of a dictionary.
 
 Helm provides the following functions to support working with dicts: [deepCopy
-(mustDeepCopy)](#deepcopy-mustdeepcopy), [dict](#dict), [get](#get),
+(mustDeepCopy)](#deepcopy-mustdeepcopy), [dict](#dict), [dig](#dig), [get](#get),
 [hasKey](#haskey), [keys](#keys), [merge (mustMerge)](#merge-mustmerge),
 [mergeOverwrite (mustMergeOverwrite)](#mergeoverwrite-mustmergeoverwrite),
 [omit](#omit), [pick](#pick), [pluck](#pluck), [set](#set), [unset](#unset), and
@@ -1302,6 +1302,40 @@ inserted.
 
 A common idiom in Helm templates is to use `pluck... | first` to get the first
 matching key out of a collection of dictionaries.
+
+### dig
+
+The `dig` function traverses a nested set of dicts, selecting keys from a list
+of values. It returns a default value if any of the keys are not found at the
+associated dict.
+
+```
+dig "user" "role" "humanName" "guest" $dict
+```
+
+Given a dict structured like
+```
+{
+  user: {
+    role: {
+      humanName: "curator"
+    }
+  }
+}
+```
+
+the above would return `"curator"`. If the dict lacked even a `user` field,
+the result would be `"guest"`.
+
+Dig can be very useful in cases where you'd like to avoid guard clauses,
+especially since Go's template package's `and` doesn't shortcut. For instance
+`and a.maybeNil a.maybeNil.iNeedThis` will always evaluate
+`a.maybeNil.iNeedThis`, and panic if `a` lacks a `maybeNil` field.)
+
+`dig` accepts its dict argument last in order to support pipelining. For instance:
+```
+merge a b c | dig "one" "two" "three" "<missing>"
+```
 
 ### merge, mustMerge
 


### PR DESCRIPTION
Add documentation for `dig` function from Sprig.
The documentation is taken from Sprig's documentation: https://github.com/Masterminds/sprig/blob/master/docs/dicts.md#dig