### PR TITLE
Clarify that the `with` action has an `else` clause

### DIFF
--- a/content/en/docs/chart_template_guide/control_structures.md
+++ b/content/en/docs/chart_template_guide/control_structures.md
@@ -259,11 +259,13 @@ The next control structure to look at is the `with` action. This controls
 variable scoping. Recall that `.` is a reference to _the current scope_. So
 `.Values` tells the template to find the `Values` object in the current scope.
 
-The syntax for `with` is similar to a simple `if` statement:
+The syntax for `with` is similar to the `if`/`else` block:
 
 ```
 {{ with PIPELINE }}
-  # restricted scope
+  # restricted scope, if PIPELINE is true
+{{ else }}
+  # restricted scope, if PIPELINE is false
 {{ end }}
 ```
 


### PR DESCRIPTION
Before this PR, there was no indication in Helm's docs that the `with` action has an `else` clause. This change clarifies that `else` exists for the `with` action.