### PR TITLE
Add Cyclops to Related Projects

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -78,6 +78,8 @@ Tools layered on top of Helm.
   Hosts on OCI Registry
 - [Codefresh](https://codefresh.io) - Kubernetes native CI/CD and management
   platform with UI dashboards for managing Helm charts and releases
+- ⁠[Cyclops](https://cyclops-ui.com) - Dynamic Kubernetes UI rendering based
+  on Helm charts
 - [Flux](https://fluxcd.io/docs/components/helm/) -
   Continuous and progressive delivery from Git to Kubernetes.
 - [Helmfile](https://github.com/helmfile/helmfile) - Helmfile is a declarative


### PR DESCRIPTION
### Add Cyclops to Additional Tools in Related Projects.
Cyclops is an open-source tool that allows you to create custom UIs for Kubernetes based on Helm charts.

_Encouraged by a comment on a recent [blog](https://dev.to/scottrigby/comment/2h3f7)._