### PR TITLE
Add tips to generate docs from Mac OS without the noise output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To update these docs, you'll need to:
 4. Commit the changes and create a PR to update the website.
 
 > [!TIP]
-> If you are on macOS and want to avoid unnecessary changes to the config location, you can use this Docker command from the `content/en/docs/helm/` folder
+> If you are on macOS and want to avoid unnecessary changes to the config location, you can use this Docker command from the `versioned_docs/version-${HELM_MAJOR_VERSION}/helm/` folder
 > ```
 > docker run --rm -v $(pwd):/output \
 >   --entrypoint /bin/bash \


### PR DESCRIPTION
Addressing @TerryHowe feedback. https://github.com/helm/helm-www/pull/1729#discussion_r2134695517

Generating doc using from Mac OS modify all `~/.config` path with one in `Application preferences` folder. With the Docker command path are preserved.