### PR TITLE
Add Aptakube to "Related Projects and Documentation"

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -60,6 +60,7 @@ tag on their plugin repositories.
 
 Tools layered on top of Helm.
 
+- [Aptakube](https://aptakube.com) - Desktop UI for Kubernetes and Helm Releases
 - [Armada](https://airshipit.readthedocs.io/projects/armada/en/latest/) - Manage
   prefixed releases throughout various Kubernetes namespaces, and removes
   completed jobs for complex deployments


### PR DESCRIPTION
Aptakube has supported Helm for some time now, and a user recently suggested adding it here.

<img width="961" alt="image" src="https://github.com/user-attachments/assets/4689d82e-553b-459f-a955-f7d64502da2b">
