### PR TITLE
fix: clarify that the repo is a chart repository

### DIFF
--- a/content/en/docs/intro/install.md
+++ b/content/en/docs/intro/install.md
@@ -27,7 +27,7 @@ and installed.
    destination (`mv linux-amd64/helm /usr/local/bin/helm`)
 
 From there, you should be able to run the client and [add the stable
-repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository):
+chart repository](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository):
 `helm help`.
 
 **Note:** Helm automated tests are performed for Linux AMD64 only during
@@ -183,4 +183,4 @@ sophisticated things with Helm.
 
 Once you have the Helm Client successfully installed, you can move on to using
 Helm to manage charts and [add the stable
-repo](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository).
+chart repository](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository).


### PR DESCRIPTION
It appears the wording of "stable repo" may have been confusing since installation may come from a repo..

Closes: https://github.com/TerryHowe/helm-www/pull/new/add-chart-repository