### PR TITLE
Fix cheat sheet documentation typo flag.

### DIFF
--- a/content/en/docs/intro/CheatSheet.md
+++ b/content/en/docs/intro/CheatSheet.md
@@ -87,8 +87,8 @@ helm search hub <keyword>         # Search for charts in the Artifact Hub or you
 
 ```bash
 helm list                       # Lists all of the releases for a specified namespace, uses current namespace context if namespace not specified
-helm list -all                  # Show all releases without any filter applied, can use -a
-helm list -all-namespaces       # List releases across all namespaces, we can use -A
+helm list --all                  # Show all releases without any filter applied, can use -a
+helm list --all-namespaces       # List releases across all namespaces, we can use -A
 helm -l key1=value1,key2=value2 # Selector (label query) to filter on, supports '=', '==', and '!='
 helm list --date                # Sort by release date
 helm list --deployed            # Show deployed releases. If no other is specified, this will be automatically enabled


### PR DESCRIPTION
**Issue**

There is a typo in the cheat sheet documentation. The command `helm list --all` and `helm list --all-namespaces` is written with only a leading single dash.

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/58095522/236611915-b03b464c-f125-41f1-8740-444b26d7dfff.png">


