### PR TITLE
Added --generate-name flag for command

### DIFF
--- a/content/en/docs/chart_template_guide/subcharts_and_globals.md
+++ b/content/en/docs/chart_template_guide/subcharts_and_globals.md
@@ -108,7 +108,7 @@ mysubchart:
 ```
 
 Note the last two lines. Any directives inside of the `mysubchart` section will
-be sent to the `mysubchart` chart. So if we run `helm install --dry-run --debug
+be sent to the `mysubchart` chart. So if we run `helm install --generate-name --dry-run --debug
 mychart`, one of the things we will see is the `mysubchart` ConfigMap:
 
 ```yaml


### PR DESCRIPTION
Command resolves to an error, saying 'must either provide a name or specify --generate-name', adding the flags fixes that.
Alternative adding "rude-cardinal" (same name as previous guides) `helm install rude-cardinal --dry-run --debug mychart`