### PR TITLE
fix: suggest using registry over repository

### DIFF
--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -13,7 +13,7 @@ The distributed community Helm chart repository is located at
 [Artifact Hub](https://artifacthub.io/packages/search?kind=0) and welcomes
 participation. But Helm also makes it possible to create and run your own chart
 repository. This guide explains how to do so. If you are considering creating a
-chart repository, you should consider using an
+chart repository, you may want to consider using an
 [OCI registry]({{< ref "/docs/topics/registries.md" >}}) instead.
 
 ## Prerequisites

--- a/content/en/docs/topics/chart_repository.md
+++ b/content/en/docs/topics/chart_repository.md
@@ -12,7 +12,9 @@ and shared.
 The distributed community Helm chart repository is located at
 [Artifact Hub](https://artifacthub.io/packages/search?kind=0) and welcomes
 participation. But Helm also makes it possible to create and run your own chart
-repository. This guide explains how to do so.
+repository. This guide explains how to do so. If you are considering creating a
+chart repository, you should consider using an
+[OCI registry]({{< ref "/docs/topics/registries.md" >}}) instead.
 
 ## Prerequisites
 


### PR DESCRIPTION
During my Helm booth duty at Kubecon in SLC a user had not considered using a registry to store charts. It seems like that should be more clear as a possibility.