### PR TITLE
fix(ci,community): update GH action Node version

### DIFF
--- a/.github/workflows/update-community-docs.yml
+++ b/.github/workflows/update-community-docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes broken run: https://github.com/helm/helm-www/actions/runs/19712536713/job/56476655580

```diff
Run actions/setup-node@v4
  with:
    node-version-file: .nvmrc
    cache: yarn
    always-auth: false
    check-latest: false
    token: ***
Error: The specified node version file at: /home/runner/work/helm-www/helm-www/.nvmrc does not exist
```

Although Node 24 is the LTS as of October this year, Node 22 is still currently the highest configurable major version for Netlify in the UI.

See options for this GH Action at https://github.com/actions/setup-node/blob/main/README.md.