### PR TITLE
Update args that will be consumed by the root helm command

### DIFF
--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -334,14 +334,22 @@ will be set as the `KUBECONFIG` variable
 
 When executing a plugin, Helm will parse global flags for its own use. None of
 these flags are passed on to the plugin.
-
+- `--burst-limit`: This is converted to `$HELM_BURST_LIMIT`
 - `--debug`: If this is specified, `$HELM_DEBUG` is set to `1`
+- `--kube-apiserver`: This is converted to `$HELM_KUBEAPISERVER`
+- `--kube-as-group`: These are converted to `$HELM_KUBEASGROUPS`
+- `--kube-as-user`: This is converted to `$HELM_KUBEASUSER`
+- `--kube-ca-file`: This is converted to `$HELM_KUBECAFILE`
+- `--kube-context`: This is converted to `$HELM_KUBECONTEXT`
+- `--kube-insecure-skip-tls-verify`: This is converted to `$HELM_KUBEINSECURE_SKIP_TLS_VERIFY`
+- `--kube-tls-server-name`: This is converted to `$HELM_KUBETLS_SERVER_NAME`
+- `--kube-token`: This is converted to `$HELM_KUBETOKEN`
+- `--kubeconfig`: This is converted to `$KUBECONFIG`
+- `--namespace` and `-n`: This is converted to `$HELM_NAMESPACE`
+- `--qps`: This is converted to `$HELM_QPS`
 - `--registry-config`: This is converted to `$HELM_REGISTRY_CONFIG`
 - `--repository-cache`: This is converted to `$HELM_REPOSITORY_CACHE`
 - `--repository-config`: This is converted to `$HELM_REPOSITORY_CONFIG`
-- `--namespace` and `-n`: This is converted to `$HELM_NAMESPACE`
-- `--kube-context`: This is converted to `$HELM_KUBECONTEXT`
-- `--kubeconfig`: This is converted to `$KUBECONFIG`
 
 Plugins _should_ display help text and then exit for `-h` and `--help`. In all
 other cases, plugins may use flags as appropriate.

--- a/content/ko/docs/topics/plugins.md
+++ b/content/ko/docs/topics/plugins.md
@@ -193,13 +193,22 @@ Helm은 플러그인을 실행할 때, 외부 환경을 플러그인에 전달�
 플러그인을 실행할 때 헬름은 자체 사용을 위해 전역 플래그를 구문 분석한다. 
 이러한 플래그는 플러그인에 전달되지 않는다.
 
+- `--burst-limit`: 이 플래그는 `$HELM_BURST_LIMIT` 로 변환된다.
 - `--debug`: 지정하면`$ HELM_DEBUG`가`1`로 설정된다.
-- `--registry-config`: 이 플래그는 `$ HELM_REGISTRY_CONFIG` 로 변환된다.
-- `--repository-cache`: 이 플래그는 `$ HELM_REPOSITORY_CACHE` 로 변환된다.
-- `--repository-config`: 이 플래그는 `$ HELM_REPOSITORY_CONFIG` 로 변환된다.
-- `--namespace` and `-n`: 이 플래그는 `$ HELM_NAMESPACE` 로 변환된다.
-- `--kube-context`: 이 플래그는 `$ HELM_KUBECONTEXT` 로 변환된다.
+- `--kube-apiserver`: 이 플래그는 `$HELM_KUBEAPISERVER` 로 변환된다.
+- `--kube-as-group`: 이 플래그는 `$HELM_KUBEASGROUPS` 로 변환된다.
+- `--kube-as-user`: 이 플래그는 `$HELM_KUBEASUSER` 로 변환된다.
+- `--kube-ca-file`: 이 플래그는 `$HELM_KUBECAFILE` 로 변환된다.
+- `--kube-context`: 이 플래그는 `$HELM_KUBECONTEXT` 로 변환된다.
+- `--kube-insecure-skip-tls-verify`: 이 플래그는 `$HELM_KUBEINSECURE_SKIP_TLS_VERIFY` 로 변환된다.
+- `--kube-tls-server-name`: 이 플래그는 `$HELM_KUBETLS_SERVER_NAME` 로 변환된다.
+- `--kube-token`: 이 플래그는 `$HELM_KUBETOKEN` 로 변환된다.
 - `--kubeconfig`: 이 플래그는 `$KUBECONFIG` 로 변환된다.
+- `--namespace` and `-n`: 이 플래그는 `$HELM_NAMESPACE` 로 변환된다.
+- `--qps`: 이 플래그는 `$HELM_QPS` 로 변환된다.
+- `--registry-config`: 이 플래그는 `$HELM_REGISTRY_CONFIG` 로 변환된다.
+- `--repository-cache`: 이 플래그는 `$HELM_REPOSITORY_CACHE` 로 변환된다.
+- `--repository-config`: 이 플래그는 `$HELM_REPOSITORY_CONFIG` 로 변환된다.
 
 플러그인은 도움말 텍스트를 표시한 다음 `-h` 및 `--help` 를 위해 _종료해야 한다_. 
 다른 모든 경우에는, 플러그인은 적절하게 플래그를 사용할 수 있다.

--- a/content/uk/docs/topics/plugins.md
+++ b/content/uk/docs/topics/plugins.md
@@ -162,14 +162,22 @@ downloaders:
 ## Примітка про парсинг прапорців {#note-on-flag-parsing}
 
 При виконанні втулка Helm буде розбирати глобальні прапорці для власного використання. Жоден з цих пропорців не передається втулку.
-
+- `--burst-limit`: Це перетворюється в `$HELM_BURST_LIMIT`.
 - `--debug`: Якщо цей прапорець вказаний, `$HELM_DEBUG` встановлюється в `1`.
+- `--kube-apiserver`: Це перетворюється в `$HELM_KUBEAPISERVER`.
+- `--kube-as-group`: Ці перетворюються в `$HELM_KUBEASGROUPS`.
+- `--kube-as-user`: Це перетворюється в `$HELM_KUBEASUSER`.
+- `--kube-ca-file`: Це перетворюється в `$HELM_KUBECAFILE`.
+- `--kube-context`: Це перетворюється в `$HELM_KUBECONTEXT`.
+- `--kube-insecure-skip-tls-verify`: Це перетворюється в `$HELM_KUBEINSECURE_SKIP_TLS_VERIFY`.
+- `--kube-tls-server-name`: Це перетворюється в `$HELM_KUBETLS_SERVER_NAME`.
+- `--kube-token`: Це перетворюється в `$HELM_KUBETOKEN`.
+- `--kubeconfig`: Це перетворюється в `$KUBECONFIG`.
+- `--namespace` and `-n`: Це перетворюється в `$HELM_NAMESPACE`.
+- `--qps`: Це перетворюється в `$HELM_QPS`.
 - `--registry-config`: Це перетворюється в `$HELM_REGISTRY_CONFIG`.
 - `--repository-cache`: Це перетворюється в `$HELM_REPOSITORY_CACHE`.
 - `--repository-config`: Це перетворюється в `$HELM_REPOSITORY_CONFIG`.
-- `--namespace` та `-n`: Це перетворюється в `$HELM_NAMESPACE`.
-- `--kube-context`: Це перетворюється в `$HELM_KUBECONTEXT`.
-- `--kubeconfig`: Це перетворюється в `$KUBECONFIG`.
 
 Втулки _повинні_ відображати текст довідки та виходити для `-h` та `--help`. У всіх інших випадках втулки можуть використовувати прапорці за потреби.
 


### PR DESCRIPTION
The flag parsing section of the plugins guide does not contain an up-to-date list of global helm args.
```
      --burst-limit int               missing in documentation and currently passed to plugins
      --kube-apiserver string    missing in documentation
      --kube-as-group stringArray    missing in documentation
      --kube-as-user string             missing in documentation
      --kube-ca-file string             missing in documentation
      --kube-insecure-skip-tls-verify   missing in documentation
      --kube-tls-server-name string     missing in documentation
      --kube-token string              missing in documentation
      --qps float32                    missing in documentation and currently passed to plugins
```

First, this PR re-orders the flags so that they appear in alphabetical order - the same order as `helm --help`

This PR adds the missing global args to the plugin documentation. I made a best effort to also update the other languages.
For Ukrainian (uk) - I can mostly vouch. One difference I'd like to point out is I used the plural `Ці перетворюються` for -kube-as-user, as this is a stringArray parameter.
For Korean, I simply reused the same format as other strings. If someone could help with using a plural form, feel free to add a suggestion.

Some flags in this PR are currently also passed to plugins. For this reason, I provide a pr in helm/helm:
https://github.com/helm/helm/pull/30614