### PR TITLE
Add external project HULL to list

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -83,6 +83,10 @@ Tools layered on top of Helm.
   helm-charts-as-code tool which enables
   installing/upgrading/protecting/moving/deleting releases from version
   controlled desired state files (described in a simple TOML format)
+- [HULL](https://github.com/vidispine/hull) - This library chart provides a 
+  ready-to-use interface for specifying all Kubernetes objects directly in the `values.yaml`.
+  It removes the need to write any templates for your charts and comes with many
+  additional features to simplify Helm chart creation and usage.
 - [Konveyor Move2Kube](https://konveyor.io/move2kube/) -
   Generate Helm charts for your
   existing projects.


### PR DESCRIPTION
Hello,

I wanted to propose a mentioning of this open source project here. 

It is built in form a Helm library chart and has been around for more than two years now. Many tests exist to back every releases stability and it is used in production.  

Not sure if it should better go under the plugins sections but these seem to be (almost) exclusively actual helm plugins there?

Thanks!