### PR TITLE
Fixed sitemap.xml uses localhost instead of https://helm.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SITE_URL := http://localhost:3000
-BASE_URL := /
+SITE_URL ?= http://localhost:3000
+BASE_URL ?= /
 
 clean:
 	rm -rf node_modules/ build/ .docusaurus .cache-loader


### PR DESCRIPTION
Changed SITE_URL and BASE_URL to use conditional assignment to allow sitemap.xml to use proper domain name.

Right now https://helm.sh/sitemap.xml looks like this

```xml
This XML file does not appear to have any style information associated with it. The document tree is shown below.
<urlset>
<url>
<loc>http://localhost:3000/blog</loc>
<changefreq>weekly</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>
http://localhost:3000/blog/2019/10/22/helm-2150-released
</loc>
<changefreq>weekly</changefreq>
<priority>0.5</priority>
</url>
…
<url>
<loc>http://localhost:3000/</loc>
<changefreq>weekly</changefreq>
<priority>0.5</priority>
</url>
</urlset>
```

This ☝️ prevents search engines from indexing the site.