### PR TITLE
Fix broken links for sdk examples source

### DIFF
--- a/content/en/docs/sdk/examples.md
+++ b/content/en/docs/sdk/examples.md
@@ -9,7 +9,7 @@ Intended to document various SDK functionalities.
 
 The final example shows `main.go` driver ([link](#driver)). That runs the below actions and includes necessary helper functions.
 
-The code for the examples lives in the [helm/helm-www/sdkexamples/](https://github.com/helm/helm-www/sdkexamples) directory.
+The code for the examples lives in the [helm/helm-www/sdkexamples/](https://github.com/helm/helm-www/tree/main/sdkexamples) directory.
 And is intended to be fully functional.
 
 ## Actions

--- a/content/uk/docs/sdk/examples.md
+++ b/content/uk/docs/sdk/examples.md
@@ -8,7 +8,7 @@ weight: 2
 
 Останній приклад показує драйвер `main.go` ([посилання](#driver)). Він виконує наведені нижче дії та включає необхідні допоміжні функції.
 
-Код для прикладів знаходиться в директорії [helm/helm-www/sdkexamples/](https://github.com/helm/helm-www/sdkexamples). І він повністю функціональний.
+Код для прикладів знаходиться в директорії [helm/helm-www/sdkexamples/](https://github.com/helm/helm-www/tree/main/sdkexamples). І він повністю функціональний.
 
 ## Дії {#actions}
 


### PR DESCRIPTION
Current link is [broken](https://github.com/helm/helm-www/sdkexamples).