### PR TITLE
Add Netlify caching

### DIFF
--- a/ARCHITECTURAL_DECISIONS.md
+++ b/ARCHITECTURAL_DECISIONS.md
@@ -231,3 +231,24 @@ Remove them only after:
 1. Docusaurus site cutover is verified
 2. All redirects are tested and working
 3. No rollback scenarios require Hugo functionality
+
+## Netlify Build Caching
+
+### Problem
+Docusaurus builds take ~11 minutes. Need faster builds for development workflow.
+
+### Solution
+Custom Netlify plugins cache `.docusaurus/`, `node_modules/`, and `build/` directories.
+
+**Current:** `cache-docusaurus-dirs-file` (stable, 2-4 minute builds)
+**Future:** `cache-docusaurus-dirs-api` (beta, potentially 10x faster)
+
+### Build Pipeline Changes
+Changed from `make build` (runs destructive `clean`) to `make netlify-build` (preserves cache).
+
+### Cache Strategy
+- **Production/branches:** Isolated per branch
+- **PR previews:** Shared across PRs via `CACHE_PER_BRANCH=false`
+- **Auto-invalidation:** `yarn.lock` changes, `CACHE_VERSION` environment variable
+
+See `netlify-plugins/README.md` for configuration details.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ install:
 build: clean install
 	SITE_URL=$(SITE_URL) BASE_URL=$(BASE_URL) yarn run build
 
+# Cache-friendly install - only runs if dependencies missing or yarn.lock is newer
+install-if-needed:
+	@if [ ! -f "node_modules/.bin/docusaurus" ] || [ "yarn.lock" -nt "node_modules" ]; then \
+		echo "Installing dependencies..."; \
+		yarn install --frozen-lockfile; \
+	else \
+		echo "Dependencies up to date, skipping install"; \
+	fi
+
+# Cache-friendly build for Netlify - preserves cached directories
+netlify-build: install-if-needed
+	SITE_URL=$(SITE_URL) BASE_URL=$(BASE_URL) yarn run build
+
 .PHONY: sdkexamples
 sdkexamples:
 	make -C sdkexamples

--- a/netlify-plugins/README.md
+++ b/netlify-plugins/README.md
@@ -1,0 +1,29 @@
+# Netlify Build Plugins
+
+Caches Docusaurus build directories to reduce ~11 minute builds to 2-4 minutes.
+
+## Quick Reference
+
+**Current plugin:** `cache-docusaurus-dirs-file` (stable)
+**Build command:** `make netlify-build` (preserves cache)
+
+## Configuration
+
+```toml
+# netlify.toml
+[[plugins]]
+package = "./netlify-plugins/cache-docusaurus-dirs-file"
+  [plugins.inputs]
+  dirs = [".docusaurus", "node_modules", "build"]
+```
+
+All caching behavior controlled by environment variables:
+- `CACHE_VERSION` - Manual cache busting per environment
+- `CACHE_PER_BRANCH` - Set to `"false"` for PR previews to share cache
+
+## Switching Plugins
+
+To test beta Cache API (potentially 10x faster):
+```toml
+package = "./netlify-plugins/cache-docusaurus-dirs-api"
+```

--- a/netlify-plugins/cache-docusaurus-dirs-api/index.js
+++ b/netlify-plugins/cache-docusaurus-dirs-api/index.js
@@ -1,0 +1,145 @@
+// Netlify Core Build Plugin to cache directories using utils.cache.
+// - Docusaurus-friendly: cache ".docusaurus", "node_modules", and "build"
+// - node_modules auto-invalidation via yarn.lock hash
+// - On-demand busting via CACHE_VERSION env var per environment
+// - Per-branch cache isolation by default
+
+const path = require("path");
+const fs = require("fs");
+const crypto = require("crypto");
+
+function dirExists(dirPath) {
+  try {
+    const stat = fs.statSync(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function fileSha256(filePath) {
+  try {
+    const data = fs.readFileSync(filePath);
+    return crypto.createHash("sha256").update(data).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function makeKey({ dir, repoRoot }) {
+  const cacheVersion = process.env.CACHE_VERSION || "";
+  const perBranch = process.env.CACHE_PER_BRANCH !== "false"; // default true
+  const branch = process.env.NETLIFY_BRANCH || process.env.BRANCH || "unknown";
+
+  let key = dir;
+
+  // Auto-invalidate node_modules with yarn.lock changes
+  if (dir === "node_modules") {
+    const yarnLockPath = path.join(repoRoot, "yarn.lock");
+    const hash = fileSha256(yarnLockPath);
+    if (hash) {
+      key = `${key}@yarn-${hash.slice(0, 16)}`;
+    }
+  }
+
+  // On-demand busting
+  if (cacheVersion) {
+    key = `${key}@cv-${cacheVersion}`;
+  }
+
+  // Per-branch isolation
+  if (perBranch) {
+    key = `${key}@${branch}`;
+  }
+  return key;
+}
+
+async function restoreDir(utils, absPath, key) {
+  try {
+    const restored = await utils.cache.restore(absPath, { key });
+    utils.status.show({
+      title: restored ? `Cache restored: ${key}` : `No cache: ${key}`,
+      summary: `${restored ? "Restored" : "No prior cache"} into ${absPath}`,
+    });
+    return restored;
+  } catch (err) {
+    utils.status.show({
+      title: `Cache restore failed: ${key}`,
+      summary: err.message,
+    });
+    return false;
+  }
+}
+
+async function saveDir(utils, absPath, key) {
+  try {
+    const saved = await utils.cache.save(absPath, { key });
+    utils.status.show({
+      title: saved ? `Cache saved: ${key}` : `Cache skipped: ${key}`,
+      summary: `${saved ? "Saved" : "Skipped"} from ${absPath}`,
+    });
+    return saved;
+  } catch (err) {
+    utils.status.show({
+      title: `Cache save failed: ${key}`,
+      summary: err.message,
+    });
+    return false;
+  }
+}
+
+module.exports = {
+
+  async onPreBuild({ inputs, utils }) {
+    const repoRoot = process.cwd();
+    const dirs = inputs.dirs;
+
+    for (const dir of dirs) {
+      const key = makeKey({ dir, repoRoot });
+      const abs = path.resolve(repoRoot, dir);
+
+      await restoreDir(utils, abs, key);
+
+      // Guidance for node_modules: ensure yarn.lock exists to keep cache fresh
+      if (dir === "node_modules") {
+        const yarnLockPath = path.join(repoRoot, "yarn.lock");
+        if (!fs.existsSync(yarnLockPath)) {
+          utils.status.show({
+            title: "node_modules cache warning",
+            summary:
+              "yarn.lock not found. Caching node_modules without yarn.lock can lead to stale dependencies. Ensure yarn.lock is committed.",
+          });
+        }
+      }
+    }
+  },
+
+  async onPostBuild({ inputs, utils }) {
+    const repoRoot = process.cwd();
+    const dirs = inputs.dirs;
+
+    for (const dir of dirs) {
+      const key = makeKey({ dir, repoRoot });
+      const abs = path.resolve(repoRoot, dir);
+
+      if (!dirExists(abs)) {
+        utils.status.show({
+          title: `Cache not saved (missing directory)`,
+          summary: `${abs} does not exist.`,
+        });
+        continue;
+      }
+
+      const hasFiles = fs.readdirSync(abs).length > 0;
+      if (!hasFiles) {
+        utils.status.show({
+          title: `Cache not saved (empty directory)`,
+          summary: `${abs} is empty.`,
+        });
+        continue;
+      }
+
+      await saveDir(utils, abs, key);
+    }
+  },
+};

--- a/netlify-plugins/cache-docusaurus-dirs-api/manifest.yml
+++ b/netlify-plugins/cache-docusaurus-dirs-api/manifest.yml
@@ -1,0 +1,5 @@
+name: cache-docusaurus-dirs-api
+inputs:
+  - name: dirs
+    description: Array of directories to cache (relative to repo root)
+    required: true

--- a/netlify-plugins/cache-docusaurus-dirs-file/index.js
+++ b/netlify-plugins/cache-docusaurus-dirs-file/index.js
@@ -1,0 +1,164 @@
+// Netlify Build Plugin to cache directories using file-based caching (stable)
+// - Docusaurus-friendly: cache ".docusaurus", "node_modules", and "build"
+// - node_modules auto-invalidation via yarn.lock hash
+// - On-demand busting via CACHE_VERSION env var per environment
+// - Per-branch cache isolation by default
+
+const path = require("path");
+const fs = require("fs");
+const crypto = require("crypto");
+
+function dirExists(dirPath) {
+  try {
+    const stat = fs.statSync(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function fileSha256(filePath) {
+  try {
+    const data = fs.readFileSync(filePath);
+    return crypto.createHash("sha256").update(data).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function makeKey({ dir, repoRoot }) {
+  const cacheVersion = process.env.CACHE_VERSION || "";
+  const perBranch = process.env.CACHE_PER_BRANCH !== "false"; // default true
+  const branch = process.env.NETLIFY_BRANCH || process.env.BRANCH || "unknown";
+
+  let key = dir;
+
+  // Auto-invalidate node_modules with yarn.lock changes
+  if (dir === "node_modules") {
+    const yarnLockPath = path.join(repoRoot, "yarn.lock");
+    const hash = fileSha256(yarnLockPath);
+    if (hash) {
+      key = `${key}@yarn-${hash.slice(0, 16)}`;
+    }
+  }
+
+  // On-demand busting
+  if (cacheVersion) {
+    key = `${key}@cv-${cacheVersion}`;
+  }
+
+  // Per-branch isolation
+  if (perBranch) {
+    key = `${key}@${branch}`;
+  }
+  return key;
+}
+
+async function restoreDir(utils, absPath, key) {
+  try {
+    // File-based caching: check if cache exists, then restore
+    const cacheExists = await utils.cache.has(key);
+    if (!cacheExists) {
+      utils.status.show({
+        title: `No cache: ${key}`,
+        summary: `No prior cache for ${absPath}`,
+      });
+      return false;
+    }
+
+    const restored = await utils.cache.restore(key);
+    if (restored) {
+      // File-based caching often requires manual copy from cache location
+      // The exact implementation may vary based on Netlify's file-based API
+      utils.status.show({
+        title: `Cache restored: ${key}`,
+        summary: `Restored into ${absPath}`,
+      });
+    } else {
+      utils.status.show({
+        title: `Cache restore failed: ${key}`,
+        summary: `Failed to restore cache for ${absPath}`,
+      });
+    }
+    return restored;
+  } catch (err) {
+    utils.status.show({
+      title: `Cache restore failed: ${key}`,
+      summary: err.message,
+    });
+    return false;
+  }
+}
+
+async function saveDir(utils, absPath, key) {
+  try {
+    // File-based caching: save directory to cache
+    const saved = await utils.cache.save(key, absPath);
+    utils.status.show({
+      title: saved ? `Cache saved: ${key}` : `Cache skipped: ${key}`,
+      summary: `${saved ? "Saved" : "Skipped"} from ${absPath}`,
+    });
+    return saved;
+  } catch (err) {
+    utils.status.show({
+      title: `Cache save failed: ${key}`,
+      summary: err.message,
+    });
+    return false;
+  }
+}
+
+module.exports = {
+  async onPreBuild({ inputs, utils }) {
+    const repoRoot = process.cwd();
+    const dirs = inputs.dirs;
+
+    for (const dir of dirs) {
+      const key = makeKey({ dir, repoRoot });
+      const abs = path.resolve(repoRoot, dir);
+
+      await restoreDir(utils, abs, key);
+
+      // Guidance for node_modules: ensure yarn.lock exists to keep cache fresh
+      if (dir === "node_modules") {
+        const yarnLockPath = path.join(repoRoot, "yarn.lock");
+        if (!fs.existsSync(yarnLockPath)) {
+          utils.status.show({
+            title: "node_modules cache warning",
+            summary:
+              "yarn.lock not found. Caching node_modules without yarn.lock can lead to stale dependencies. Ensure yarn.lock is committed.",
+          });
+        }
+      }
+    }
+  },
+
+  async onPostBuild({ inputs, utils }) {
+    const repoRoot = process.cwd();
+    const dirs = inputs.dirs;
+
+    for (const dir of dirs) {
+      const key = makeKey({ dir, repoRoot });
+      const abs = path.resolve(repoRoot, dir);
+
+      if (!dirExists(abs)) {
+        utils.status.show({
+          title: `Cache not saved (missing directory)`,
+          summary: `${abs} does not exist.`,
+        });
+        continue;
+      }
+
+      const hasFiles = fs.readdirSync(abs).length > 0;
+      if (!hasFiles) {
+        utils.status.show({
+          title: `Cache not saved (empty directory)`,
+          summary: `${abs} is empty.`,
+        });
+        continue;
+      }
+
+      await saveDir(utils, abs, key);
+    }
+  },
+};

--- a/netlify-plugins/cache-docusaurus-dirs-file/manifest.yml
+++ b/netlify-plugins/cache-docusaurus-dirs-file/manifest.yml
@@ -1,0 +1,5 @@
+name: cache-docusaurus-dirs-file
+inputs:
+  - name: dirs
+    description: Array of directories to cache (relative to repo root)
+    required: true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,27 @@
 [build]
-  command = "make build"
+  command = "make netlify-build"
   publish = "build"
 
 [build.environment]
   NODE_VERSION = "20"
 
+# Cache Docusaurus internal cache (.docusaurus) with optional CACHE_VERSION per environment
+[[plugins]]
+package = "./netlify-plugins/cache-docusaurus-dirs-file"
+
+  [plugins.inputs]
+  dirs = [".docusaurus", "node_modules", "build"]
+
 [context.production.environment]
   SITE_URL = "https://helm.sh"
+  CACHE_VERSION = "prod-v1"
+
+[context.deploy-preview.environment]
+  CACHE_VERSION = "preview-v1"
+  CACHE_PER_BRANCH = "false"
+
+[context.branch-deploy.environment]
+  CACHE_VERSION = "branch-v1"
 
 # redirect docs homepage
 [[redirects]]


### PR DESCRIPTION
fixes #1811

This PR adds two custom Netlify plugins:
1. that uses Netlify's GA caching. We are using this plugin.
2. that uses Netlify's Beta Cache API. Not using due to unreliability, but keeping for future optimization.

Updated architectural decisions doc with info on this.

Reduces build time from ~11 mins to 3-4 mins:

<img width="1130" height="297" alt="Screenshot 2025-10-27 at 2 06 40 PM" src="https://github.com/user-attachments/assets/9b4bbfa1-a3c9-4b9b-b69e-3627cd7e2ee8" />

#### Follow-up:
- [ ] We can explore the Netlify Beta Cache API for potential speed optimization post-cutover to Docusaurus. It could be there there's a flaw in my plugin for it, and/or we can follow along as their service matures from it's current Beta.