### PR TITLE
Add links to helm-sigstore project

### DIFF
--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -259,6 +259,16 @@ From the end user's perspective, `helm install --verify myrepo/mychart-1.2.3`
 should result in the download of both the chart and the provenance file with no
 additional user configuration or action.
 
+### Signatures in OCI-based registries
+
+Whe publishing charts to an [OCI-based registry]({{< ref "registries.md" >}}), the
+[`helm-sigstore` plugin](https://github.com/sigstore/helm-sigstore/) can be used 
+to publish provenance to [sigstore](https://sigstore.dev/).  [As described in the
+documentation](https://github.com/sigstore/helm-sigstore/blob/main/USAGE.md), the
+process of creating provenance and signing with a GPG key are common, but the
+`helm sigstore upload` command can be used to publish the provenance to an
+immutable transparency log.
+
 ## Establishing Authority and Authenticity
 
 When dealing with chain-of-trust systems, it is important to be able to

--- a/content/en/docs/topics/registries.md
+++ b/content/en/docs/topics/registries.md
@@ -64,6 +64,12 @@ Follow the hosted container registry provider's documentation to create and conf
 
 **Note:**  You can run [Docker Registry](https://docs.docker.com/registry/deploying/) or [`zot`](https://github.com/project-zot/zot), which are OCI-based registries, on your development computer. Running an OCI-based registry on your development computer should only be used for testing purposes.
 
+### Using sigstore to sign OCI-based charts
+
+The [`helm-sigstore`](https://github.com/sigstore/helm-sigstore) plugin allows using [Sigstore](https://sigstore.dev/) to sign Helm charts with the same tools used to sign container images.  This provides an alternative to the [GPG-based provenance]({{< ref "provenance.md" >}}) supported by classic [chart repositories]({{< ref "chart_repository.md" >}}).
+
+For more details on using the `helm sigstore` plugin, see [that project's documentation](https://github.com/sigstore/helm-sigstore/blob/main/USAGE.md).
+
 ## Commands for working with registries
 
 ### The `registry` subcommand


### PR DESCRIPTION
Fixes https://github.com/sigstore/cosign/issues/1118

Related-to https://github.com/helm/helm/issues/11496

It's possible to use (GPG-keyed) signing with Sigstore today, adding cross-links to documentation to make it more discoverable.
