### PR TITLE
docs: Document --untar and --untardir flags for helm dependency update

### DIFF
--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -300,6 +300,37 @@ charts/
   mysql-3.2.1.tgz
 ```
 
+#### Extracting Dependencies as Directories
+
+By default, `helm dependency update` stores dependencies as compressed archives
+(`.tgz` files). To extract them as chart directories instead, use the `--untar`
+flag:
+
+```console
+$ helm dependency update --untar ./mychart
+```
+
+With `--untar`:
+- Dependencies are extracted into directories named after the chart (or its
+  alias if specified)
+- The original `.tgz` archives are removed after extraction
+- Re-running the command replaces existing directories, making the operation
+  idempotent
+
+To specify a different extraction directory, use `--untardir`:
+
+```console
+$ helm dependency update --untar --untardir vendor/charts ./mychart
+```
+
+The `--untardir` path must be relative to the chart root and cannot escape the
+chart directory through path traversal or symlinks. When using a custom
+`--untardir`, the archives in `charts/` are preserved and stale charts in the
+custom directory are not cleaned up.
+
+**NOTE:** The `--untar` and `--untardir` flags are only available for `helm
+dependency update`, not `helm dependency build`.
+
 #### Alias field in dependencies
 
 In addition to the other fields above, each requirements entry may contain the


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/change-history/f40268af-aefd-4ac7-8872-4b646d053ae6)

Adds a new section to the Chart Dependencies documentation explaining the `--untar` and `--untardir` flags for `helm dependency update`. These flags allow users to extract dependencies as directories instead of keeping them as `.tgz` archives, with support for custom extraction directories and idempotent re-runs.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31835">helm/helm PR #31835: dependency update: add untar flags with safe extraction flow</a></summary>
<br>

**Promptless Research** (1 GitHub PR)

- [Reviewed helm/helm#31835](https://github.com/helm/helm/pull/31835)

**Agent Response**

> I've completed the documentation update for this PR. Here's a summary of what I did:
> 
> ## Summary
> 
> I created a documentation suggestion to cover the new `--untar` and `--untardir` flags being added to `helm dependency update` in PR #31835.
> 
> ### What was documented
> 
> I added a new section called **"Extracting Dependencies as Directories"** to the Chart Dependencies documentation in `docs/topics/charts.mdx`. This section covers:
> 
> - How to use `--untar` to extract dependencies as directories instead of `.tgz` archives
> - How to specify a custom extraction directory with `--untardir`
> - Key behaviors (idempotent operation, archive cleanup, alias support)
> - Security restrictions (relative paths only, no symlink escapes)
> - Note clarifying these flags are only for `helm dependency update`, not `helm dependency build`
> 
> ### Why this approach
> 
> Per the client instructions, I did not modify the CLI reference docs at `docs/helm/` since those are auto-generated from code. Instead, I added conceptual documentation in the Charts guide where users learn about dependency management workflows.
> 
> ### Suggestion created
> 
> **Document --untar and --untardir flags for helm dependency update** - Adds a new section explaining how to extract dependencies as directories instead of keeping them as compressed archives.

</details>



---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_