### PR TITLE
Add Dockerfile and .dockerignore with targets in Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore node_modules directory
+node_modules
+
+# Ignore any log files
+*.log
+
+# Ignore Dockerfile and .dockerignore itself
+Dockerfile
+.dockerignore
+
+# Ignore git repository files
+.git
+.gitignore
+
+# Ignore temporary files
+tmp
+*.tmp
+
+# Ignore build output
+dist
+build
+resources
+app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM hugomods/hugo:node
+ARG HUGO_VERSION=
+FROM hugomods/hugo:node-${HUGO_VERSION}
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM hugomods/hugo:node
+
+WORKDIR /src
+
+RUN apk update && apk add --no-cache make curl bash
+
+RUN npm install yarn
+
+COPY . .
+
+RUN npx yarn install
+
+EXPOSE 1313
+
+ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,15 @@ run-link-checker:
 	bin/htmltest
 
 check-links-ci: set-up-link-checker run-link-checker
+
+serve:
+	hugo server --buildDrafts --buildFuture --bind 0.0.0.0
+
+image:
+	docker build -t helm-docs .
+
+# Extract the target after 'image-run' or default to 'serve'
+DOCKER_TARGET = $(if $(filter-out image-run,$(MAKECMDGOALS)),$(filter-out image-run,$(MAKECMDGOALS)),serve)
+
+image-run:
+	docker run --rm --init -it -p 1313:1313 -v $(PWD):/src helm-docs $(DOCKER_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ check-links-ci: set-up-link-checker run-link-checker
 serve:
 	hugo server --buildDrafts --buildFuture --bind 0.0.0.0
 
+HUGO_VERSION ?= $(shell grep HUGO_VERSION ./netlify.toml | head -1 | cut -d '"' -f 2)
+
+IMAGE_NAME ?= helm-docs
+
 image:
-	docker build -t helm-docs .
+	docker build --build-arg HUGO_VERSION=$(HUGO_VERSION) -t $(IMAGE_NAME) .
 
 # Extract the target after 'image-run' or default to 'serve'
 DOCKER_TARGET = $(if $(filter-out image-run,$(MAKECMDGOALS)),$(filter-out image-run,$(MAKECMDGOALS)),serve)
 
 image-run:
-	docker run --rm --init -it -p 1313:1313 -v $(PWD):/src helm-docs $(DOCKER_TARGET)
+	docker run --rm --init -it -p 1313:1313 -v $(PWD):/src $(IMAGE_NAME) $(DOCKER_TARGET)


### PR DESCRIPTION
Resolve: #1591

This PR adds `serve`, `image` and `image-run` targets to the Makefile. This allows you to build and run a container locally with the latest Hugo version to serve the Helm documentation.

Use `make image` to build the container locally. `make image-run [target]` allows you to run specific targets from the Makefile using the container; running `make image-run` is the same as `make image-run serve`, it runs Hugo in the container to serve the documentation locally.

In case you already have Hugo installed, feel free to use it with the `make serve` target.

