### PR TITLE
Adding redirect for helm/v4 to the code

### DIFF
--- a/content/en/code/helm-v4.md
+++ b/content/en/code/helm-v4.md
@@ -1,0 +1,6 @@
+---
+url: "helm/v4"
+name: "helm/v4"
+repoURL: "https://github.com/helm/helm"
+branch: "main"
+---


### PR DESCRIPTION
Helm uses custom URLs to get to the code. In this case helm.sh/helm/v4 should point to the main branch for helm so that people who try to use it with go modules are able to.

This change adds that redirect to the default language which means it should work for everyone.