### PR TITLE
docs: add a warning about default value for condition

### DIFF
--- a/content/en/docs/chart_best_practices/dependencies.md
+++ b/content/en/docs/chart_best_practices/dependencies.md
@@ -58,6 +58,9 @@ is in a sub-directory of the `charts` folder with the name being the same as the
 
 Conditions or tags should be added to any dependencies that _are optional_.
 
+> [!IMPORTANT]
+> By default a `condition` is `true`.
+
 The preferred form of a condition is:
 
 ```yaml


### PR DESCRIPTION
this warning seems important because the default value is usually `false`