### PR TITLE
exclude content/pl directory from typos check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -32,6 +32,8 @@ extend-exclude = [
   "i18n/",
   # Portuguese content - these are not English typos
   "content/pt/**",
+  # Polish content
+  "content/pl/**",
   # Russian content
   "content/ru/**",
   # Ukrainian content


### PR DESCRIPTION
[pl] exclude content/pl directory from typos check

initialization of the content/pl directory is in an incubation phase : #1818 .

however, any build will fail without this update to `.types.toml` .