### PR TITLE
updating the docs for local testing setup

### DIFF
--- a/content/en/docs/community/developers.md
+++ b/content/en/docs/community/developers.md
@@ -35,6 +35,18 @@ As a pre-requisite, you would need to have
 [golangci-lint](https://golangci-lint.run)
 installed.
 
+## Running Locally
+
+You can update your path and add the path of your local helm binary. In an editor
+open your shell config file. Add the following line making sure you replace
+`<path to your binary folder>` with your local bin directory.
+
+``` bash
+export PATH="<path to your binary folder>:$PATH"
+```
+
+This will allow you to run the locally built version of helm from your terminal.
+
 ## Contribution Guidelines
 
 We welcome contributions. This project has set up some guidelines in order to

--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -53,6 +53,22 @@ If you have a plugin tar distribution, simply untar the plugin into the
 directly from url by issuing `helm plugin install
 https://domain/path/to/plugin.tar.gz`
 
+## Testing a locally built Plugin
+
+First you need to find your `HELM_PLUGINS` path to do it run the folowing command:
+
+``` bash
+helm env
+```
+
+Change your current directory to the director that `HELM_PLUGINS` is set to.
+
+Now you can add a symbolic link to your build out put of your plugin in this example we did it for `mapkubeapis`.
+
+``` bash
+ln -s ~/GitHub/helm-mapkubeapis ./helm-mapkubeapis
+```
+
 ## Building Plugins
 
 In many ways, a plugin is similar to a chart. Each plugin has a top-level


### PR DESCRIPTION
Small doc's update to explain to developers how to test helm and plugins locally.