### PR TITLE
Fix: typo in data_types.md

### DIFF
--- a/content/en/docs/chart_template_guide/data_types.md
+++ b/content/en/docs/chart_template_guide/data_types.md
@@ -22,5 +22,5 @@ part, variables will be exposed as one of the following types:
 
 There are many other types in Go, and sometimes you will have to convert between
 them in your templates. The easiest way to debug an object's type is to pass it
-through `printf "%t"` in a template, which will print the type. Also see the
+through `printf "%T"` in a template, which will print the type. Also see the
 `typeOf` and `kindOf` functions.


### PR DESCRIPTION
According to the [go docs](https://pkg.go.dev/fmt)
- %t	the word true or false
- %T	a Go-syntax representation of the type of the value