### PR TITLE
clarify global scope meaning for named templates

### DIFF
--- a/content/en/docs/chart_template_guide/named_templates.md
+++ b/content/en/docs/chart_template_guide/named_templates.md
@@ -219,7 +219,7 @@ metadata:
 
 Note that we pass `.` at the end of the `template` call. We could just as easily
 pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want
-is the top-level scope. Note that in the context of the named template `$` will refer
+is the top-level scope. In the context of the named template `$` will refer
 to the scope you passed in and not some global scope.
 
 Now when we execute this template with `helm install --dry-run --debug

--- a/content/en/docs/chart_template_guide/named_templates.md
+++ b/content/en/docs/chart_template_guide/named_templates.md
@@ -219,7 +219,7 @@ metadata:
 
 Note that we pass `.` at the end of the `template` call. We could just as easily
 pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want
-is the top-level scope. In the context of the named template `$` will refer
+is the top-level scope. In the context of the named template, `$` will refer
 to the scope you passed in and not some global scope.
 
 Now when we execute this template with `helm install --dry-run --debug

--- a/content/en/docs/chart_template_guide/named_templates.md
+++ b/content/en/docs/chart_template_guide/named_templates.md
@@ -219,7 +219,8 @@ metadata:
 
 Note that we pass `.` at the end of the `template` call. We could just as easily
 pass `.Values` or `.Values.favorite` or whatever scope we want. But what we want
-is the top-level scope.
+is the top-level scope. Note that in the context of the named template `$` will refer
+to the scope you passed in and not some global scope.
 
 Now when we execute this template with `helm install --dry-run --debug
 plinking-anaco ./mychart`, we get this:

--- a/content/en/docs/chart_template_guide/variables.md
+++ b/content/en/docs/chart_template_guide/variables.md
@@ -121,8 +121,8 @@ That variable will be in scope for the entire template. But in our last example,
 `$key` and `$val` will only be in scope inside of the `{{ range... }}{{ end }}`
 block.
 
-However, there is one variable that is always global - `$` - this variable will
-always point to the root context. This can be very useful when you are looping
+However, there is one variable that will always point to the root context: - `$` -.
+This can be very useful when you are looping
 in a range and you need to know the chart's release name.
 
 An example illustrating this:


### PR DESCRIPTION
I just got bitten by the fact that you cannot use the `$` sign to access the root context when using a named template.

This should solve #1399