### PR TITLE
fix: Update author info in blog post

### DIFF
--- a/blog/2025-11-04-helm-at-kubecon-na-25.md
+++ b/blog/2025-11-04-helm-at-kubecon-na-25.md
@@ -1,9 +1,7 @@
 ---
 title: "Helm @ KubeCon + CloudNativeCon NA '25"
 slug: "helm-at-kubecon-na-25"
-authorname: "Karen Chu"
-author: "@karenhchu"
-authorlink: "https://bsky.app/profile/karenchu.online"
+authors: ["karenchu"]
 date: "2025-11-04"
 ---
 


### PR DESCRIPTION
the metadata format has changed for authors since migrating from hugo to docusaurus.

this will change the blog author info from this:
<img width="698" height="219" alt="Screenshot 2025-11-05 at 12 46 57 PM" src="https://github.com/user-attachments/assets/c3bbf9d2-a5aa-442b-a2fb-d0fe8359d846" />

to looking like this:
<img width="666" height="253" alt="Screenshot 2025-11-05 at 12 48 01 PM" src="https://github.com/user-attachments/assets/8dbe013e-2f09-4312-ba40-a5988a98d568" />
