### PR TITLE
docs: correct slight grammatical error in content/en/docs/intro/Cheat…

### DIFF
--- a/content/en/docs/intro/CheatSheet.md
+++ b/content/en/docs/intro/CheatSheet.md
@@ -10,7 +10,7 @@ Helm cheatsheet featuring all the necessary commands required to manage an appli
 ### Basic interpretations/context
 
 Chart:
-- It is name of your chart in case it has been pulled and untarred.
+- It is the name of your chart in case it has been pulled and untarred.
 - It is <repo_name>/<chart_name> in case the repository has been added but chart not pulled.
 - It is the URL/Absolute path to the chart.
 


### PR DESCRIPTION
Hi.
I made a slight grammatical correction to CheatSheet.md 