### PR TITLE
Modified for copy/paste to function

### DIFF
--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -43,9 +43,9 @@ You can fetch that script, and then execute it locally. It's well documented so
 that you can read through it and understand what it is doing before you run it.
 
 ```console
-$ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4
-$ chmod 700 get_helm.sh
-$ ./get_helm.sh
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4
+chmod 700 get_helm.sh
+./get_helm.sh
 ```
 
 Yes, you can `curl


### PR DESCRIPTION
Copy paste from this doc brings `$` results in the following:

`$: command not found`
