### PR TITLE
style: unify comments in CheatSheet.mdx

### DIFF
--- a/docs/intro/CheatSheet.mdx
+++ b/docs/intro/CheatSheet.mdx
@@ -25,29 +25,29 @@ Release:
 - Is the name you assigned to an installation instance.
 
 Revision:
-- Is the value from the Helm history command
+- Is the value from the Helm history command.
 
 Repo-name:
 - The name of a repository.
 
 DIR:
-- Directory name/path
+- Directory name/path.
 
 ------------------------------------------------------------------------------------------------------------------------------------------------
 
 ### Chart Management
 
 ```bash
-helm create <name>                      # Creates a chart directory along with the common files and directories used in a chart.
-helm package <chart-path>               # Packages a chart into a versioned chart archive file.
-helm lint <chart>                       # Run tests to examine a chart and identify possible issues:
-helm show all <chart>                   # Inspect a chart and list its contents:
-helm show values <chart>                # Displays the contents of the values.yaml file
+helm create <name>                      # Create a chart directory along with the common files and directories used in a chart
+helm package <chart-path>               # Package a chart into a versioned chart archive file
+helm lint <chart>                       # Run tests to examine a chart and identify possible issues
+helm show all <chart>                   # Inspect a chart and list its contents
+helm show values <chart>                # Display the contents of the values.yaml file
 helm pull <chart>                       # Download/pull chart
 helm pull <chart> --untar=true          # If set to true, will untar the chart after downloading it
 helm pull <chart> --verify              # Verify the package before using it
 helm pull <chart> --version <number>    # Default-latest is used, specify a version constraint for the chart version to use
-helm dependency list <chart>            # Display a list of a chart’s dependencies:
+helm dependency list <chart>            # Display a list of a chart’s dependencies
 ```
 --------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -60,19 +60,19 @@ helm install <name> <chart> --set key1=val1,key2=val2 # Set values on the comman
 helm install <name> <chart> --values <yaml-file/url>  # Install the chart with your specified values
 helm install <name> <chart> --dry-run --debug         # Run a test installation to validate chart (p)
 helm install <name> <chart> --verify                  # Verify the package before using it
-helm install <name> <chart> --dependency-update       # update dependencies if they are missing before installing the chart
-helm uninstall <name>                                 # Uninstalls a release from the current (default) namespace
-helm uninstall <release-name> --namespace <namespace> # Uninstalls a release from the specified namespace
+helm install <name> <chart> --dependency-update       # Update dependencies if they are missing before installing the chart
+helm uninstall <name>                                 # Uninstall a release from the current (default) namespace
+helm uninstall <release-name> --namespace <namespace> # Uninstall a release from the specified namespace
 ```
 ------------------------------------------------------------------------------------------------------------------------------------------------
 ### Perform App Upgrade and Rollback
 
 ```bash
 helm upgrade <release> <chart>                            # Upgrade a release
-helm upgrade <release> <chart> --rollback-on-failure      # If set, upgrade process rolls back changes made in case of failed upgrade.
-helm upgrade <release> <chart> --dependency-update        # update dependencies if they are missing before installing the chart
-helm upgrade <release> <chart> --version <version_number> # specify a version constraint for the chart version to use
-helm upgrade <release> <chart> --values                   # specify values in a YAML file or a URL (can specify multiple)
+helm upgrade <release> <chart> --rollback-on-failure      # If set, upgrade process rolls back changes made in case of failed upgrade
+helm upgrade <release> <chart> --dependency-update        # Update dependencies if they are missing before installing the chart
+helm upgrade <release> <chart> --version <version_number> # Specify a version constraint for the chart version to use
+helm upgrade <release> <chart> --values                   # Specify values in a YAML file or a URL (can specify multiple)
 helm upgrade <release> <chart> --set key1=val1,key2=val2  # Set values on the command line (can specify multiple or separate valuese)
 helm upgrade <release> <chart> --force                    # Force resource updates through a replacement strategy
 helm rollback <release> <revision>                        # Roll back a release to a specific revision
@@ -82,11 +82,11 @@ helm rollback <release> <revision>  --cleanup-on-fail     # Allow deletion of ne
 ### List, Add, Remove, and Update Repositories
 
 ```bash
-helm repo add <repo-name> <url>   # Add a repository from the internet:
+helm repo add <repo-name> <url>   # Add a repository from the internet
 helm repo list                    # List added chart repositories
 helm repo update                  # Update information of available charts locally from chart repositories
 helm repo remove <repo_name>      # Remove one or more chart repositories
-helm repo index <DIR>             # Read the current directory and generate an index file based on the charts found.
+helm repo index <DIR>             # Read the current directory and generate an index file based on the charts found
 helm repo index <DIR> --merge     # Merge the generated index with an existing index file
 helm search repo <keyword>        # Search repositories for a keyword in charts
 helm search hub <keyword>         # Search for charts in the Artifact Hub or your own hub instance
@@ -95,7 +95,7 @@ helm search hub <keyword>         # Search for charts in the Artifact Hub or you
 ### Helm Release monitoring
 
 ```bash
-helm list                       # Lists all of the releases for a specified namespace, uses current namespace context if namespace not specified
+helm list                       # List all of the releases for a specified namespace, uses current namespace context if namespace not specified
 helm list --all                 # Show all releases without any filter applied, can use -a
 helm list --all-namespaces      # List releases across all namespaces, we can use -A
 helm list -l key1=value1,key2=value2 # Selector (label query) to filter on, supports '=', '==', and '!='
@@ -105,21 +105,21 @@ helm list --pending             # Show pending releases
 helm list --failed              # Show failed releases
 helm list --uninstalled         # Show uninstalled releases (if 'helm uninstall --keep-history' was used)
 helm list --superseded          # Show superseded releases
-helm list -o yaml               # Prints the output in the specified format. Allowed values: table, json, yaml (default table)
-helm status <release>           # This command shows the status of a named release.
+helm list -o yaml               # Print the output in the specified format. Allowed values: table, json, yaml (default table)
+helm status <release>           # Show the status of a named release
 helm status <release> --revision <number>   # if set, display the status of the named release with revision
-helm history <release>          # Historical revisions for a given release.
-helm env                        # Env prints out all the environment information in use by Helm.
+helm history <release>          # Historical revisions for a given release
+helm env                        # Print out all the environment information in use by Helm
 ```
 -------------------------------------------------------------------------------------------------------------------------------------------------
 ### Download Release Information
 
 ```bash
-helm get all <release>      # A human readable collection of information about the notes, hooks, supplied values, and generated manifest file of the given release.
-helm get hooks <release>    # This command downloads hooks for a given release. Hooks are formatted in YAML and separated by the YAML '---\n' separator.
-helm get manifest <release> # A manifest is a YAML-encoded representation of the Kubernetes resources that were generated from this release's chart(s). If a chart is dependent on other charts, those resources will also be included in the manifest.
-helm get notes <release>    # Shows notes provided by the chart of a named release.
-helm get values <release>   # Downloads a values file for a given release. use -o to format output
+helm get all <release>      # A human readable collection of information about the notes, hooks, supplied values, and generated manifest file of the given release
+helm get hooks <release>    # Download hooks for a given release. Hooks are formatted in YAML and separated by the YAML '---\n' separator
+helm get manifest <release> # A manifest is a YAML-encoded representation of the Kubernetes resources that were generated from this release's chart(s). If a chart is dependent on other charts, those resources will also be included in the manifest
+helm get notes <release>    # Show notes provided by the chart of a named release
+helm get values <release>   # Download a values file for a given release. use -o to format output
 ```
 -------------------------------------------------------------------------------------------------------------------------------------------------
 ### Plugin Management


### PR DESCRIPTION
style: unify comments in CheatSheet.mdx

1.    all comments begin with a capital letter
2.    remove unnecessary symbol, such as ":"
3.    write comments in a form of order - where it is possible

similar to #1865 



