### PR TITLE
chore: add stale issue workflow

### DIFF
--- a/.github/workflow/stale.yml
+++ b/.github/workflow/stale.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "30 1 * * *"
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as stale because it has been open for 90 days with no activity. This thread will be automatically closed in 30 days if no further activity occurs.'
+        exempt-issue-labels: 'keep open,v4.x,in progress'
+        days-before-issue-stale: 90
+        days-before-issue-close: 30
+        operations-per-run: 100


### PR DESCRIPTION
Add a stale issue workflow to the web site just like the one to the CLI.

This job does run at a different time though.