### PR TITLE
fix: typo in CheatSheet.md

### DIFF
--- a/content/en/docs/intro/CheatSheet.md
+++ b/content/en/docs/intro/CheatSheet.md
@@ -120,7 +120,7 @@ helm get values <release>   # Downloads a values file for a given release. use -
 ### Plugin Management
 
 ```bash
-helm plugin install <path/url1>     # Install plugins
+helm plugin install <path/url>      # Install plugins
 helm plugin list                    # View a list of all installed plugins
 helm plugin update <plugin>         # Update plugins
 helm plugin uninstall <plugin>      # Uninstall a plugin


### PR DESCRIPTION
fix from `ulr1` to `url`