### PR TITLE
Fixed anchor link for Getter Plugin type (Issue #1985)

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -111,7 +111,7 @@ ignoreFlags: Ignores any flags passed in from Helm
 
 #### Getter Plugin Configuration
 
-If `type` field is `getter/v1`, it is a [Getter Plugin type](#cli-plugins), and the following plugin type configurations are allowed:
+If `type` field is `getter/v1`, it is a [Getter Plugin type](#getter-plugins), and the following plugin type configurations are allowed:
 
 ```yaml
 protocols: The list of schemes from the charts URL that this plugin supports.


### PR DESCRIPTION
Fixed issue #1985. 

The "Getter Plugin type" text previously linked to `#cli-plugins` instead of the correct anchor `#getter-plugins`.   This updates the link so it now points correctly to `#getter-plugins`.

Signed-off-by: Monal Gupta <monalmehal@gmail.com>