### PR TITLE
Update helm_ignore_file.md

### DIFF
--- a/content/en/docs/chart_template_guide/helm_ignore_file.md
+++ b/content/en/docs/chart_template_guide/helm_ignore_file.md
@@ -55,7 +55,16 @@ Some notable differences from .gitignore:
 - The '**' syntax is not supported.
 - The globbing library is Go's 'filepath.Match', not fnmatch(3)
 - Trailing spaces are always ignored (there is no supported escape sequence)
-- There is no support for '\!' as a special leading sequence.
+- There is no support for '\!' as a special leading sequence. That is,
+  ```
+  values-*.yaml
+  !values-example.yaml
+  ```
+  does not "unignore" `values-example.yaml`
+  -- as you might expect if you are familiar with `.gitignore` --
+  but ignores _all_ YAML files _except_ `values-example.yaml` 
+  (which is also excluded because of the first line)
+  -- which would include `Chart.yaml`, leading to a broken chart.
 - It does not exclude itself by default, you have to add an explicit entry for `.helmignore`
 
 


### PR DESCRIPTION
Clarify what "no support for `!` as special leading sequence" means.

---

We ran into this behaviour with this exact example; couldn't come up with a better one on short notice.

Suffice to say, the error
```
+ helm dependency update charts/some-service/
Error: Chart.yaml file is missing
```
confused us quite a bit. 😅