### PR TITLE
Remove leading dollar from command examples in installation documentation across multiple languages

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -44,9 +44,9 @@ Sie können dieses Script aufrufen und lokal ausführen. Es ist gut dokumentiert
 so dass Sie es lesen und gut verstehen können, bevor Sie es ausführen.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Ja, Sie können auch `curl

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -44,9 +44,9 @@ Puede recuperar ese script y luego ejecutarlo localmente. Está bien documentado
 que puedas leerlo y comprender lo que está haciendo antes de ejecutarlo.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Sí, puedes `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`si

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -31,9 +31,9 @@ Helm a maintenant un script d'installation qui récupérera automatiquement la d
 Vous pouvez récupérer ce script, puis l'exécuter localement. Il est bien documenté donc que vous pouvez le lire et comprendre ce qu'il fait avant de l'exécuter.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Oui, vous pouvez également `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash` si vous aimez vivre dangereusement.

--- a/i18n/ja/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -41,9 +41,9 @@ Helm に、最新バージョンの Helm を自動的に取得して
 十分に文書化されているため、実行する前にそれを読んで何が行われているかを理解できます。
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 もちろん、

--- a/i18n/ko/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -39,9 +39,9 @@ sidebar_position: 2
 문서가 잘 작성되어 있으므로, 실행 전에 읽어보면 어떤 작업을 하는 것인지 이해할 수 있습니다.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 최신 버전을 설치하려면 `curl

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -44,9 +44,9 @@ Baixe o _script_ e execute-o localmente. O _script_ está bem escrito e document
 podendo ser verificado e revisado antes de proceder com a instalação local.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Sim, você pode executar `curl

--- a/i18n/ru/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -38,9 +38,9 @@ sidebar_position: 2
 Он хорошо документирован, так что вы можете прочитать его и понять, что он делает, прежде чем запускать.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Yes, you can `curl

--- a/i18n/uk/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/uk/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -29,9 +29,9 @@ sidebar_position: 2
 Ви можете завантажити цей скрипт, а потім виконати його локально. Він добре задокументований, щоб ви могли ознайомитися з ним і зрозуміти, що він робить перед його запуском.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Так, ви можете виконати `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`, якщо хочете жити на межі.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -30,9 +30,9 @@ Helm现在有个安装脚本可以自动拉取最新的Helm版本并在[本地�
 您可以获取这个脚本并在本地执行。它良好的文档会让您在执行之前知道脚本都做了什么。
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 如果想直接执行安装，运行`curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3

--- a/versioned_docs/version-3/intro/install.md
+++ b/versioned_docs/version-3/intro/install.md
@@ -43,9 +43,9 @@ You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Yes, you can `curl


### PR DESCRIPTION
This pull request updates the installation instructions for Helm across multiple language documentation files. The main change is the removal of the leading dollar $ prompt character from the example shell commands, ensuring consistency and clarity for users copying and running these commands.

Documentation updates for installation instructions:

* Removed the leading $ from shell command examples in the following files to improve clarity:
  - `versioned_docs/version-3/intro/install.md`
  - `i18n/de/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/es/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/ja/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/ko/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/pt/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/ru/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/uk/docusaurus-plugin-content-docs/version-3/intro/install.md`
  - `i18n/zh/docusaurus-plugin-content-docs/version-3/intro/install.md`