### PR TITLE
describe mergeOverwrite with nil field in src (#3)

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1445,10 +1445,12 @@ dst:
   default: default
   overwrite: me
   key: true
+  nullify: me
 
 src:
   overwrite: overwritten
   key: false
+  nullify: nil # AKA null
 ```
 
 will result in:
@@ -1458,6 +1460,7 @@ newdict:
   default: default
   overwrite: overwritten
   key: false
+  nullify: nil # AKA null
 ```
 
 ```


### PR DESCRIPTION
If any keys in the mergeOverwrite function's src dict are nil, they will also be set to nil in the dst dict