### PR TITLE
Make docs tags more accessible

### DIFF
--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import TagsListInline from '@theme/TagsListInline';
+import EditMetaRow from '@theme/EditMetaRow';
+export default function DocItemFooter() {
+  const {metadata} = useDoc();
+  const {editUrl, lastUpdatedAt, lastUpdatedBy, tags} = metadata;
+  const canDisplayTagsRow = tags.length > 0;
+  const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+  const canDisplayFooter = canDisplayTagsRow || canDisplayEditMetaRow;
+  if (!canDisplayFooter) {
+    return null;
+  }
+  return (
+    <footer
+      className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
+      {canDisplayTagsRow && (
+        <div
+          className={clsx(
+            'row margin-top--sm',
+            ThemeClassNames.docs.docFooterTagsRow,
+          )}>
+          <div className="col">
+            <TagsListInline tags={tags} />
+          </div>
+        </div>
+      )}
+      {canDisplayEditMetaRow && (
+        <EditMetaRow
+          className={clsx(
+            'margin-top--sm',
+            ThemeClassNames.docs.docFooterEditMetaRow,
+          )}
+          editUrl={editUrl}
+          lastUpdatedAt={lastUpdatedAt}
+          lastUpdatedBy={lastUpdatedBy}
+        />
+      )}
+    </footer>
+  );
+}

--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -1,37 +1,27 @@
-import React from 'react';
-import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDoc} from '@docusaurus/plugin-content-docs/client';
-import TagsListInline from '@theme/TagsListInline';
-import EditMetaRow from '@theme/EditMetaRow';
+import React from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+
+import EditMetaRow from "@theme/EditMetaRow";
 export default function DocItemFooter() {
-  const {metadata} = useDoc();
-  const {editUrl, lastUpdatedAt, lastUpdatedBy, tags} = metadata;
-  const canDisplayTagsRow = tags.length > 0;
+  const { metadata } = useDoc();
+  const { editUrl, lastUpdatedAt, lastUpdatedBy } = metadata;
+
   const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
-  const canDisplayFooter = canDisplayTagsRow || canDisplayEditMetaRow;
+  const canDisplayFooter = canDisplayEditMetaRow;
   if (!canDisplayFooter) {
     return null;
   }
   return (
     <footer
-      className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}>
-      {canDisplayTagsRow && (
-        <div
-          className={clsx(
-            'row margin-top--sm',
-            ThemeClassNames.docs.docFooterTagsRow,
-          )}>
-          <div className="col">
-            <TagsListInline tags={tags} />
-          </div>
-        </div>
-      )}
+      className={clsx(ThemeClassNames.docs.docFooter, "docusaurus-mt-lg")}
+    >
       {canDisplayEditMetaRow && (
         <EditMetaRow
           className={clsx(
-            'margin-top--sm',
-            ThemeClassNames.docs.docFooterEditMetaRow,
+            "margin-top--sm",
+            ThemeClassNames.docs.docFooterEditMetaRow
           )}
           editUrl={editUrl}
           lastUpdatedAt={lastUpdatedAt}

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useWindowSize} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import ContentVisibility from '@theme/ContentVisibility';
+import styles from './styles.module.css';
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+export default function DocItemLayout({children}) {
+  const docTOC = useDocTOC();
+  const {metadata} = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,28 +1,30 @@
-import React from 'react';
-import clsx from 'clsx';
-import {useWindowSize} from '@docusaurus/theme-common';
-import {useDoc} from '@docusaurus/plugin-content-docs/client';
-import DocItemPaginator from '@theme/DocItem/Paginator';
-import DocVersionBanner from '@theme/DocVersionBanner';
-import DocVersionBadge from '@theme/DocVersionBadge';
-import DocItemFooter from '@theme/DocItem/Footer';
-import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
-import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
-import DocItemContent from '@theme/DocItem/Content';
-import DocBreadcrumbs from '@theme/DocBreadcrumbs';
-import ContentVisibility from '@theme/ContentVisibility';
-import styles from './styles.module.css';
+import React from "react";
+import clsx from "clsx";
+import { useWindowSize } from "@docusaurus/theme-common";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import DocItemPaginator from "@theme/DocItem/Paginator";
+import DocVersionBanner from "@theme/DocVersionBanner";
+import DocVersionBadge from "@theme/DocVersionBadge";
+import DocItemFooter from "@theme/DocItem/Footer";
+import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile";
+import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop";
+import DocItemContent from "@theme/DocItem/Content";
+import DocBreadcrumbs from "@theme/DocBreadcrumbs";
+import ContentVisibility from "@theme/ContentVisibility";
+import TagsListInline from "@theme/TagsListInline";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import styles from "./styles.module.css";
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
  */
 function useDocTOC() {
-  const {frontMatter, toc} = useDoc();
+  const { frontMatter, toc } = useDoc();
   const windowSize = useWindowSize();
   const hidden = frontMatter.hide_table_of_contents;
   const canRender = !hidden && toc.length > 0;
   const mobile = canRender ? <DocItemTOCMobile /> : undefined;
   const desktop =
-    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+    canRender && (windowSize === "desktop" || windowSize === "ssr") ? (
       <DocItemTOCDesktop />
     ) : undefined;
   return {
@@ -31,18 +33,32 @@ function useDocTOC() {
     desktop,
   };
 }
-export default function DocItemLayout({children}) {
+export default function DocItemLayout({ children }) {
   const docTOC = useDocTOC();
-  const {metadata} = useDoc();
+  const { metadata } = useDoc();
+  const { tags } = metadata;
+  const canDisplayTagsRow = tags.length > 0;
   return (
     <div className="row">
-      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+      <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
         <ContentVisibility metadata={metadata} />
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />
+            {canDisplayTagsRow && (
+              <div
+                className={clsx(
+                  "row margin-top--sm",
+                  ThemeClassNames.docs.docFooterTagsRow
+                )}
+              >
+                <div className="col">
+                  <TagsListInline tags={tags} />
+                </div>
+              </div>
+            )}
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
This PR moves docs tags (which we currently aren't using) from the bottom of the page to the top. See screenshots below.

We aren't currently using docs tags, but this could be a good way to categorize docs content in addition to the sidebar.

This PR swizzles two components:
- the Docs/Footer, in order to remove the inline tags
- the Docs/Layout, in order to add the inline tags below the version badge

Orthogonal to https://github.com/helm/helm-www/issues/1864, but could enhance that effort by providing links to pages that group certain types of docs content together in various ways.

---
## Move tags from bottom to top

### before
<img width="1512" height="982" alt="Screenshot 2025-12-05 at 4 57 08 PM" src="https://github.com/user-attachments/assets/210694c0-865e-433b-8c0e-319919ead485" />

### after
<img width="1512" height="982" alt="Screenshot 2025-12-05 at 4 54 44 PM" src="https://github.com/user-attachments/assets/5a919439-f159-4b5b-bd22-c6c7be17600e" />

---
## Style tags pages

### before

<img width="1512" height="982" alt="Screenshot 2025-12-05 at 4 54 57 PM" src="https://github.com/user-attachments/assets/be905104-c24e-482b-98eb-47f487308cbd" />
<img width="1512" height="982" alt="Screenshot 2025-12-05 at 4 59 40 PM" src="https://github.com/user-attachments/assets/a2a0b8ca-940e-45a8-b306-5af7ac756579" />

### after

