### PR TITLE
Removing inactive maintainers from the owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,13 @@
 maintainers:
   - yxxhero
-  - angellk
-  - bacongobbler
-  - flynnduism
-  - gjenkins8
-  - jdolitsky
   - karenhchu
   - mattfarina
-  - scottrigby
   - technosophos
 emeritus:
-  - hickeyma
-  - thomastaylor312
+  - angellk
+  - bacongobbler
   - bridgetkromhout
+  - flynnduism
+  - hickeyma
+  - jdolitsky
+  - thomastaylor312


### PR DESCRIPTION
According to the governance maintainers must remain actice and are removed for inactivity.

The maintainers moved to emeritus here have already signaled they are going emeritus and this repo was missed or have been inactive for more than 1 year.

Note, bridgetkromhout was moved in the ordering to keep the list in alpha order.

Note 2, I have reached out to angellk and technosophos about this but have not yet heard back.

**UPDATE NOTE: People added outside the governance process were also removed.**