### PR TITLE
Adding kubecon NA SLC to upcoming events

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,7 @@ jsFiles = [
 ]
 
 [[params.versions]]
-version = "v3.16.0"
+version = "v3.16.2"
 patch = "stable"
 url = "https://helm.sh/docs"
 primary = true

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -133,7 +133,7 @@ other = "Events"
 other = "Upcoming Events"
 
 [community_upcoming_events_desc]
-other = "Watch this space..."
+other = "_Nov 14th 2024_ - [KubeCon North America](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)"
 
 [community_past_events_title]
 other = "Past Events"


### PR DESCRIPTION
Note, also bumped current Helm version