### PR TITLE
Replace broken URL in derivePassword zh docs

### DIFF
--- a/content/zh/docs/chart_template_guide/function_list.md
+++ b/content/zh/docs/chart_template_guide/function_list.md
@@ -876,7 +876,7 @@ htpasswd "myUser" "myPassword"
 
 ### derivePassword
 
-`derivePassword` 函数可用于基于某些共享的“主密码”约束得到特定密码。这方面的算法有[详细说明](https://masterpassword.app/masterpassword-algorithm.pdf)。
+`derivePassword` 函数可用于基于某些共享的“主密码”约束得到特定密码。这方面的算法有[详细说明](https://spectre.app/spectre-algorithm.pdf)。
 
 ```yaml
 derivePassword 1 "long" "password" "user" "example.com"


### PR DESCRIPTION
The "Chart 模板指南 > 模板函数列表 > Cryptographic and Security > derivePassword" docs have a broken link.

The algorithm for this is well-specified.

Since Master Password was rebranded as Spectre in 2021, I replaced the link with the new URL and path.