### PR TITLE
Fix i18n Next version label to match default language current version (4.0.0)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,6 +108,9 @@ const config = {
             // v2 is in /versioned_docs/version-2
             // TODO when we start work on Helm v5, we will copy /docs to /versioned_docs/version-4
             // and v5 will then live in /docs
+            // Be sure to update each locale's docusaurus-plugin-content-docs/current.json to match the current label
+            // To-do: add this snippet to automation for bumping the version for each new release:
+            // `for f in i18n/*/docusaurus-plugin-content-docs/current.json; do jq '."version.label".message = "4.0.0"' "$f" > "$f.tmp" && mv "$f.tmp" "$f"; done`
             current: { label: "4.0.0" },
             3: { label: "3.19.0", path: "v3" },
             2: { label: "2.17.0", path: "v2" },

--- a/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/el/docusaurus-plugin-content-docs/current.json
+++ b/i18n/el/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/pt/docusaurus-plugin-content-docs/current.json
+++ b/i18n/pt/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/ru/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ru/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/uk/docusaurus-plugin-content-docs/current.json
+++ b/i18n/uk/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {

--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "4.0.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Tutorial - Basics": {


### PR DESCRIPTION
Current site shows the configured version, "4.0.0", in the default language (EN):
<img width="342" height="219" alt="Screenshot 2025-11-20 at 12 31 09 AM" src="https://github.com/user-attachments/assets/72fa56ee-c8ae-4954-a84a-c8cec42c737b" />

But each i18n locale shows "Next":
<img width="423" height="222" alt="Screenshot 2025-11-20 at 12 32 25 AM" src="https://github.com/user-attachments/assets/715fd1ba-35dd-4736-81e6-1f7655203b1b" />

This PR fixes that.

I included a To-do with a snippet to add to our upcoming version release automation.