### PR TITLE
fix: hugo deprecation on permalink

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,7 +22,7 @@ guessSyntax = true
 unsafe = true
 
 [Permalinks]
-code = "/:filename/"
+code = "/:contentbasename/"
 
 [params]
 title = "Helm"


### PR DESCRIPTION
Fix Hugo deprecation

Closes: https://github.com/helm/helm-www/issues/1754