### PR TITLE
docs: add compression template functions

### DIFF
--- a/docs/chart_template_guide/function_list.mdx
+++ b/docs/chart_template_guide/function_list.mdx
@@ -15,6 +15,7 @@ They are listed here and broken down by the following categories:
 * [Date](#date-functions)
 * [Dictionaries](#dictionaries-and-dict-functions)
 * [Encoding](#encoding-functions)
+* [Compression](#compression-functions)
 * [File Path](#file-path-functions)
 * [Kubernetes and Chart](#kubernetes-and-chart-functions)
 * [Logic and Flow Control](#logic-and-flow-control-functions)
@@ -1607,6 +1608,35 @@ Helm has the following encoding and decoding functions:
 
 - `b64enc`/`b64dec`: Encode or decode with Base64
 - `b32enc`/`b32dec`: Encode or decode with Base32
+
+## Compression Functions
+
+Helm has the following compression and decompression functions:
+
+- `gzip`/`ungzip`: Compress or decompress with Gzip
+
+All compression functions return a Base64 encoded string. All decompression functions accept a Base64 encoded string.
+
+### gzip
+
+The `gzip` function compresses a string using Gzip and returns a Base64 encoded result.
+
+```
+gzip "Hello world!"
+```
+
+It enforces a size limit of 1MB on the output to prevent creating objects too large for Kubernetes Secrets/ConfigMap.
+
+### ungzip
+
+The `ungzip` function decodes a Base64 encoded string and then decompresses it using Gzip.
+
+```
+"H4sIAAAAAAAA/8pIzcnJVyjPL8pJAQQAAP//hRFKDQsAAAA=" | ungzip
+```
+
+It enforces a size limit of 1MB on the input string to prevent creating objects too large for Kubernetes Secrets. It also enforces a size limit of 1MB on the decompressed output and verifies that the content is valid UTF-8 text.
+
 
 ## Lists and List Functions
 


### PR DESCRIPTION
Document the new compression template functions added to Helm.

These functions allow for compression/decompression directly within templates, which is particularly useful for managing data in Secrets and ConfigMaps.

Related to helm/helm#31746