### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is where you'll find all of the assets that make up [helm.sh](https://helm.
 
 ## Development
 
-Helm.sh is a simple [Hugo](https://gohugo.io/) static site, built with a custom theme. To run the website locally, you'll need to first [install](https://gohugo.io/getting-started) Hugo and any dependencies.
+Helm.sh is a simple [Hugo](https://gohugo.io/) static site, built with a custom theme. To run the website locally, you'll need to first [install](https://gohugo.io/getting-started) Hugo extended edition and any dependencies.
 
 ```
 brew install hugo

--- a/config.toml
+++ b/config.toml
@@ -105,7 +105,7 @@ weight = 2
 
 [[languages.en.menus.main]]
 name = "Charts"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.en.menus.main]]
@@ -138,7 +138,7 @@ weight = 2
 
 [[languages.de.menus.main]]
 name = "Charts"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.de.menus.main]]
@@ -174,7 +174,7 @@ weight = 2
 
 [[languages.es.menus.main]]
 name = "Charts"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.es.menus.main]]
@@ -207,7 +207,7 @@ weight = 2
 
 [[languages.fr.menus.main]]
 name = "Charts"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.fr.menus.main]]
@@ -240,7 +240,7 @@ weight = 2
 
 [[languages.gr.menus.main]]
 name = "Charts"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.gr.menus.main]]
@@ -273,7 +273,7 @@ weight = 2
 
 [[languages.ja.menus.main]]
 name = "チャート"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.ja.menus.main]]
@@ -310,7 +310,7 @@ weight = 2
 
 [[languages.ko.menus.main]]
 name = "차트"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 external = "yes"
 
@@ -347,7 +347,7 @@ weight = 2
 
 [[languages.pt.menus.main]]
 name = "Charts"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 
 [[languages.pt.menus.main]]
@@ -383,7 +383,7 @@ weight = 2
 
 [[languages.ru.menus.main]]
 name = "Chart-ы"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 external = "yes"
 
@@ -420,7 +420,7 @@ weight = 2
 
 [[languages.zh.menus.main]]
 name = "应用中心"
-url = "https://hub.helm.sh/"
+url = "https://artifacthub.io//"
 weight = 3
 external = "yes"
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -15,7 +15,7 @@ report](https://www.cncf.io/cncf-helm-project-journey/).
 Helm has a lot of documentation. A high-level overview of how it’s organized
 will help you know where to look for certain things:
 
-- [Tutorials](intro) take you by the hand through a series of steps to create
+- [Tutorials](chart_template_guide/getting_started/) take you by the hand through a series of steps to create
   your first Helm chart. Start here if you’re new to Helm.
 - [Topic guides](topics) discuss key topics and concepts at a fairly high level
   and provide useful background information and explanation.

--- a/content/en/docs/chart_template_guide/accessing_files.md
+++ b/content/en/docs/chart_template_guide/accessing_files.md
@@ -21,7 +21,7 @@ this works:
   security reasons.
   - Files in `templates/` cannot be accessed.
   - Files excluded using `.helmignore` cannot be accessed.
-  - Files outside of a helm application [subchart]({{< ref
+  - Files outside of a Helm application [subchart]({{< ref
 "/docs/chart_template_guide/subcharts_and_globals.md" >}}), including those of the parent, cannot be accessed
 - Charts do not preserve UNIX mode information, so file-level permissions will
   have no impact on the availability of a file when it comes to the `.Files`
@@ -34,8 +34,7 @@ this works:
 - [Basic example](#basic-example)
 - [Path helpers](#path-helpers)
 - [Glob patterns](#glob-patterns)
-- [ConfigMap and Secrets utility
-  functions](#configmap-and-secrets-utility-functions)
+- [ConfigMap and Secrets utility functions](#configmap-and-secrets-utility-functions)
 - [Encoding](#encoding)
 - [Lines](#lines)
 
@@ -82,7 +81,7 @@ data:
   {{- end }}
 ```
 
-This config map uses several of the techniques discussed in previous sections.
+This ConfigMap uses several of the techniques discussed in previous sections.
 For example, we create a `$files` variable to hold a reference to the `.Files`
 object. We also use the `tuple` function to create a list of files that we loop
 through. Then we print each file name (`{{ . }}: |-`) followed by the contents

--- a/content/en/docs/chart_template_guide/builtin_objects.md
+++ b/content/en/docs/chart_template_guide/builtin_objects.md
@@ -10,7 +10,7 @@ statements). There are even a few ways to create new objects within your
 templates, like with the `tuple` function we'll see later.
 
 Objects can be simple, and have just one value. Or they can contain other
-objects or functions. For example. the `Release` object contains several objects
+objects or functions. For example, the `Release` object contains several objects
 (like `Release.Name`) and the `Files` object has a few functions.
 
 In the previous section, we use `{{ .Release.Name }}` to insert the name of a
@@ -63,9 +63,9 @@ access in your templates.
     Kubernetes version.
   - `Capabilities.KubeVersion.Major` is the Kubernetes major version.
   - `Capabilities.KubeVersion.Minor` is the Kubernetes minor version.
-  - `Capabilities.HelmVersion` is the object containing the Helm Version details, it is the same output of `helm version`  
+  - `Capabilities.HelmVersion` is the object containing the Helm Version details, it is the same output of `helm version`.
   - `Capabilities.HelmVersion.Version` is the current Helm version in semver format.
-  - `Capabilities.HelmVersion.GitCommit` is the Helm git sha1. 
+  - `Capabilities.HelmVersion.GitCommit` is the Helm git sha1.
   - `Capabilities.HelmVersion.GitTreeState` is the state of the Helm git tree.
   - `Capabilities.HelmVersion.GoVersion` is the version of the Go compiler used.
 - `Template`: Contains information about the current template that is being

--- a/content/en/docs/chart_template_guide/control_structures.md
+++ b/content/en/docs/chart_template_guide/control_structures.md
@@ -164,7 +164,7 @@ data:
 ```
 
 Notice that we received a few empty lines in our YAML. Why? When the template
-engine runs, it _removes_ the contents inside of `{{` end `}}`, but it leaves
+engine runs, it _removes_ the contents inside of `{{` and `}}`, but it leaves
 the remaining whitespace exactly as is.
 
 YAML ascribes meaning to whitespace, so managing the whitespace becomes pretty

--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -239,7 +239,7 @@ for the existence of an object.
 
 The `lookup` function uses Helm's existing Kubernetes connection configuration
 to query Kubernetes. If any error is returned when interacting with calling the
-API server (for example due to lack of permission to access a resource), helm's
+API server (for example due to lack of permission to access a resource), Helm's
 template processing will fail.
 
 Keep in mind that Helm is not supposed to contact the Kubernetes API Server

--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -35,7 +35,7 @@ _default values_ for a chart. These values may be overridden by users during
 `helm install` or `helm upgrade`.
 
 The `Chart.yaml` file contains a description of the chart. You can access it
-from within a template. 
+from within a template.
 
 The `charts/` directory _may_ contain other charts
 (which we call _subcharts_). Later in this guide we will see how those work when
@@ -59,9 +59,9 @@ files already there.
 - `NOTES.txt`: The "help text" for your chart. This will be displayed to your
   users when they run `helm install`.
 - `deployment.yaml`: A basic manifest for creating a Kubernetes
-  [deployment](https://kubernetes.io/docs/user-guide/deployments/)
+  [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 - `service.yaml`: A basic manifest for creating a [service
-  endpoint](https://kubernetes.io/docs/user-guide/services/) for your deployment
+  endpoint](https://kubernetes.io/docs/concepts/services-networking/service/) for your deployment
 - `_helpers.tpl`: A place to put template helpers that you can re-use throughout
   the chart
 

--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -202,7 +202,7 @@ TEST SUITE: None
 
 You can run `helm get manifest clunky-serval` to see the entire generated YAML.
 
-Note that the config map inside kubernetes name is `clunky-serval-configmap`
+Note that the ConfigMap inside Kubernetes name is `clunky-serval-configmap`
 instead of `mychart-configmap` previously.
 
 At this point, we've seen templates at their most basic: YAML files that have

--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -100,7 +100,7 @@ data:
 recommend using the extension `.yaml` for YAML files and `.tpl` for helpers.
 
 The YAML file above is a bare-bones ConfigMap, having the minimal necessary
-fields. In virtue of the fact that this file is in the `mychart/templates/`
+fields. By virtue of the fact that this file is in the `mychart/templates/`
 directory, it will be sent through the template engine.
 
 It is just fine to put a plain YAML file like this in the `mychart/templates/`

--- a/content/en/docs/chart_template_guide/getting_started.md
+++ b/content/en/docs/chart_template_guide/getting_started.md
@@ -97,7 +97,7 @@ data:
 ```
 
 **TIP:** Template names do not follow a rigid naming pattern. However, we
-recommend using the suffix `.yaml` for YAML files and `.tpl` for helpers.
+recommend using the extension `.yaml` for YAML files and `.tpl` for helpers.
 
 The YAML file above is a bare-bones ConfigMap, having the minimal necessary
 fields. In virtue of the fact that this file is in the `mychart/templates/`

--- a/content/en/docs/intro/using_helm.md
+++ b/content/en/docs/intro/using_helm.md
@@ -263,7 +263,7 @@ There are two ways to pass configuration data during install:
 - `--set`: Specify overrides on the command line.
 
 If both are used, `--set` values are merged into `--values` with higher
-precedence. Overrides specified with `--set` are persisted in a ConfigMap.
+precedence. Overrides specified with `--set` are persisted in a Secret.
 Values that have been `--set` can be viewed for a given release with `helm get
 values <release-name>`. Values that have been `--set` can be cleared by running
 `helm upgrade` with `--reset-values` specified.

--- a/themes/helm/layouts/partials/footer-links.html
+++ b/themes/helm/layouts/partials/footer-links.html
@@ -11,11 +11,11 @@
     </dl>
 
     <dl class="column">
-      <dt><a href="https://hub.helm.sh">Charts</a></dt>
+      <dt><a href="https://artifacthub.io/">Charts</a></dt>
       <dd><a href="/docs/topics/charts/">Introduction</a></dd>
       <dd><a href="/docs/howto/charts_tips_and_tricks/">Chart tips &amp; tricks</a></dd>
       <dd><a href="/docs/chart_template_guide/">Developing Charts</a></dd>
-      <dd><a href="https://hub.helm.sh">Search 800+ Charts</a> <i class="fa fa-external"></i></dd>
+      <dd><a href="https://artifacthub.io/">Search 800+ Charts</a> <i class="fa fa-external"></i></dd>
     </dl>
 
     <dl class="column">


### PR DESCRIPTION
Closes #1526 
Closes #1530 
Fixes #1528 
Fixes #1525 

* Adds a small note that Hugo extended edition is required. GitHub Codespaces, for example, have default runners with regular Hugo installed which will fail when attempting to render the site. Although `brew install hugo` does install the extended edition, this isn't obvious from the command alone.
* Fixes a sentence which appears to be a remnant from Helm v2 days.
* Fixes some broken links
* Updates links from Helm Hub to Artifact Hub
* Minor linting and styling updates