### PR TITLE
chore: Update version_skew.md for 3.15.0 release

### DIFF
--- a/content/en/docs/topics/version_skew.md
+++ b/content/en/docs/topics/version_skew.md
@@ -46,6 +46,7 @@ with your cluster.
 
 | Helm Version | Supported Kubernetes Versions |
 |--------------|-------------------------------|
+| 3.15.x       | 1.30.x - 1.27.x               |
 | 3.14.x       | 1.29.x - 1.26.x               |
 | 3.13.x       | 1.28.x - 1.25.x               |
 | 3.12.x       | 1.27.x - 1.24.x               |


### PR DESCRIPTION
I know it's a duplicate of #1613, but since that PR hasn't been able to move for 2 weeks I offer an alternative that can be merged