### PR TITLE
Fix minified React error 418 (hydration mismatch)

### DIFF
--- a/ARCHITECTURAL_DECISIONS.md
+++ b/ARCHITECTURAL_DECISIONS.md
@@ -51,6 +51,20 @@ Hero content must never be hidden behind navbar or waves, especially on mobile l
 
 See `src/components/HomeHeader/styles.module.css` for implementation details.
 
+## React Hydration Warning Suppression
+
+### Helm-Specific Requirement
+
+The HomeCommunity component displays event dates using locale-specific formatting, which causes unavoidable hydration mismatches between server and client rendering.
+
+### Solution
+
+Following [React's official guidance for suppressing unavoidable hydration mismatches](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors), we use `suppressHydrationWarning` on date-displaying `<span>` elements in `src/components/HomeCommunity/index.js`.
+
+**Why this happens:** The server renders dates using one locale during static generation, but the client may have a different locale, causing React error #418 (text content mismatch). Since dates are intentionally locale-aware for internationalization, this mismatch is expected and acceptable.
+
+**Implementation:** Added `suppressHydrationWarning` prop to both date range and single date `<span>` elements in the CustomDate component.
+
 ## Boat and Wave Animation
 
 ### Helm-Specific Requirement

--- a/src/components/HomeCommunity/index.js
+++ b/src/components/HomeCommunity/index.js
@@ -1,3 +1,4 @@
+import React from "react";
 import clsx from "clsx";
 import Heading from "@theme/Heading";
 import styles from "./styles.module.css";
@@ -42,14 +43,14 @@ function CustomDate({dateString, formatType, endDateString}) {
     const year = yearFormatter.format(startDate);
 
     return (
-      <span>
+      <span suppressHydrationWarning>
         {startFormatted} - {endFormatted}, {year}
       </span>
     );
   } else {
     const options = formats[formatType] || formats['day'];
     const formatter = new Intl.DateTimeFormat(i18n.currentLocale, options);
-    return <span>{formatter.format(date)}</span>;
+    return <span suppressHydrationWarning>{formatter.format(date)}</span>;
   }
 }
 


### PR DESCRIPTION
Add suppressHydrationWarning to date spans in HomeCommunity component following React's
recommendation for unavoidable hydration mismatches.

Server and client may use different locales for date formatting, causing React error https://github.com/helm/helm-www/issues/418. This is
expected behavior for i18n support.

error:

```
main.b2965e39.js:2 Docusaurus React Root onRecoverableError: Error: Minified React error `#418`; visit https://react.dev/errors/418?args[]=text&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at bo (main.b2965e39.js:2:169197)
    at go (main.b2965e39.js:2:170216)
    at ms (main.b2965e39.js:2:223659)
    at mu (main.b2965e39.js:2:258817)
    at uu (main.b2965e39.js:2:256618)
    at cu (main.b2965e39.js:2:256529)
    at main.b2965e39.js:2:251646
    at Kc (main.b2965e39.js:2:251744)
    at Bu (main.b2965e39.js:2:267623)
    at MessagePort.j (main.b2965e39.js:2:3810) {componentStack: '\n    at span (<anonymous>)\n    at _ (https://helm.…ps://helm.sh/assets/js/main.b2965e39.js:2:544459)'}
n @ main.b2965e39.js:2
vu @ main.b2965e39.js:2
fu @ main.b2965e39.js:2
Yc @ main.b2965e39.js:2
Kc @ main.b2965e39.js:2
Bu @ main.b2965e39.js:2
j @ main.b2965e39.js:2
```

full message https://react.dev/errors/418?args[]=text&args[]=