### PR TITLE
docs: add note about namespace-scoped resources

### DIFF
--- a/content/en/docs/chart_template_guide/functions_and_pipelines.md
+++ b/content/en/docs/chart_template_guide/functions_and_pipelines.md
@@ -203,7 +203,8 @@ The synopsis of the lookup function is `lookup apiVersion, kind, namespace, name
 | name       | string |
 
 Both `name` and `namespace` are optional and can be passed as an empty string
-(`""`).
+(`""`). However, if you're working with a namespace-scoped resource, both `name`
+and `namespace` must be specified.
 
 The following combination of parameters are possible:
 


### PR DESCRIPTION
Hi :wave:,

Regarding `lookup` function, I discovered that this point needs to be explicitly written.