### PR TITLE
[HIP-0024] Fix hero height and scroll issues on production builds

### DIFF
--- a/src/components/HomeHeader/styles.module.css
+++ b/src/components/HomeHeader/styles.module.css
@@ -5,6 +5,9 @@
   overflow: hidden;
   --ifm-hero-background-color: none;
   --ifm-hero-text-color: var(--navy);
+  /* Prevent layout shift on page load/refresh by setting a reasonable default height */
+  /* Use 90vh to account for potential announcement bar and avoid exact match with JS calculation */
+  min-height: 90vh;
 }
 
 .container {

--- a/src/css/announcement-bar.css
+++ b/src/css/announcement-bar.css
@@ -1,3 +1,11 @@
+:root {
+  /* set custom var for announcement bar height because
+  --docusaurus-announcement-bar-height var is not properly overridden from here
+  during yarn build/serve, eve with !important. use this custom var in
+  announcement-bar.css until a better solution is found. */
+  --helm-announcement-bar-height: 5rem;
+}
+
 /* Position the announcement bar fixed below the navbar and keep it within the body border */
 .theme-announcement-bar {
   position: fixed;
@@ -9,6 +17,8 @@
   box-sizing: border-box;
   /* Honor the site's body border visually */
   margin-inline: var(--helm-body-border);
+  /* we must override the default announcement bar height here for yarn build/serve */
+  height: var(--helm-announcement-bar-height);
 }
 
 [class*="announcementBarContent"] {
@@ -33,20 +43,22 @@
 
 /* bump content down when announcement is present */
 .theme-announcement-bar + .navbar + .main-wrapper {
-  margin-top: var(--docusaurus-announcement-bar-height);
+  margin-top: var(--helm-announcement-bar-height);
 }
 
 /* offset the sidebar viewport when announcement is present */
 @media (min-width: 997px) {
   #__docusaurus:has(.theme-announcement-bar) .theme-doc-sidebar-container {
-    margin-top: calc(-1 * calc(var(--ifm-navbar-height) + var(--docusaurus-announcement-bar-height)));
+    margin-top: calc(-1 * calc(var(--ifm-navbar-height) + var(--helm-announcement-bar-height)));
   }
 
-  #__docusaurus:has(.theme-announcement-bar) [class*="sidebarViewport"] .sidebar_njMd {
-    padding-top: calc(var(--ifm-navbar-height) + var(--docusaurus-announcement-bar-height));
+  /* target sidebar menu on both docs and blog with announcement bar */
+  #__docusaurus:has(.theme-announcement-bar) [class*="sidebarViewport"] .thin-scrollbar {
+    padding-top: var(--ifm-navbar-height);
   }
 
-  [class*="menuWithAnnouncementBar"] {
+  /* bottom of docs scrollbar when docusaurus adds this class with js */
+  #__docusaurus:has(.theme-announcement-bar) [class*="menuWithAnnouncementBar"] {
     margin-bottom: 0px;
   }
 }
@@ -54,14 +66,14 @@
 /* bump TOC on desktop down when announcement is present */
 #__docusaurus:has(.theme-announcement-bar) .theme-doc-toc-desktop,
 #__docusaurus:has(.theme-announcement-bar) [class*="tableOfContents"] {
-  top: calc(var(--ifm-navbar-height) + 1rem + var(--docusaurus-announcement-bar-height));
+  top: calc(var(--ifm-navbar-height) + 1rem + var(--helm-announcement-bar-height));
 }
 
 #__docusaurus:has(.theme-announcement-bar) [class*="tableOfContents"] {
-  max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem + var(--docusaurus-announcement-bar-height)));
+  max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem + var(--helm-announcement-bar-height)));
 }
 
 /* fix headers visually cut off by announcement bar */
 #__docusaurus:has(.theme-announcement-bar) .anchor {
-  scroll-margin-top: calc(var(--ifm-navbar-height) + 2rem + var(--docusaurus-announcement-bar-height));
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 2rem + var(--helm-announcement-bar-height));
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -59,9 +59,6 @@
   /* global navbar style (needed elsewhere) */
   --ifm-navbar-height: 5.5rem;
 
-  /* announcement bar */
-  --docusaurus-announcement-bar-height: 5rem;
-
   /* custom site vars */
   --helm-body-border: 8px;
 }


### PR DESCRIPTION
This PR:
- Resolves hero height not applying on initial page load due to React hydration timing
- Fixes page scrolling down on refresh when no announcement bar present
- Disables browser scroll restoration on homepage to prevent jumps
- Adds retry mechanism to ensure styles apply after React hydration
- Simplifies hero height calculator and removes excessive recalculations
- Sets CSS min-height to prevent layout shift during load

Netlify PR preview: https://deploy-preview-1840--helm-merge.netlify.app/

#### Before:
<img width="1512" height="806" alt="Screenshot 2025-10-27 at 9 09 18 PM" src="https://github.com/user-attachments/assets/bcc19ae4-7071-4646-8735-32a9e8bfe607" />

#### After (with announcement bar):
<img width="1512" height="805" alt="Screenshot 2025-10-27 at 9 09 56 PM" src="https://github.com/user-attachments/assets/78c5931a-92d4-411b-88f0-9f5702fc5bf5" />

#### After (no announcement bar):
<img width="1512" height="806" alt="Screenshot 2025-10-27 at 9 10 35 PM" src="https://github.com/user-attachments/assets/369e61ae-e668-449b-91c7-ad32e99cbdcb" />