### PR TITLE
add note about ed25519 key issue

### DIFF
--- a/content/en/docs/topics/provenance.md
+++ b/content/en/docs/topics/provenance.md
@@ -60,9 +60,13 @@ can use `gpg --list-secret-keys` to list the keys you have.
 the default location  `~/.gnupg/pubring.kbx`. Please use the following command
 to convert your keyring to the legacy gpg format:
 
+**Warning:** Helm cannot sign packages if there is an ed25519 key inside your
+keyring. Please only export the gpg keys that you will use for signing by using
+the `--export-filter keep-uid` option:
+
 ```console
-$ gpg --export >~/.gnupg/pubring.gpg
-$ gpg --export-secret-keys >~/.gnupg/secring.gpg
+$ gpg --export-filter keep-uid="John Smith" --export >~/.gnupg/pubring.gpg
+$ gpg --export-filter keep-uid="John Smith" --export-secret-keys >~/.gnupg/secring.gpg
 ```
 
 At this point, you should see both `mychart-0.1.0.tgz` and


### PR DESCRIPTION
In the following helm issue: https://github.com/helm/helm/issues/31181

we discovered that the presence of an ed25519 key anywhere in your keyring will cause all package signing to fail even if you configure helm to sign with an RSA key (in a keyring that happens to have an ed25519 key within it).  This is a side-effect of using an outdated openpgp library that is only receiving security updates.

This change will notify users that when exporting their keys, they should try to ONLY export the keys that they plan on using for the helm signature, and not all of their keys.