### PR TITLE
fix: get rid of build warning

### DIFF
--- a/themes/helm/layouts/_default/list.html
+++ b/themes/helm/layouts/_default/list.html
@@ -1,0 +1,68 @@
+{{ define "title" }}
+Helm | Docs
+{{ end }}
+
+{{ define "main" }}
+{{ $isDocsRoot := eq .CurrentSection .FirstSection }}
+
+<div id="helm" class="page-docs page-wrapper page-docs-list">
+  <header>
+    {{ partial "banner.html" . }}
+    {{ partial "nav.html" . }}
+    {{ partial "nav-fixed.html" . }}
+  </header>
+
+  <div class="columns" id="helm">
+    <aside class="column is-narrow is-gapless sidebar-wrapper">
+      {{ partial "sidebar.html" . }}
+    </aside>
+    
+    <section class="column content-docs">
+      <article class="content-wrapper">
+        {{ .Content }}
+
+        <section class="quick-links clearfix">
+          <h3 class="text-center">Quicklinks</h3>
+          
+          {{ if $isDocsRoot }}
+          {{ $quicklinks := site.Params.quicklinks }}
+          {{ range $quicklinks }}
+          <a href="{{ .url }}" class="quick-item clearfix"> 
+            <h4>
+              {{ .title }}
+              {{ with .via }}
+              &nbsp;<small><i class="fa fa-external-link"></i></small>
+              {{ end }}
+            </h4>
+            <p>
+              {{ .description }}
+              {{ with .via }}
+              - <small>
+                (via {{ . }})
+              </small>
+              {{ end }}
+            </p>
+          </a>
+          {{ end }}
+
+          {{ else }}
+
+          {{ range .Pages }}
+          <a href="{{ .RelPermalink }}" class="quick-item">
+            <h4>
+              {{ .Title }}
+            </h4>
+            <p>
+              {{ .Description }}
+            </p>
+          </a>
+          {{ end }}
+          {{ end }}
+        </section>
+      </article>
+    </section>
+  </div>
+</div>
+
+{{ partial "footer-links.html" . }}
+{{ end }}

--- a/themes/helm/layouts/_default/single.html
+++ b/themes/helm/layouts/_default/single.html
@@ -1,0 +1,50 @@
+{{ define "title" }}
+Helm | {{ .Title }}
+{{ end }}
+
+{{ define "main" }}
+
+<div id="helm" class="page-docs page-wrapper page-docs-list">
+  <header>
+    {{ partial "banner.html" . }}
+    {{ partial "nav.html" . }}
+    {{ partial "nav-fixed.html" . }}
+  </header>
+
+  <div class="columns" id="helm">
+    <aside class="column is-narrow is-gapless sidebar-wrapper">
+      {{ partial "sidebar.html" . }}
+    </aside>
+    
+    <section class="column content-docs">
+      <article class="content-wrapper">
+        <h1>{{ .Title }}</h1>
+        
+        {{ .Content }}
+
+        <nav class="level prev-next">
+          <div class="level-left level-item">
+            {{ if .NextInSection }}
+            <a class="" href="{{ .NextInSection.Permalink }}" title="{{ .Title }}">
+              <small class="heading">Prev</small>
+              <p class="title">← {{ .NextInSection.Title }}</p>
+            </a>
+            {{ end }}
+          </div>
+          
+          <div class="level-right level-item has-text-right">
+            {{ if .PrevInSection }}
+            <a class="" href="{{ .PrevInSection.Permalink }}" title="{{ .Title }}">
+              <small class="heading">Next</small>
+              <p class="title">{{ .PrevInSection.Title }} →</p>
+            </a>
+            {{ end }}
+          </div>
+        </nav>
+      </article>
+    </section>
+  </div>
+</div>
+
+{{ partial "footer-links.html" . }}
+{{ end }}


### PR DESCRIPTION
This change gets rid of this warning:

```
WARN  found no layout file for "html" for kind "section": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
```