### PR TITLE
Spell "Cappuccino" consistently

### DIFF
--- a/content/en/docs/chart_template_guide/yaml_techniques.md
+++ b/content/en/docs/chart_template_guide/yaml_techniques.md
@@ -324,7 +324,7 @@ that value by reference. YAML refers to this as "anchoring":
 
 ```yaml
 coffee: "yes, please"
-favorite: &favoriteCoffee "Cappucino"
+favorite: &favoriteCoffee "Cappuccino"
 coffees:
   - Latte
   - *favoriteCoffee
@@ -344,10 +344,10 @@ would be:
 
 ```yaml
 coffee: yes, please
-favorite: Cappucino
+favorite: Cappuccino
 coffees:
 - Latte
-- Cappucino
+- Cappuccino
 - Espresso
 ```
 

--- a/content/ko/docs/chart_template_guide/yaml_techniques.md
+++ b/content/ko/docs/chart_template_guide/yaml_techniques.md
@@ -324,7 +324,7 @@ that value by reference. YAML refers to this as "anchoring":
 
 ```yaml
 coffee: "yes, please"
-favorite: &favoriteCoffee "Cappucino"
+favorite: &favoriteCoffee "Cappuccino"
 coffees:
   - Latte
   - *favoriteCoffee
@@ -344,10 +344,10 @@ would be:
 
 ```yaml
 coffee: yes, please
-favorite: Cappucino
+favorite: Cappuccino
 coffees:
 - Latte
-- Cappucino
+- Cappuccino
 - Espresso
 ```
 

--- a/content/zh/docs/chart_template_guide/yaml_techniques.md
+++ b/content/zh/docs/chart_template_guide/yaml_techniques.md
@@ -274,7 +274,7 @@ YAML规范存储了一种引用值的方法，然后通过引用指向该值。Y
 
 ```yaml
 coffee: "yes, please"
-favorite: &favoriteCoffee "Cappucino"
+favorite: &favoriteCoffee "Cappuccino"
 coffees:
   - Latte
   - *favoriteCoffee
@@ -290,10 +290,10 @@ coffees:
 
 ```yaml
 coffee: yes, please
-favorite: Cappucino
+favorite: Cappuccino
 coffees:
 - Latte
-- Cappucino
+- Cappuccino
 - Espresso
 ```
 


### PR DESCRIPTION
Some of the Yaml examples spell "Cappucino", others "Cappuccino". [The correct spelling appears to be "Cappuccino".](https://en.wikipedia.org/wiki/Cappuccino) This changes uses that spelling.