### PR TITLE
charts_tips_and_tricks.md - quote password in case of special characters

### DIFF
--- a/content/de/docs/howto/charts_tips_and_tricks.md
+++ b/content/de/docs/howto/charts_tips_and_tricks.md
@@ -169,7 +169,7 @@ Wir definieren dann unsere Hilfsvorlage wie folgt:
 ```
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":%s,\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username (.password | quote) .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
 ```

--- a/content/en/docs/howto/charts_tips_and_tricks.md
+++ b/content/en/docs/howto/charts_tips_and_tricks.md
@@ -171,7 +171,7 @@ We then define our helper template as follows:
 ```
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":%s,\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username (.password | quote) .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
 ```

--- a/content/es/docs/howto/charts_tips_and_tricks.md
+++ b/content/es/docs/howto/charts_tips_and_tricks.md
@@ -183,7 +183,7 @@ Luego definimos nuestra plantilla auxiliar de la siguiente manera:
 ```
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":%s,\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username (.password | quote) .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
 ```

--- a/content/ja/docs/howto/charts_tips_and_tricks.md
+++ b/content/ja/docs/howto/charts_tips_and_tricks.md
@@ -170,7 +170,7 @@ imageCredentials:
 ```
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":%s,\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username (.password | quote) .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
 ```

--- a/content/ko/docs/howto/charts_tips_and_tricks.md
+++ b/content/ko/docs/howto/charts_tips_and_tricks.md
@@ -156,7 +156,7 @@ imageCredentials:
 ```
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":%s,\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username (.password | quote) .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
 ```

--- a/content/zh/docs/howto/charts_tips_and_tricks.md
+++ b/content/zh/docs/howto/charts_tips_and_tricks.md
@@ -141,7 +141,7 @@ imageCredentials:
 ```yaml
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":%s,\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username (.password | quote) .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
 ```


### PR DESCRIPTION
Add quoting (using `| quote`) for password in imagePullSecret helper and removing additional (artificial) quote 
characters as those are added by `quote` func.

This change allows to use more complicated password with e.g. quotes, backslashes and other special characters.