### PR TITLE
fix: add permission to write repo & upgrade action to v1.6.0

### DIFF
--- a/content/en/docs/howto/chart_releaser_action.md
+++ b/content/en/docs/howto/chart_releaser_action.md
@@ -68,6 +68,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,7 +83,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```
@@ -95,7 +97,7 @@ the chart version, adds Helm chart artifacts to the release, and creates or
 updates an `index.yaml` file with metadata about those releases, which is then
 hosted on GitHub pages.
 
-The Chart Releaser Action version number used in the above example is `v1.5.0`.
+The Chart Releaser Action version number used in the above example is `v1.6.0`.
 You can change it to the [latest available
 version](https://github.com/helm/chart-releaser-action/releases).
 

--- a/content/es/docs/howto/chart_releaser_action.md
+++ b/content/es/docs/howto/chart_releaser_action.md
@@ -61,6 +61,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,14 +76,14 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
 La configuración anterior utiliza [@helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) para converitr su proyecto GitHub en un repositorio de Helm chart autoalojado. Lo hace - durante cada push a main - comprobando cada chart en su proyecto, y siempre que la nueva versión de chart, crea una versión correspondiente en GitHub con el nombre de la versión del chart, añade artefactos de Helm chart al release, y crea o actualiza un fichero `index.yaml` con metadatos sobre esas releases, que luego se alojan en la páginas de GitHub.
 
-El número de versión de la Chart Releaser Action utilizado en el ejemplo anterior es `v1.5.0`.
+El número de versión de la Chart Releaser Action utilizado en el ejemplo anterior es `v1.6.0`.
 Puedes cambiarlo por la [última versión disponible](https://github.com/helm/chart-releaser-action/releases).
 
 Nota: El Chart Releaser Action se utiliza casi siempre junto con [Helm Testing

--- a/content/zh/docs/howto/chart_releaser_action.md
+++ b/content/zh/docs/howto/chart_releaser_action.md
@@ -60,6 +60,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,7 +75,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```
@@ -83,7 +85,7 @@ jobs:
 且每当有新的chart版本时，会创建一个与chart版本对应的GitHub版本，添加Helm chart组件到这个版本中，
 并用该版本的元数据创建或更新一个`index.yaml`文件，然后托管在GitHub页面上。
 
-上述Chart发布操作示例使用的版本号是`v1.5.0`。你可以将其改成[最新可用版本](https://github.com/helm/chart-releaser-action/releases)。
+上述Chart发布操作示例使用的版本号是`v1.6.0`。你可以将其改成[最新可用版本](https://github.com/helm/chart-releaser-action/releases)。
 
 注意：Chart发布操作程序几乎总是和 [Helm测试操作Action](https://github.com/marketplace/actions/helm-chart-testing)
 以及[Kind操作](https://github.com/marketplace/actions/kind-cluster)。


### PR DESCRIPTION
1. `helm/chart-releaser-action` need write permission to run it correctly otherwise it will report permission error 
![image](https://github.com/helm/helm-www/assets/6478745/13d9be5c-9a55-4763-a804-ac16fe911786)

2. upgrade `helm/chart-releaser-action` to v1.6.0