### PR TITLE
Fix all the typos with help of `typos` CLI

### DIFF
--- a/content/en/blog/2019-04-18-helm-summit-eu-2019.md
+++ b/content/en/blog/2019-04-18-helm-summit-eu-2019.md
@@ -8,7 +8,7 @@ authorlink: "https://twitter.com/karenhchu"
 date: "2019-04-18"
 ---
 
-We're beyond excited to share that [Helm Summit EU 2019](https://events.linuxfoundation.org/events/helm-summit-2019/) is now official (h/t to [CNCF](https://cncf.io/))! Join the Helm community on September 11 - 12 in Amsterdam, The Netherlands at Pakhuis de Zwijger for our first European Helm Summit. Over the course of two days, we'll discuss all things Helm and hold tutorials, working sessions, and small group discussions with new and exisiting users. 
+We're beyond excited to share that [Helm Summit EU 2019](https://events.linuxfoundation.org/events/helm-summit-2019/) is now official (h/t to [CNCF](https://cncf.io/))! Join the Helm community on September 11 - 12 in Amsterdam, The Netherlands at Pakhuis de Zwijger for our first European Helm Summit. Over the course of two days, we'll discuss all things Helm and hold tutorials, working sessions, and small group discussions with new and existing users. 
 
 Interested in... 
 

--- a/content/en/blog/2019-06-10-get-helm-sh.md
+++ b/content/en/blog/2019-06-10-get-helm-sh.md
@@ -37,7 +37,7 @@ All the download URLs in our [GitHub releases](https://github.com/helm/helm/rele
 1. [Azure CDN](https://azure.microsoft.com/en-ca/services/cdn/)
 1. The domain name `get.helm.sh`
 
-In our release pipeline, Helm 2 and Helm 3 downloads are [uploaded to Azure Blob Storage](https://github.com/helm/helm/commit/022c8869bee37d02cf01507c11c6cfc6d58a1eca) (Helm 2 downloads are also [uploaded to Google Cloud Storage](https://github.com/helm/helm/commit/95775d0c60804b3d3674510e1f57a30ca8074ddd) for backwards compatibililty). Azure CDN serves that content, which is fronted with a custom domain name.
+In our release pipeline, Helm 2 and Helm 3 downloads are [uploaded to Azure Blob Storage](https://github.com/helm/helm/commit/022c8869bee37d02cf01507c11c6cfc6d58a1eca) (Helm 2 downloads are also [uploaded to Google Cloud Storage](https://github.com/helm/helm/commit/95775d0c60804b3d3674510e1f57a30ca8074ddd) for backwards compatibility). Azure CDN serves that content, which is fronted with a custom domain name.
 
 ## Why the new location?
 

--- a/content/en/blog/2019-09-11-migrate-from-helm-v2-to-helm-v3.md
+++ b/content/en/blog/2019-09-11-migrate-from-helm-v2-to-helm-v3.md
@@ -115,9 +115,9 @@ $ helm3 2to3 move config --dry-run
 2019/11/14 14:54:04
 2019/11/14 14:54:04 WARNING: Helm v3 configuration maybe overwritten during this operation.
 2019/11/14 14:54:04
-[Move Config/confirm] Are you sure you want to move the v2 configration? [y/N]: y
+[Move Config/confirm] Are you sure you want to move the v2 configuration? [y/N]: y
 2019/11/14 14:54:12
-Helm v2 configuration will be moved to Helm v3 configration.
+Helm v2 configuration will be moved to Helm v3 configuration.
 2019/11/14 14:54:12 [Helm 2] Home directory: /Users/rimas/.helm
 2019/11/14 14:54:12 [Helm 3] Config directory: /Users/rimas/Library/Preferences/helm
 2019/11/14 14:54:12 [Helm 3] Data directory: /Users/rimas/Library/helm
@@ -134,9 +134,9 @@ Cool, now let's do the actual migration:
 $ helm3 2to3 move config
 WARNING: Helm v3 configuration maybe overwritten during this operation.
 
-[Move Config/confirm] Are you sure you want to move the v2 configration? [y/N]: y
+[Move Config/confirm] Are you sure you want to move the v2 configuration? [y/N]: y
 
-2019/11/14 14:55:00 Helm v2 configuration will be moved to Helm v3 configration.
+2019/11/14 14:55:00 Helm v2 configuration will be moved to Helm v3 configuration.
 2019/11/14 14:55:00 [Helm 2] Home directory: /Users/rimas/.helm
 2019/11/14 14:55:00 [Helm 3] Config directory: /Users/rimas/Library/Preferences/helm
 2019/11/14 14:55:00 [Helm 3] Data directory: /Users/rimas/Library/helm
@@ -150,7 +150,7 @@ WARNING: Helm v3 configuration maybe overwritten during this operation.
 2019/11/14 14:55:00 [Helm 2] plugins "/Users/rimas/.helm/plugins" copied successfully to [Helm 3] data folder "/Users/rimas/Library/helm/plugins" .
 2019/11/14 14:55:00 [Helm 2] starters "/Users/rimas/.helm/starters" will copy to [Helm 3] data folder "/Users/rimas/Library/helm/starters" .
 2019/11/14 14:55:00 [Helm 2] starters "/Users/rimas/.helm/starters" copied successfully to [Helm 3] data folder "/Users/rimas/Library/helm/starters" .
-2019/11/14 14:55:00 Helm v2 configuration was moved successfully to Helm v3 configration.
+2019/11/14 14:55:00 Helm v2 configuration was moved successfully to Helm v3 configuration.
 ```
 
 Now let's run `helm3 repo list` again:
@@ -254,7 +254,7 @@ $ helm3 2to3 convert postgres
 2019/11/14 15:03:57 v2 release information should only be removed using `helm 2to3` cleanup and when all releases have been migrated over.
 ```
 
-Check out whether it was succesful:
+Check out whether it was successful:
 
 ```
 $ helm list

--- a/content/en/blog/2020-10-30-charts-repo-deprecation.md
+++ b/content/en/blog/2020-10-30-charts-repo-deprecation.md
@@ -7,7 +7,7 @@ authorlink: "https://twitter.com/vicnastea"
 date: "2020-10-30"
 ---
 
-Back in 2019, when the Helm v2 support timeline and end of life plan was announced, [the deprecation](https://github.com/helm/charts#deprecation-timeline) of the [helm/charts GitHub repository](https://github.com/helm/charts) was announced, as well. The primary reason for the deprecation is the significant increase in upkeep for the [repo maintainers](https://github.com/helm/charts/blob/master/OWNERS). Over the last couple of years the number of charts under maintainance increased from ~100 to 300+ causing a commensurate increase in pull requests and updates to the repo. Unfortunately, despite many efforts to automate review and maintenance tasks, the amount of time available from maintainers has not increased.
+Back in 2019, when the Helm v2 support timeline and end of life plan was announced, [the deprecation](https://github.com/helm/charts#deprecation-timeline) of the [helm/charts GitHub repository](https://github.com/helm/charts) was announced, as well. The primary reason for the deprecation is the significant increase in upkeep for the [repo maintainers](https://github.com/helm/charts/blob/master/OWNERS). Over the last couple of years the number of charts under maintenance increased from ~100 to 300+ causing a commensurate increase in pull requests and updates to the repo. Unfortunately, despite many efforts to automate review and maintenance tasks, the amount of time available from maintainers has not increased.
 
 When we announced the deprecation we also began to share the tools and guidance that we had used to maintain the helm/charts repo. For folks that want to host and maintain their own repositories you now have these tools available to streamline the process:
 
@@ -25,7 +25,7 @@ There has been refinement to the plans and confusion/questions about what happen
     * **RECOMMENDED ACTION** - If you depend on a chart in the Charts repository look for the new official location. If one does not exist, consider adopting the chart.
 * Nov 6, 2020 the stable and incubator charts repos will be removed from the [Artifact Hub](https://artifacthub.io/)
     * **RECOMMENDED ACTION** - None
-* Nov 13, 2020 - CI on the [helm/charts repository](https://github.com/helm/chart) will be disabled and no more Pull Requests will be accpeted.
+* Nov 13, 2020 - CI on the [helm/charts repository](https://github.com/helm/chart) will be disabled and no more Pull Requests will be accepted.
     * **RECOMMENDED ACTION** - For more info on the ongoing initiative to relocate charts to new repos please see [this issue](https://github.com/helm/charts/issues/21103).
 * *After* Nov 13, 2020 - Downloads of Charts at their old locations will be re-directed to the read-only archive available in GitHub Pages. The old locations may no longer be available after this date.
     * **RECOMMENDED ACTION** - See info on [switching to the archived stable and incubator charts](https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository). Keep in mind that these charts will no longer be updated with bug fixes or security patches.

--- a/content/en/blog/2022-02-28-storing-charts-in-oci.md
+++ b/content/en/blog/2022-02-28-storing-charts-in-oci.md
@@ -42,7 +42,7 @@ More detail on [working with registries can be found in the Helm documentation](
 
 ## The Helm SDK
 
-The Helm SDK, which is useful for those building tools to integrate with Helm, also includes support to work with registries programatically. The following example illustrates pushing a chart to a registry:
+The Helm SDK, which is useful for those building tools to integrate with Helm, also includes support to work with registries programmatically. The following example illustrates pushing a chart to a registry:
 
 ```go
 package main

--- a/content/en/blog/helm-at-kubecon-eu-25.md
+++ b/content/en/blog/helm-at-kubecon-eu-25.md
@@ -7,7 +7,7 @@ authorlink: "https://bsky.app/profile/karenchu.online"
 date: "2025-03-31"
 ---
 
-It's that time of the year again – the Helm team is headed to KubeCon + CloudNativeCon EU '25 in London, UK this week from April 1 - 4! Helm 4 is in the works for later this year so be sure to join the conversation with our maintainers during our talk sessions and at our Helm booth in the Project Pavilion! See below for more details on all Helm-related activies throughout the week.
+It's that time of the year again – the Helm team is headed to KubeCon + CloudNativeCon EU '25 in London, UK this week from April 1 - 4! Helm 4 is in the works for later this year so be sure to join the conversation with our maintainers during our talk sessions and at our Helm booth in the Project Pavilion! See below for more details on all Helm-related activities throughout the week.
 
 <!--more-->
 

--- a/content/en/docs/community/related.md
+++ b/content/en/docs/community/related.md
@@ -94,7 +94,7 @@ Tools layered on top of Helm.
   helm-charts-as-code tool which enables
   installing/upgrading/protecting/moving/deleting releases from version
   controlled desired state files (described in a simple TOML format)
-- [HULL](https://github.com/vidispine/hull) - This library chart provides a 
+- [HULL](https://github.com/vidispine/hull) - This library chart provides a
   ready-to-use interface for specifying all Kubernetes objects directly in the `values.yaml`.
   It removes the need to write any templates for your charts and comes with many
   additional features to simplify Helm chart creation and usage.

--- a/content/en/docs/sdk/examples.md
+++ b/content/en/docs/sdk/examples.md
@@ -47,6 +47,6 @@ This example pulls a chart from an OCI repository
 
 ## Driver
 
-The driver here shows the necessary auxillary functions needed for the Helm SDK actions to function. And shows the above examples in action, to pull, install, update, and uninstall the 'podinfo' chart from an OCI repository.
+The driver here shows the necessary auxiliary functions needed for the Helm SDK actions to function. And shows the above examples in action, to pull, install, update, and uninstall the 'podinfo' chart from an OCI repository.
 
 {{< highlightexamplego file="sdkexamples/main.go" >}}

--- a/content/en/docs/topics/kubernetes_distros.md
+++ b/content/en/docs/topics/kubernetes_distros.md
@@ -99,6 +99,6 @@ KUBECONFIG=/etc/kubernetes/admin.conf` or create a `~/.kube/config`.
 
 ## VMware Tanzu Kubernetes Grid
 
-Helm runs on VMware Tanzu Kubernetes Grid, TKG, without needing configuration changes. 
-The Tanzu CLI can manage installing packages for [helm-controller](https://fluxcd.io/flux/components/helm/) allowing for declaratively managing Helm chart releases. 
+Helm runs on VMware Tanzu Kubernetes Grid, TKG, without needing configuration changes.
+The Tanzu CLI can manage installing packages for [helm-controller](https://fluxcd.io/flux/components/helm/) allowing for declaratively managing Helm chart releases.
 Further details available in the TKG documentation for [CLI-Managed Packages](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.6/vmware-tanzu-kubernetes-grid-16/GUID-packages-user-managed-index.html#package-locations-and-dependencies-5).

--- a/content/en/docs/topics/plugins.md
+++ b/content/en/docs/topics/plugins.md
@@ -57,7 +57,7 @@ https://domain/path/to/plugin.tar.gz`
 ## The Plugin File Structure
 
 In many ways, a plugin is similar to a chart. Each plugin has a top-level
-directory containing a `plugin.yaml` file. Additonal files may be present but
+directory containing a `plugin.yaml` file. Additional files may be present but
 only the `plugin.yaml` file is required.
 
 ```console
@@ -77,25 +77,25 @@ usage: Single line usage text shown in help
 description: Long description shown in places like helm help
 ignoreFlags: Ignore flags passed in from Helm
 platformCommand: # Configure command to run based on the platform
-  - os: OS match, can be empty or ommited to match all OS'
-    arch: Architecture match, can be empty or ommited to match all architectures
+  - os: OS match, can be empty or omitted to match all OS'
+    arch: Architecture match, can be empty or omitted to match all architectures
     command: Plugin command to execute
     args: Plugin command arguments
 command: (DEPRECATED) Plugin command, use platformCommand instead
 platformHooks: # Configure plugin lifecycle hooks based on the platform
   install: # Install lifecycle commands
-    - os: OS match, can be empty or ommited to match all OS'
-      arch: Architecture match, can be empty or ommited to match all architectures
+    - os: OS match, can be empty or omitted to match all OS'
+      arch: Architecture match, can be empty or omitted to match all architectures
       command: Plugin install command to execute
       args: Plugin install command arguments
   update: # Update lifecycle commands
-    - os: OS match, can be empty or ommited to match all OS'
-      arch: Architecture match, can be empty or ommited to match all architectures
+    - os: OS match, can be empty or omitted to match all OS'
+      arch: Architecture match, can be empty or omitted to match all architectures
       command: Plugin update command to execute
       args: Plugin update command arguments
   delete: # Delete lifecycle commands
-    - os: OS match, can be empty or ommited to match all OS'
-      arch: Architecture match, can be empty or ommited to match all architectures
+    - os: OS match, can be empty or omitted to match all OS'
+      arch: Architecture match, can be empty or omitted to match all architectures
       command: Plugin delete command to execute
       args: Plugin delete command arguments
 hooks: # (Deprecated) Plugin lifecycle hooks, use platformHooks instead
@@ -253,7 +253,7 @@ There are some strategies for working with plugin commands:
 
 ### Testing a Local Plugin
 
-First you need to find your `HELM_PLUGINS` path to do it run the folowing command:
+First you need to find your `HELM_PLUGINS` path to do it run the following command:
 
 ``` bash
 helm env


### PR DESCRIPTION
Used the [`typos` CLI](https://github.com/crate-ci/typos) to prepare this PR. I ran:

```bash
typos -w ./content/en
```
and then removed some false positives manually.