### PR TITLE
Remove unnecessary dollar signs from commands

### DIFF
--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -43,9 +43,9 @@ You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Yes, you can `curl
@@ -165,9 +165,9 @@ you want to test the latest Helm version.
 You must have a working Go environment.
 
 ```console
-$ git clone https://github.com/helm/helm.git
-$ cd helm
-$ make
+git clone https://github.com/helm/helm.git
+cd helm
+make
 ```
 
 If required, it will fetch the dependencies and cache them, and validate


### PR DESCRIPTION
Currently, users need to copy + paste individual commands. These changes remove keystrokes for the users when installing helm, improving UX.
<img width="726" height="247" alt="Screenshot 2025-12-17 at 7 02 47 AM" src="https://github.com/user-attachments/assets/d47849a0-3b98-4b19-9ec6-90dfa32db298" />
