### PR TITLE
Update URL in derivePassword docs

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -999,7 +999,7 @@ Note that it is insecure to store the password directly in the template.
 
 The `derivePassword` function can be used to derive a specific password based on
 some shared "master password" constraints. The algorithm for this is [well
-specified](https://masterpassword.app/masterpassword-algorithm.pdf).
+specified](https://web.archive.org/web/20211019121301/https://masterpassword.app/masterpassword-algorithm.pdf).
 
 ```
 derivePassword 1 "long" "password" "user" "example.com"


### PR DESCRIPTION
The "Chart Template Guide > Template Function List > Cryptographic and Security > derivePassword" docs have a broken link.

The algorithm for this is well specified.

I replaced the link to the original PDF on the internet archive: https://web.archive.org/web/20211019121301/https://masterpassword.app/masterpassword-algorithm.pdf

Fixes helm#1589