### PR TITLE
feat: add support for S3 Compatible Blob storages as StorageDriver

### DIFF
--- a/content/en/docs/helm/helm.md
+++ b/content/en/docs/helm/helm.md
@@ -19,31 +19,31 @@ Common actions for Helm:
 
 Environment variables:
 
-| Name                               | Description                                                                                       |
-|------------------------------------|---------------------------------------------------------------------------------------------------|
-| $HELM_CACHE_HOME                   | set an alternative location for storing cached files.                                             |
-| $HELM_CONFIG_HOME                  | set an alternative location for storing Helm configuration.                                       |
-| $HELM_DATA_HOME                    | set an alternative location for storing Helm data.                                                |
-| $HELM_DEBUG                        | indicate whether or not Helm is running in Debug mode                                             |
-| $HELM_DRIVER                       | set the backend storage driver. Values are: configmap, secret, memory, sql.                       |
-| $HELM_DRIVER_SQL_CONNECTION_STRING | set the connection string the SQL storage driver should use.                                      |
-| $HELM_MAX_HISTORY                  | set the maximum number of helm release history.                                                   |
-| $HELM_NAMESPACE                    | set the namespace used for the helm operations.                                                   |
-| $HELM_NO_PLUGINS                   | disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.                                        |
-| $HELM_PLUGINS                      | set the path to the plugins directory                                                             |
-| $HELM_REGISTRY_CONFIG              | set the path to the registry config file.                                                         |
-| $HELM_REPOSITORY_CACHE             | set the path to the repository cache directory                                                    |
-| $HELM_REPOSITORY_CONFIG            | set the path to the repositories file.                                                            |
-| $KUBECONFIG                        | set an alternative Kubernetes configuration file (default "~/.kube/config")                       |
-| $HELM_KUBEAPISERVER                | set the Kubernetes API Server Endpoint for authentication                                         |
-| $HELM_KUBECAFILE                   | set the Kubernetes certificate authority file.                                                    |
-| $HELM_KUBEASGROUPS                 | set the Groups to use for impersonation using a comma-separated list.                             |
-| $HELM_KUBEASUSER                   | set the Username to impersonate for the operation.                                                |
-| $HELM_KUBECONTEXT                  | set the name of the kubeconfig context.                                                           |
-| $HELM_KUBETOKEN                    | set the Bearer KubeToken used for authentication.                                                 |
-| $HELM_KUBEINSECURE_SKIP_TLS_VERIFY | indicate if the Kubernetes API server's certificate validation should be skipped (insecure)       |
-| $HELM_KUBETLS_SERVER_NAME          | set the server name used to validate the Kubernetes API server certificate                        |
-| $HELM_BURST_LIMIT                  | set the default burst limit in the case the server contains many CRDs (default 100, -1 to disable)|
+| Name                               | Description                                                                                        |
+|------------------------------------|----------------------------------------------------------------------------------------------------|
+| $HELM_CACHE_HOME                   | set an alternative location for storing cached files.                                              |
+| $HELM_CONFIG_HOME                  | set an alternative location for storing Helm configuration.                                        |
+| $HELM_DATA_HOME                    | set an alternative location for storing Helm data.                                                 |
+| $HELM_DEBUG                        | indicate whether or not Helm is running in Debug mode                                              |
+| $HELM_DRIVER                       | set the backend storage driver. Values are: configmap, secret, memory, sql, s3.                    |
+| $HELM_DRIVER_SQL_CONNECTION_STRING | set the connection string the SQL storage driver should use.                                       |
+| $HELM_MAX_HISTORY                  | set the maximum number of helm release history.                                                    |
+| $HELM_NAMESPACE                    | set the namespace used for the helm operations.                                                    |
+| $HELM_NO_PLUGINS                   | disable plugins. Set HELM_NO_PLUGINS=1 to disable plugins.                                         |
+| $HELM_PLUGINS                      | set the path to the plugins directory                                                              |
+| $HELM_REGISTRY_CONFIG              | set the path to the registry config file.                                                          |
+| $HELM_REPOSITORY_CACHE             | set the path to the repository cache directory                                                     |
+| $HELM_REPOSITORY_CONFIG            | set the path to the repositories file.                                                             |
+| $KUBECONFIG                        | set an alternative Kubernetes configuration file (default "~/.kube/config")                        |
+| $HELM_KUBEAPISERVER                | set the Kubernetes API Server Endpoint for authentication                                          |
+| $HELM_KUBECAFILE                   | set the Kubernetes certificate authority file.                                                     |
+| $HELM_KUBEASGROUPS                 | set the Groups to use for impersonation using a comma-separated list.                              |
+| $HELM_KUBEASUSER                   | set the Username to impersonate for the operation.                                                 |
+| $HELM_KUBECONTEXT                  | set the name of the kubeconfig context.                                                            |
+| $HELM_KUBETOKEN                    | set the Bearer KubeToken used for authentication.                                                  |
+| $HELM_KUBEINSECURE_SKIP_TLS_VERIFY | indicate if the Kubernetes API server's certificate validation should be skipped (insecure)        |
+| $HELM_KUBETLS_SERVER_NAME          | set the server name used to validate the Kubernetes API server certificate                         |
+| $HELM_BURST_LIMIT                  | set the default burst limit in the case the server contains many CRDs (default 100, -1 to disable) |
 
 Helm stores cache, configuration, and data based on the following configuration order:
 

--- a/content/en/docs/topics/advanced.md
+++ b/content/en/docs/topics/advanced.md
@@ -222,3 +222,35 @@ with the following command:
 ```shell
 kubectl get secret --all-namespaces -l "owner=helm"
 ```
+
+### S3 compatible storage backend
+
+There is a S3 storage backend that stores release information in S3 compatible blob storage.
+
+The usage of S3 could be a better alternative compared to the ConfigMaps/Secrets approach as it doesn't have the limit of 1MB
+and in parallel it also doesn't have the disadvantage of SQL that usually Databases are the resources with the
+highest level of protection (Firewall etc).
+
+To enable the S3 compatible backend, you'll need to create a S3 Bucket and an IAM role with the following Actions:
+
+* `s3:GetObject`
+* `s3:ListBucket`
+* `s3:PutObject`
+* `s3:DeleteObject`
+
+Dependent on your S3 Bucket configuration for kms also other Actions like `kms:Decrypt` and `kms:Encrypt` could be needed.
+
+Helm utilizes the [default credential chain](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials) for Credentials lookup.
+An example configuration looks like this:
+
+```shell
+export HELM_DRIVER=s3
+export HELM_DRIVER_S3_BUCKET_NAME="test-bucket"
+```
+
+If you plan to utilize this with other Cloud providers then AWS or locally with tools like localstack the following additional variables can be exposed:
+
+```shell
+export HELM_DRIVER_S3_BUCKET_LOCATION_URL="http://127.0.0.1:9002"
+export HELM_DRIVER_S3_USE_PATH_STYLE="true"
+```


### PR DESCRIPTION
What this PR does / why we need it:

```
In case you run a large installation of Kubernetes with a lot of releases the amount of secrets and the size get a potential issue. To overcome this there are other storage drivers like SQL, but if you are in a restricted environment usually Databases are the worth protecting resource. Due to this S3 is IMHO a valid alternative and as the protocol is widely adapted also outside of the AWS area it's not only cloud provider specific.
```

Documents https://github.com/helm/helm/pull/12173