### PR TITLE
Fix typo in the korean docs

### DIFF
--- a/content/ko/docs/community/release_checklist.md
+++ b/content/ko/docs/community/release_checklist.md
@@ -366,7 +366,7 @@ Helm vX.Y.Z는 기능 릴리스이다. 이번 릴리스에서는 <insert focal p
 ## 주목할 만한 변화
 
 - Kubernetes 1.16은 이제 새 매니페스트 apiVersion도 지원한다.
-- Spring은 2.22으로 업그레이드되었다.
+- Sprig은 2.22으로 업그레이드되었다.
 
 ## 설치 및 업그레이드
 


### PR DESCRIPTION
- Replace “spring” with “sprig” in the korean docs