### PR TITLE
Fix error in wrapWith example

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -510,7 +510,7 @@ The above will wrap the string in `$someText` at 80 columns.
 wrapWith 5 "\t" "Hello World"
 ```
 
-The above produces `hello world` (where the whitespace is an ASCII tab
+The above produces `Hello World` (where the whitespace is an ASCII tab
 character)
 
 ### contains


### PR DESCRIPTION
I spotted what appears to be an error in the docs for the casing of the example for `wrapWith`.

What I've changed in this PR is the simplest thing that fixes the documentation issue.

However, I think the example could perhaps be improved, eg:
> ```
> wrapWith 5 "_" "abcdefghijkl"
> ```
>  The above produces `abcde_fghij_kl`.

Perhaps that would make the behaviour of `wrapWith` clearer? If that is wanted, let me know if it should go in this PR or be separate.