### PR TITLE
make is clear duration expects a string

### DIFF
--- a/content/en/docs/chart_template_guide/function_list.md
+++ b/content/en/docs/chart_template_guide/function_list.md
@@ -1188,7 +1188,7 @@ Formats a given amount of seconds as a `time.Duration`.
 This returns 1m35s
 
 ```
-duration 95
+duration "95"
 ```
 
 ### durationRound


### PR DESCRIPTION
```shell
❯ helm version
version.BuildInfo{Version:"v3.15.2", GitCommit:"1a500d5625419a524fdae4b33de351cc4f58ec35", GitTreeState:"clean", GoVersion:"go1.22.4"}

❯ cat templates/main.yaml
kind: wow
metadata:
  name: amazing
data:
  int: {{ 1 | duration }}
  string: {{ "1" | duration }}

❯ helm template .
---
# Source: duration/templates/main.yaml
kind: wow
metadata:
  name: amazing
data:
  int: 0s
  string: 1s
```