### PR TITLE
Remove duplicate navigation entries in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -232,7 +232,7 @@ const config = {
               },
               {
                 label: "Developing Charts",
-                to: "#",
+                to: "docs/topics/charts",
               },
               {
                 label: "Search 800+ Charts",


### PR DESCRIPTION
Removed duplicate entries for 'Chart tips & tricks' and 'Developing Charts' from the footer navigation.