### PR TITLE
Bump to latest hugo version 0.115.4

### DIFF
--- a/content/en/go.mod
+++ b/content/en/go.mod
@@ -1,0 +1,3 @@
+module github.com/helm/helm-www
+
+go 1.20

--- a/hugo.toml
+++ b/hugo.toml
@@ -88,7 +88,6 @@ disableLanguages = ["zh"]
 # English
 [languages.en]
 title = "Helm"
-description = "Helm - The Kubernetes Package Manager."
 contentDir = "content/en"
 languageName = "English"
 weight = 1
@@ -118,10 +117,12 @@ name = "Community"
 url = "https://github.com/helm/community"
 weight = 5
 
+[languages.en.params]
+description = "Helm - The Kubernetes Package Manager."
+
 # German
 [languages.de]
 title = "Helm"
-description = "Helm - Der Kubernetes Paket Manager."
 contentDir = "content/de"
 languageName = "Deutsch"
 weight = 2
@@ -152,12 +153,12 @@ url = "https://github.com/helm/community"
 weight = 5
 
 [languages.de.params]
+description = "Helm - Der Kubernetes Paket Manager."
 language_alternatives = ["en"]
 
 # Spanish
 [languages.es]
 title = "Helm"
-description = "Helm - El Administrador de Paquetes de Kubernetes."
 contentDir = "content/es"
 languageName = "Español"
 weight = 3
@@ -187,10 +188,12 @@ name = "Comunidad"
 url = "https://github.com/helm/community"
 weight = 5
 
+[languages.es.params]
+description = "Helm - El Administrador de Paquetes de Kubernetes."
+
 # French
 [languages.fr]
 title = "Helm"
-description = "Helm - Le manageur de paquets de Kubernetes."
 contentDir = "content/fr"
 languageName = "Français"
 weight = 4
@@ -220,10 +223,12 @@ name = "Communauté"
 url = "https://github.com/helm/community"
 weight = 5
 
+[languages.fr.params]
+description = "Helm - Le manageur de paquets de Kubernetes."
+
 # Ελληνικά
 [languages.gr]
 title = "Helm"
-description = "Helm - Ο package manager του Kubernetes."
 contentDir = "content/gr"
 languageName = "Ελληνικά"
 weight = 5
@@ -253,10 +258,12 @@ name = "Επικοινωνία"
 url = "https://github.com/helm/community"
 weight = 5
 
+[languages.gr.params]
+description = "Helm - Ο package manager του Kubernetes."
+
 # Japanese
 [languages.ja]
 title = "Helm"
-description = "Helm - Kubernetes パッケージマネージャー"
 contentDir = "content/ja"
 languageName = "日本語"
 weight = 6
@@ -287,13 +294,13 @@ url = "https://github.com/helm/community"
 weight = 5
 
 [languages.ja.params]
+description = "Helm - Kubernetes パッケージマネージャー"
 language_alternatives = ["en"]
 
 
 # Korean
 [languages.ko]
 title = "헬름"
-description = "헬름 - 쿠버네티스 패키지 매니저"
 contentDir = "content/ko"
 languageName = "한국어"
 weight = 7
@@ -325,12 +332,12 @@ url = "https://github.com/helm/community"
 weight = 5
 
 [languages.ko.params]
+description = "헬름 - 쿠버네티스 패키지 매니저"
 language_alternatives = ["en"]
 
 # Portuguese
 [languages.pt]
 title = "Helm"
-description = "Helm - O Gerenciador de Pacotes do Kubernetes."
 contentDir = "content/pt"
 languageName = "Português"
 weight = 8
@@ -361,12 +368,12 @@ url = "https://github.com/helm/community"
 weight = 5
 
 [languages.pt.params]
+description = "Helm - O Gerenciador de Pacotes do Kubernetes."
 language_alternatives = ["en"]
 
 # Russian
 [languages.ru]
 title = "Helm"
-description = "Helm – Менеджер Пакетов Kubernetes."
 contentDir = "content/ru"
 languageName = "Русский"
 weight = 9
@@ -398,12 +405,12 @@ url = "https://github.com/helm/community"
 weight = 5
 
 [languages.ru.params]
+description = "Helm – Менеджер Пакетов Kubernetes."
 language_alternatives = ["en"]
 
 # Chinese
 [languages.zh]
 title = "Helm"
-description = "Helm - Kubernetes 包管理器"
 contentDir = "content/zh"
 languageName = "中文"
 weight = 10
@@ -435,4 +442,5 @@ url = "https://github.com/helm/community"
 weight = 5
 
 [languages.zh.params]
+description = "Helm - Kubernetes 包管理器"
 language_alternatives = ["en"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "app"
 
 [build.environment]
-  HUGO_VERSION = "0.94.0"
+  HUGO_VERSION = "0.115.4"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]

--- a/themes/helm/layouts/code/list.html
+++ b/themes/helm/layouts/code/list.html
@@ -1,0 +1,1 @@
+{{ "<!-- Layout with no content to avoid WARN message about missing page layout -->" | safeHTML }}


### PR DESCRIPTION
This PR bumps hugo to latest released version `v.115.4`.

It also resolves various deprecation warnings emitted by latest hugo version.

```
hugo server
WARN  config: languages.zh.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.zh.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  config: languages.en.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  config: languages.fr.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.fr.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  config: languages.ja.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
Start building sites … 
hugo v0.115.0-67caf50698783d3b3d78559ac81483d83e5e1a35+extended linux/amd64 BuildDate=2023-06-29T15:56:39Z VendorInfo=gohugoio

WARN  found no layout file for "html" for kind "section": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
```
