### PR TITLE
docs: Remove gofish from index samples

### DIFF
--- a/themes/helm/layouts/index.html
+++ b/themes/helm/layouts/index.html
@@ -89,7 +89,6 @@ Helm
           <li id="tablinks"><a href="#Homebrew" class="active">Homebrew</a></li>
           <li id="tablinks"><a href="#Chocolatey">Chocolatey</a></li>
           <li id="tablinks"><a href="#Scoop">Scoop</a></li>
-          <li id="tablinks"><a href="#Gofish">GoFish</a></li>
           <li id="tablinks"><a href="#Snap">Snap</a></li>
         </ul>
         <div class="tabgroup">
@@ -104,10 +103,6 @@ Helm
           <div class="tabcontent" id="Scoop">
             <input id="copyscoop" value="scoop install helm" />
             <button data-clipboard-target="#copyscoop" class="button">{{ T "action_copy" }}</button>
-          </div>
-          <div class="tabcontent" id="Gofish">
-            <input id="copyfish" value="gofish install helm" />
-            <button data-clipboard-target="#copyfish" class="button">{{ T "action_copy" }}</button>
           </div>
           <div class="tabcontent" id="Snap">
             <input id="copysnap" value="sudo snap install helm --classic" />


### PR DESCRIPTION
In learning what a gofish was, I see that it's now deprecated. Instructions are not in the docs; this commit updates the home page to match.