### PR TITLE
Change path for v2 docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,7 +110,7 @@ const config = {
             // and v5 will then live in /docs
             current: { label: "4.0.0-beta.1 🚧" },
             3: { label: "3.19.0" },
-            2: { label: "2.17.0" },
+            2: { label: "2.17.0", path: "v2" },
           },
         },
         blog: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -35,7 +35,7 @@ package = "./netlify-plugins/cache-docusaurus-dirs-file"
 
 [[redirects]]
   from = "/docs/developing_charts/"
-  to = "https://helm.sh/docs/2/developing-charts/"
+  to = "https://helm.sh/docs/v2/developing-charts/"
 
 # Go module import support handled by static HTML files in /static/
 # These paths serve HTML with go-import meta tags + client-side redirects
@@ -68,7 +68,7 @@ package = "./netlify-plugins/cache-docusaurus-dirs-file"
 
 [[redirects]]
   from = "https://v2.helm.sh/docs/using_helm/"
-  to = "/docs/2/using-helm/"
+  to = "/docs/v2/using-helm/"
   status = 302
 
 [[redirects]]
@@ -78,7 +78,7 @@ package = "./netlify-plugins/cache-docusaurus-dirs-file"
 
 [[redirects]]
   from = "https://v2.helm.sh/docs/developing_charts/"
-  to = "/docs/2/developing-charts/"
+  to = "/docs/v2/developing-charts/"
   status = 302
 
 [[redirects]]


### PR DESCRIPTION
Related to https://github.com/helm/helm-www/issues/1809

This PR sets the path for all v2 docs to `v2` (by default, it was `2`, which was strange to see in the url path)

Updates existing redirects to the v2 docs accordingly