### PR TITLE
fix: yaml examples with bad doc separator

### DIFF
--- a/content/en/docs/chart_template_guide/accessing_files.md
+++ b/content/en/docs/chart_template_guide/accessing_files.md
@@ -176,6 +176,7 @@ conjunction with the `Glob` method.
 Given the directory structure from the [Glob](#glob-patterns) example above:
 
 ```yaml
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/content/en/docs/chart_template_guide/variables.md
+++ b/content/en/docs/chart_template_guide/variables.md
@@ -128,6 +128,7 @@ in a range and you need to know the chart's release name.
 An example illustrating this:
 ```yaml
 {{- range .Values.tlsSecrets }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -146,7 +147,6 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate }}
   tls.key: {{ .key }}
----
 {{- end }}
 ```
 


### PR DESCRIPTION
Closes: https://github.com/helm/helm-www/issues/1513