### PR TITLE
Fix docs related to `merge` and `mustMerge` template functions

### DIFF
--- a/versioned_docs/version-3/chart_template_guide/function_list.md
+++ b/versioned_docs/version-3/chart_template_guide/function_list.md
@@ -1435,43 +1435,39 @@ merge a b c | dig "one" "two" "three" "<missing>"
 
 ### merge, mustMerge
 
-Merge two or more dictionaries into one, giving precedence to the dest
-dictionary:
-
-Given:
-
+Merge two or more dictionaries into one. Earlier arguments have higher
+precedence. For the data:
 ```
-dest:
-  default: default
-  overwrite: me
-  key: true
+source3:
+  field1: source3
+  field2: source3
+  field3: source3
 
-src:
-  overwrite: overwritten
-  key: false
-```
+source2:
+  field1: source2
+  field2: source2
 
-will result in:
-
+source1:
+  field1: source1
 ```
-newdict:
-  default: default
-  overwrite: me
-  key: true
+the template:
 ```
+$output := merge $source1 $source2 $source3
 ```
-$newdict := merge $dest $source1 $source2
+will result in the output:
 ```
-
+output:
+  field1: source1
+  field2: source2
+  field3: source3
+```
 This is a deep merge operation but not a deep copy operation. Nested objects
 that are merged are the same instance on both dicts. If you want a deep copy
 along with the merge, then use the `deepCopy` function along with merging. For
-example,
-
+example:
 ```
 deepCopy $source | merge $dest
 ```
-
 `mustMerge` will return an error in case of unsuccessful merge.
 
 ### mergeOverwrite, mustMergeOverwrite


### PR DESCRIPTION
I noticed that the docs for `merge` and `mustMerge` don't make any sense. This fixes this problem.

Also note that the docs for the `mergeOverwrite` and `mustMergeOverwrite` functions don't make sense, but I don't have time to understand them well enough to fix their docs.