### PR TITLE
chore: remove archived and update plugin link

### DIFF
--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -36,8 +36,6 @@ request](https://github.com/helm/helm-www/pulls).
 - [helm-release-plugin](https://github.com/JovianX/helm-release-plugin) - Plugin for Release management, Update release values, pulls(re-creates) helm Charts from deployed releases, set helm release TTL.
 - [helm-s3](https://github.com/hypnoglow/helm-s3) - Helm plugin that allows to
   use AWS S3 as a [private] chart repository
-- [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) - Helm
-  Plugin that generates values yaml schema for your Helm 3 charts
 - [helm-secrets](https://github.com/jkroepke/helm-secrets) - Plugin to manage
   and store secrets safely (based on [sops](https://github.com/mozilla/sops))
 - [helm-sigstore](https://github.com/sigstore/helm-sigstore) -
@@ -46,7 +44,7 @@ request](https://github.com/helm/helm-www/pulls).
   rendering Tanka/Jsonnet inside Helm charts.
 - [hc-unit](https://github.com/xchapter7x/hcunit) - Plugin for unit testing
   charts locally using OPA (Open Policy Agent) & Rego
-- [helm-unittest](https://github.com/quintush/helm-unittest) - Plugin for unit
+- [helm-unittest](https://github.com/helm-unittest/helm-unittest) - Plugin for unit
   testing chart locally with YAML
 - [helm-val](https://github.com/HamzaZo/helm-val) - A plugin to get
   values from a previous release.

--- a/content/ko/docs/community/related.md
+++ b/content/ko/docs/community/related.md
@@ -21,14 +21,12 @@ weight: 3
   릴리스 및 롤백을 모니터링하는 플러그인
 - [helm-k8comp](https://github.com/cststack/k8comp) - k8comp 를 사용하여 hiera 에서 
   헬름 차트를 생성하는 플러그인
-- [helm-unittest](https://github.com/lrills/helm-unittest) - YAML로 
+- [helm-unittest](https://github.com/helm-unittest/helm-unittest) - YAML로 
   로컬에서 차트를 단위 테스트하기 위한 플러그인
 - [hc-unit](https://github.com/xchapter7x/hcunit) - OPA (Open Policy Agent) 및 Rego로
   로컬에서 차트를 단위 테스트하기 위한 플러그인
 - [helm-s3](https://github.com/hypnoglow/helm-s3) - [프라이빗] 차트 저장소로 AWS S3를 
   사용할 수 있게 해주는 헬름 플러그인
-- [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) - 헬름 3 차트에 대한 
-  값(values) yaml 스키마를 생성하는 헬름 플러그인
 - [helm-secrets](https://github.com/jkroepke/helm-secrets) - 비밀정보를 안전하게 관리하고
   보관하기 위한 플러그인 ([sops](https://github.com/mozilla/sops) 기반)
 

--- a/content/uk/docs/community/related.md
+++ b/content/uk/docs/community/related.md
@@ -23,12 +23,11 @@ weight: 3
 - [helm-monitor](https://github.com/ContainerSolutions/helm-monitor) — Втулок для моніторингу релізу та відкату на основі запиту Prometheus/ElasticSearch.
 - [helm-release-plugin](https://github.com/JovianX/helm-release-plugin) — Втулок для управління релізами, оновлення значень релізу, витягує (перестворює) Helm чарти з розгорнутих релізів, встановлює TTL релізу Helm.
 - [helm-s3](https://github.com/hypnoglow/helm-s3) — Втулок Helm, який дозволяє використовувати AWS S3 як [приватний] репозиторій чартів.
-- [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) — Втулок Helm, який генерує схему yaml значень для ваших Helm 3 чартів.
 - [helm-secrets](https://github.com/jkroepke/helm-secrets) — Втулок для безпечного керування та зберігання секретів (на основі [sops](https://github.com/mozilla/sops)).
 - [helm-sigstore](https://github.com/sigstore/helm-sigstore) — Втулок для Helm для інтеграції з екосистемою [sigstore](https://sigstore.dev/). Пошук, завантаження та перевірка підписаних Helm чартів.
 - [helm-tanka](https://github.com/Duologic/helm-tanka) — Втулок Helm для рендерингу Tanka/Jsonnet всередині Helm чартів.
 - [hc-unit](https://github.com/xchapter7x/hcunit) — Втулок для юніт-тестування чартів локально за допомогою OPA (Open Policy Agent) & Rego.
-- [helm-unittest](https://github.com/quintush/helm-unittest) — Втулок для юніт-тестування чартів локально з YAML.
+- [helm-unittest](https://github.com/helm-unittest/helm-unittest) — Втулок для юніт-тестування чартів локально з YAML.
 - [helm-val](https://github.com/HamzaZo/helm-val) — Втулок для отримання значень з попереднього релізу.
 - [helm-external-val](https://github.com/kuuji/helm-external-val) — Втулок, який отримує значення helm з зовнішніх джерел (configMaps, Secrets тощо).
 - [helm-images](https://github.com/nikhilsbhat/helm-images) — Втулок Helm для отримання всіх можливих зображень з чарту перед розгортанням або з розгорнутого релізу.

--- a/content/zh/docs/community/related.md
+++ b/content/zh/docs/community/related.md
@@ -23,15 +23,13 @@ chart的helm v3插件。
   Prometheus/ElasticSearch的用于监控版本发布和回滚的插件
 - [helm-release-plugin](https://github.com/JovianX/helm-release-plugin) - 该插件用于管理已部署的release，更新release值，拉取（重建）helm chart，以及设置helm release TTL。
 - [helm-s3](https://github.com/hypnoglow/helm-s3) - 允许使用AWS S3作为[私有]chart仓库的插件
-- [helm-schema-gen](https://github.com/karuppiah7890/helm-schema-gen) - 为Helm
-  3生成values的yaml框架的插件
 - [helm-secrets](https://github.com/jkroepke/helm-secrets) - 安全存储密钥的插件
   （基于[sops](https://github.com/mozilla/sops)）
 - [helm-sigstore](https://github.com/sigstore/helm-sigstore) - Helm集成[sigstore](https://sigstore.dev/)生态的插件。
 用于搜索、上传及验证已签名的Helm chart。
 - [helm-tanka](https://github.com/Duologic/helm-tanka) - 在Helm chart中渲染Tanka/Jsonnet的插件
 - [hc-unit](https://github.com/xchapter7x/hcunit) - 使用OPA (Open Policy Agent) 和 Rego本地进行chart单元测试的插件
-- [helm-unittest](https://github.com/quintush/helm-unittest) - 使用YAML本地进行chart单元测试的插件
+- [helm-unittest](https://github.com/helm-unittest/helm-unittest) - 使用YAML本地进行chart单元测试的插件
 - [helm-val](https://github.com/HamzaZo/helm-val) - 从之前的版本中获取值的插件
 - [helm-external-val](https://github.com/kuuji/helm-external-val) - 从外部资源（configMaps，
 Secrets等）获取Helm values的插件


### PR DESCRIPTION
Removes traces of archived plugin:
- `helm-schema-gen`

Change url of plugin:
- `helm-unittest`

---

resolves #1723 