### PR TITLE
Update GitHub Actions examples

### DIFF
--- a/content/en/docs/howto/chart_releaser_action.md
+++ b/content/en/docs/howto/chart_releaser_action.md
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/content/es/docs/howto/chart_releaser_action.md
+++ b/content/es/docs/howto/chart_releaser_action.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/content/zh/docs/howto/chart_releaser_action.md
+++ b/content/zh/docs/howto/chart_releaser_action.md
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Updated the examples for GitHub Actions to match the latest `actions/checkout` version, cleaning up deprecation messages.

It has the same motivation as https://github.com/helm/helm-www/pull/1432 😄 

I hope it helps!