### PR TITLE
Fix TOML syntax in "chart_template_guide/accessing_files"

### DIFF
--- a/content/en/docs/chart_template_guide/accessing_files.md
+++ b/content/en/docs/chart_template_guide/accessing_files.md
@@ -49,19 +49,19 @@ three directly inside of the `mychart/` directory.
 `config1.toml`:
 
 ```toml
-message = Hello from config 1
+message = "Hello from config 1"
 ```
 
 `config2.toml`:
 
 ```toml
-message = This is config 2
+message = "This is config 2"
 ```
 
 `config3.toml`:
 
 ```toml
-message = Goodbye from config 3
+message = "Goodbye from config 3"
 ```
 
 Each of these is a simple TOML file (think old-school Windows INI files). We
@@ -98,13 +98,13 @@ metadata:
   name: quieting-giraf-configmap
 data:
   config1.toml: |-
-    message = Hello from config 1
+    message = "Hello from config 1"
 
   config2.toml: |-
-    message = This is config 2
+    message = "This is config 2"
 
   config3.toml: |-
-    message = Goodbye from config 3
+    message = "Goodbye from config 3"
 ```
 
 ## Path helpers
@@ -220,7 +220,7 @@ metadata:
 type: Opaque
 data:
   token: |-
-    bWVzc2FnZSA9IEhlbGxvIGZyb20gY29uZmlnIDEK
+    bWVzc2FnZSA9ICJIZWxsbyBmcm9tIGNvbmZpZyAxIgo=
 ```
 
 ## Lines

--- a/content/ko/docs/chart_template_guide/accessing_files.md
+++ b/content/ko/docs/chart_template_guide/accessing_files.md
@@ -15,7 +15,7 @@ weight: 10
 
 - 헬름 차트에 파일을 추가해도 된다. 추가된 파일들은 하나로 묶인다.
   다만, 쿠버네티스 객체 저장소에는 제한이 있어
-  차트는 1M 보다 작아야 한다. 
+  차트는 1M 보다 작아야 한다.
 - 어떤 파일은 `.Files` 객체를 통해 액세스할 수 없는데,
   주로 보안 상의 이유 때문이다.
   - `templates/`에 있는 파일은 액세스할 수 없다.
@@ -46,19 +46,19 @@ three directly inside of the `mychart/` directory.
 `config1.toml`:
 
 ```toml
-message = Hello from config 1
+message = "Hello from config 1"
 ```
 
 `config2.toml`:
 
 ```toml
-message = This is config 2
+message = "This is config 2"
 ```
 
 `config3.toml`:
 
 ```toml
-message = Goodbye from config 3
+message = "Goodbye from config 3"
 ```
 
 Each of these is a simple TOML file (think old-school Windows INI files). We
@@ -95,13 +95,13 @@ metadata:
   name: quieting-giraf-configmap
 data:
   config1.toml: |-
-    message = Hello from config 1
+    message = "Hello from config 1"
 
   config2.toml: |-
-    message = This is config 2
+    message = "This is config 2"
 
   config3.toml: |-
-    message = Goodbye from config 3
+    message = "Goodbye from config 3"
 ```
 
 ## 경로 헬퍼
@@ -216,7 +216,7 @@ metadata:
 type: Opaque
 data:
   token: |-
-    bWVzc2FnZSA9IEhlbGxvIGZyb20gY29uZmlnIDEK
+    bWVzc2FnZSA9ICJIZWxsbyBmcm9tIGNvbmZpZyAxIgo=
 ```
 
 ## Lines 메소드

--- a/content/uk/docs/chart_template_guide/accessing_files.md
+++ b/content/uk/docs/chart_template_guide/accessing_files.md
@@ -35,19 +35,19 @@ Helm надає доступ до файлів через обʼєкт `.Files`.
 `config1.toml`:
 
 ```toml
-message = Hello from config 1
+message = "Hello from config 1"
 ```
 
 `config2.toml`:
 
 ```toml
-message = This is config 2
+message = "This is config 2"
 ```
 
 `config3.toml`:
 
 ```toml
-message = Goodbye from config 3
+message = "Goodbye from config 3"
 ```
 
 Кожен з цих файлів є простим TOML-файлом (згадайте про старі INI-файли Windows). Ми знаємо імена цих файлів, тому можемо використовувати функцію `range`, щоб перебрати їх і вставити їх вміст у наш ConfigMap.
@@ -77,13 +77,13 @@ metadata:
   name: quieting-giraf-configmap
 data:
   config1.toml: |-
-    message = Hello from config 1
+    message = "Hello from config 1"
 
   config2.toml: |-
-    message = This is config 2
+    message = "This is config 2"
 
   config3.toml: |-
-    message = Goodbye from config 3
+    message = "Goodbye from config 3"
 ```
 
 ## Помічники оброки шляхів {#path-helpers}
@@ -186,7 +186,7 @@ metadata:
 type: Opaque
 data:
   token: |-
-    bWVzc2FnZSA9IEhlbGxvIGZyb20gY29uZmlnIDEK
+    bWVzc2FnZSA9ICJIZWxsbyBmcm9tIGNvbmZpZyAxIgo=
 ```
 
 ## Рядки {#lines}

--- a/content/zh/docs/chart_template_guide/accessing_files.md
+++ b/content/zh/docs/chart_template_guide/accessing_files.md
@@ -38,19 +38,19 @@ Helm 提供了通过`.Files`对象访问文件的方法。不过，在我们使�
 `config1.toml`:
 
 ```toml
-message = Hello from config 1
+message = "Hello from config 1"
 ```
 
 `config2.toml`:
 
 ```toml
-message = This is config 2
+message = "This is config 2"
 ```
 
 `config3.toml`:
 
 ```toml
-message = Goodbye from config 3
+message = "Goodbye from config 3"
 ```
 
 每个都是简单的TOML文件（类似于windows老式的INI文件）。我们知道这些文件的名称，因此我们使用`range`功能遍历它们并将它们的内容注入到我们的ConfigMap中。
@@ -81,13 +81,13 @@ metadata:
   name: quieting-giraf-configmap
 data:
   config1.toml: |-
-    message = Hello from config 1
+    message = "Hello from config 1"
 
   config2.toml: |-
-    message = This is config 2
+    message = "This is config 2"
 
   config3.toml: |-
-    message = Goodbye from config 3
+    message = "Goodbye from config 3"
 ```
 
 ## Path helpers
@@ -192,7 +192,7 @@ metadata:
 type: Opaque
 data:
   token: |-
-    bWVzc2FnZSA9IEhlbGxvIGZyb20gY29uZmlnIDEK
+    bWVzc2FnZSA9ICJIZWxsbyBmcm9tIGNvbmZpZyAxIgo=
 ```
 
 ## Lines
@@ -209,5 +209,5 @@ data:
 
 在`helm install`过程中无法将文件传递到chart外。因此如果你想请求用户提供数据，必须使用`helm install -f`或`helm install --set`加载。
 
-该部分讨论整合了我们对编写Helm模板的工具和技术的深入研究。下个章节我们会看到如何使用特殊文件`templates/NOTES.txt`， 
+该部分讨论整合了我们对编写Helm模板的工具和技术的深入研究。下个章节我们会看到如何使用特殊文件`templates/NOTES.txt`，
 向chart的用户发送安装后的说明。


### PR DESCRIPTION
TOML requires string values to be [quoted](https://toml.io/en/v1.0.0#string).