### PR TITLE
Modernize sync-repo.sh script and migrate to scriptexamples

### DIFF
--- a/docs/howto/chart_repository_sync_example.md
+++ b/docs/howto/chart_repository_sync_example.md
@@ -8,11 +8,11 @@ sidebar_position: 2
 which serves a chart repository.*
 
 ## Prerequisites
-* Install the [gsutil](https://cloud.google.com/storage/docs/gsutil) tool. *We
-  rely heavily on the gsutil rsync functionality*
+* Install the [gcloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk). *We
+  rely heavily on the gcloud storage rsync functionality*
 * Be sure to have access to the Helm binary
 * _Optional: We recommend you set [object
-  versioning](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#top_of_page)
+  versioning](https://cloud.google.com/storage/docs/object-versioning)
   on your GCS bucket in case you accidentally delete something._
 
 ## Set up a local chart repository directory
@@ -36,23 +36,21 @@ This will generate an updated index.yaml file and place it in the
 `fantastic-charts/` directory.
 
 ## Sync your local and remote chart repositories
-Upload the contents of the directory to your GCS bucket by running
-`scripts/sync-repo.sh` and pass in the local directory name and the GCS bucket
-name.
+Upload the contents of the directory to your GCS bucket by running the
+[sync-repo.sh](https://github.com/helm/helm-www/blob/main/scriptexamples/sync-repo.sh) script and pass in the local
+directory name and the GCS bucket name.
 
 For example:
 ```console
-$ pwd
-/Users/me/code/go/src/helm.sh/helm
-$ scripts/sync-repo.sh fantastic-charts/ fantastic-charts
+$ ./sync-repo.sh fantastic-charts/ fantastic-charts
 Getting ready to sync your local directory (fantastic-charts/) to a remote repository at gs://fantastic-charts
 Verifying Prerequisites....
-Thumbs up! Looks like you have gsutil. Let's continue.
+Thumbs up! Looks like you have gcloud. Let's continue.
 Building synchronization state...
 Starting synchronization
 Would copy file://fantastic-charts/alpine-0.1.0.tgz to gs://fantastic-charts/alpine-0.1.0.tgz
 Would copy file://fantastic-charts/index.yaml to gs://fantastic-charts/index.yaml
-Are you sure you would like to continue with these changes?? [y/N]} y
+Are you sure you would like to continue with these changes? [y/N] y
 Building synchronization state...
 Starting synchronization
 Copying file://fantastic-charts/alpine-0.1.0.tgz [Content-Type=application/x-tar]...
@@ -63,18 +61,18 @@ Congratulations your remote chart repository now matches the contents of fantast
 ```
 ## Updating your chart repository
 You'll want to keep a local copy of the contents of your chart repository or use
-`gsutil rsync` to copy the contents of your remote chart repository to a local
+`gcloud storage rsync` to copy the contents of your remote chart repository to a local
 directory.
 
 For example:
 ```console
-$ gsutil rsync -d -n gs://bucket-name local-dir/    # the -n flag does a dry run
+$ gcloud storage rsync --delete-unmatched-destination-objects --dry-run gs://bucket-name local-dir/
 Building synchronization state...
 Starting synchronization
 Would copy gs://bucket-name/alpine-0.1.0.tgz to file://local-dir/alpine-0.1.0.tgz
 Would copy gs://bucket-name/index.yaml to file://local-dir/index.yaml
 
-$ gsutil rsync -d gs://bucket-name local-dir/       # performs the copy actions
+$ gcloud storage rsync --delete-unmatched-destination-objects gs://bucket-name local-dir/
 Building synchronization state...
 Starting synchronization
 Copying gs://bucket-name/alpine-0.1.0.tgz...
@@ -84,9 +82,8 @@ Downloading file://local-dir/index.yaml:                              346 B/346 
 ```
 
 Helpful Links:
-* Documentation on [gsutil
-  rsync](https://cloud.google.com/storage/docs/gsutil/commands/rsync#description)
+* Documentation on [gcloud storage
+  rsync](https://cloud.google.com/sdk/gcloud/reference/storage/rsync)
 * [The Chart Repository Guide](/topics/chart_repository.md)
-* Documentation on [object versioning and concurrency
-  control](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#overview)
+* Documentation on [object versioning](https://cloud.google.com/storage/docs/object-versioning)
   in Google Cloud Storage

--- a/scriptexamples/sync-repo.sh
+++ b/scriptexamples/sync-repo.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bash 'Strict Mode'
+# http://redsymbol.net/articles/unofficial-bash-strict-mode
+set -euo pipefail
+IFS=$'\n\t'
+
+# Helper Functions -------------------------------------------------------------
+
+# Display error message and exit
+error_exit() {
+  echo "error: ${1:-"unknown error"}" 1>&2
+  exit 1
+}
+
+# Checks if a command exists.  Returns 1 or 0
+command_exists() {
+  hash "${1}" 2>/dev/null
+}
+
+# Program Functions ------------------------------------------------------------
+
+verify_prereqs() {
+  echo "Verifying Prerequisites...."
+  if command_exists gcloud; then
+    echo "Thumbs up! Looks like you have gcloud. Let's continue."
+  else
+    error_exit "Couldn't find gcloud. Bailing out."
+  fi
+}
+
+# Main -------------------------------------------------------------------------
+
+main() {
+  if [ "$#" -ne 2 ]; then
+    error_exit "Illegal number of parameters. You must pass in local directory path and a GCS bucket name"
+  fi
+
+  echo "Getting ready to sync your local directory ($1) to a remote repository at gs://$2"
+
+  verify_prereqs
+
+  # dry run of the command
+  gcloud storage rsync --delete-unmatched-destination-objects --dry-run "$1" gs://"$2"
+
+  read -r -p "Are you sure you would like to continue with these changes? [y/N] " confirm
+  if [[ $confirm =~ [yY](es)* ]]; then
+    gcloud storage rsync --delete-unmatched-destination-objects "$1" gs://"$2"
+  else
+    error_exit "Discontinuing sync process."
+  fi
+
+  echo "Your remote chart repository now matches the contents of the $1 directory!"
+
+}
+
+main "${@:-}"


### PR DESCRIPTION
### What

Modernizes the sync-repo.sh script by migrating from deprecated gsutil to gcloud CLI and relocates it to the helm-www repository.

### Why

The script in helm/helm was outdated:
- Used deprecated gsutil instead of the recommended gcloud CLI
- Hadn't been updated since Helm v2
- Served no internal purpose in the helm/helm repository
- Was only referenced by documentation in this repository

### How

- Created new scriptexamples/ directory (following the existing sdkexamples/ pattern)
- Added modernized sync-repo.sh using gcloud storage rsync commands
- Updated docs/howto/chart_repository_sync_example.md:
  - Changed prerequisites from gsutil to gcloud CLI
  - Updated script reference to new /scriptexamples/sync-repo.sh location
  - Replaced all gsutil rsync commands with gcloud storage rsync equivalents
  - Updated documentation links to current Google Cloud docs

Fixes helm/helm#31727