### PR TITLE
describe mergeOverwrite with nil field in src

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1445,12 +1445,12 @@ dst:
   default: default
   overwrite: me
   key: true
-  unset: me
+  nullify: me
 
 src:
   overwrite: overwritten
   key: false
-  unset: nil
+  nullify: nil # AKA null
 ```
 
 will result in:
@@ -1460,6 +1460,7 @@ newdict:
   default: default
   overwrite: overwritten
   key: false
+  nullify: nil # AKA null
 ```
 
 ```

--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1445,10 +1445,12 @@ dst:
   default: default
   overwrite: me
   key: true
+  unset: me
 
 src:
   overwrite: overwritten
   key: false
+  unset: nil
 ```
 
 will result in:


### PR DESCRIPTION
The mergeOverwrite function removes any keys in the src dict that are explicitly set to nil