### PR TITLE
add a simple example for merge function

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1308,6 +1308,27 @@ matching key out of a collection of dictionaries.
 Merge two or more dictionaries into one, giving precedence to the dest
 dictionary:
 
+Given:
+
+```
+dst:
+  default: default
+  overwrite: me
+  key: true
+
+src:
+  overwrite: overwritten
+  key: false
+```
+
+will result in:
+
+```
+newdict:
+  default: default
+  overwrite: me
+  key: true
+```
 ```
 $newdict := merge $dest $source1 $source2
 ```


### PR DESCRIPTION
Add a simple example for a better understanding the `merge` function. The values also have been taken from the `mergeOverwrite` example to be compared the results.