### PR TITLE
Fix KubeCon NA event showing as upcoming

### DIFF
--- a/src/components/HomeCommunity/index.js
+++ b/src/components/HomeCommunity/index.js
@@ -114,9 +114,9 @@ const BlockList = [
             </Translate>
           </dt>
           <dd>
-            <em><CustomDate dateString="2025-11-10" endDateString="2025-11-13" formatType="dayRange" /></em> -{" "}
-            <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/">
-              KubeCon North America
+            <em><CustomDate dateString="2026-03-23" endDateString="2026-03-26" formatType="dayRange" /></em> -{" "}
+            <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/">
+              KubeCon Europe 2026
             </a>
           </dd>
           <dt>
@@ -129,6 +129,12 @@ const BlockList = [
             </Translate>
           </dt>
           <dd>
+            <em><CustomDate dateString="2025-11-10" endDateString="2025-11-13" formatType="dayRange" /></em> -{" "}
+            <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/">
+              KubeCon North America 2025
+            </a>
+          </dd>
+          <dd>
             <em><CustomDate dateString="2025-04-01" endDateString="2025-04-04" formatType="dayRange" /></em> -{" "}
             <a href="https://events.linuxfoundation.org/archive/2025/kubecon-cloudnativecon-europe/">
               KubeCon Europe 2025
@@ -138,12 +144,6 @@ const BlockList = [
             <em><CustomDate dateString="2024-11-12" endDateString="2024-11-15" formatType="dayRange" /></em> -{" "}
             <a href="https://events.linuxfoundation.org/archive/2024/kubecon-cloudnativecon-north-america/">
               KubeCon North America 2024
-            </a>
-          </dd>
-          <dd>
-            <em><CustomDate dateString="2024-05-19" endDateString="2024-05-22" formatType="dayRange" /></em> -{" "}
-            <a href="https://events.linuxfoundation.org/archive/2024/kubecon-cloudnativecon-europe/">
-              KubeCon Europe 2024
             </a>
           </dd>
         </dl>


### PR DESCRIPTION
Fixes #1977  

### What
Moves KubeCon NA 2025 from Upcoming to Past Events on the Helm website.

### Why
KubeCon NA 2025 has already occurred but was still shown as upcoming.

### How
Updated the upcoming event listing with 2026 EU event and pushed the 2025 NA event into the past events list.

## Before:
<img width="403" height="324" alt="image" src="https://github.com/user-attachments/assets/f0816ff3-6236-4e64-8ba4-fa3610c104ce" />

## After:
<img width="423" height="340" alt="image" src="https://github.com/user-attachments/assets/f21afb02-a864-45c8-8733-222033ea2fcf" />

