### PR TITLE
Replace deprecated "helm delete" with "helm uninstall"

### DIFF
--- a/content/en/docs/howto/chart_releaser_action.md
+++ b/content/en/docs/howto/chart_releaser_action.md
@@ -46,7 +46,7 @@ To install the <chart-name> chart:
 
 To uninstall the chart:
 
-    helm delete my-<chart-name>
+    helm uninstall my-<chart-name>
 ```
 
 The charts will be published to a website with URL like this:

--- a/content/es/docs/howto/chart_releaser_action.md
+++ b/content/es/docs/howto/chart_releaser_action.md
@@ -38,7 +38,7 @@ helm install my-<chart-name> <alias>/<chart-name>
 ```
 Para desinstalar el chart:
 ```
-helm delete my-<chart-name>
+helm uninstall my-<chart-name>
 ```
 
 Los charts se publicarán en un sitio web con una URL como esta:

--- a/content/uk/docs/howto/chart_releaser_action.md
+++ b/content/uk/docs/howto/chart_releaser_action.md
@@ -33,7 +33,7 @@ weight: 3
 
 Щоб видалити чарт:
 
-    helm delete my-<chart-name>
+    helm uninstall my-<chart-name>
 ```
 
 Чарти будуть опубліковані на вебсайті з URL-адресою типу:

--- a/content/zh/docs/howto/chart_releaser_action.md
+++ b/content/zh/docs/howto/chart_releaser_action.md
@@ -39,7 +39,7 @@ To install the <chart-name> chart:
 
 To uninstall the chart:
 
-    helm delete my-<chart-name>
+    helm uninstall my-<chart-name>
 ```
 
 发布后的chart的url类似这样：


### PR DESCRIPTION
The PR replaces deprecated `helm delete` command with `helm uninstall` on the `chart_releaser_action.md` pages.