### PR TITLE
Add plugin `helm-tui`

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -52,6 +52,7 @@ request](https://github.com/helm/helm-www/pulls).
 - [helm-external-val](https://github.com/kuuji/helm-external-val) - A plugin that fetches helm values from external sources (configMaps, Secrets, etc.)
 - [helm-images](https://github.com/nikhilsbhat/helm-images) - Helm plugin to fetch all possible images from the chart before deployment or from a deployed release
 - [helm-drift](https://github.com/nikhilsbhat/helm-drift) - Helm plugin that identifies the configuration that has drifted from the Helm chart
+- [helm-tui](https://github.com/pidanou/helm-tui) - A light UI to manage your Helm assets without leaving the terminal
 
 We also encourage GitHub authors to use the
 [helm-plugin](https://github.com/search?q=topic%3Ahelm-plugin&type=Repositories)


### PR DESCRIPTION
https://github.com/pidanou/helm-tui

It's a terminal UI written in GO, the objective is to have a simple way to manage Helm assets without typing all the commands