### PR TITLE
chore: remove unused redirects to reduce confusion

### DIFF
--- a/content/code/chartmuseum.md
+++ b/content/code/chartmuseum.md
@@ -1,5 +1,0 @@
----
-name: "chartmuseum"
-repoURL: "https://github.com/helm/chartmuseum"
-branch: "main"
----

--- a/content/code/helm-v2.md
+++ b/content/code/helm-v2.md
@@ -1,6 +1,0 @@
----
-url: "helm/v2"
-name: "helm/v2"
-repoURL: "https://github.com/helm/helm"
-branch: "dev-v2"
----

--- a/content/code/helm-v3.md
+++ b/content/code/helm-v3.md
@@ -1,6 +1,0 @@
----
-url: "helm/v3"
-name: "helm/v3"
-repoURL: "https://github.com/helm/helm"
-branch: "main"
----

--- a/content/code/helm.md
+++ b/content/code/helm.md
@@ -1,5 +1,0 @@
----
-name: "helm"
-repoURL: "https://github.com/helm/helm"
-branch: "main"
----


### PR DESCRIPTION
These redirects removed in this PR are not used. The extra files cause confusion and delay.

These redirects *are* used: https://github.com/helm/helm-www/tree/main/content/en/code

Validate redirects from this PRs preview:
https://deploy-preview-1645--helm-merge.netlify.app/chartmuseum
https://deploy-preview-1645--helm-merge.netlify.app/helm
https://deploy-preview-1645--helm-merge.netlify.app/helm/v2
https://deploy-preview-1645--helm-merge.netlify.app/helm/v3
