### PR TITLE
docs: Document OCI registry search support for helm search repo

### DIFF
--- a/docs/intro/CheatSheet.mdx
+++ b/docs/intro/CheatSheet.mdx
@@ -89,6 +89,7 @@ helm repo remove <repo_name>      # Remove one or more chart repositories
 helm repo index <DIR>             # Read the current directory and generate an index file based on the charts found.
 helm repo index <DIR> --merge     # Merge the generated index with an existing index file
 helm search repo <keyword>        # Search repositories for a keyword in charts
+helm search repo oci://<registry>/<chart> --versions  # Search for chart versions in an OCI registry
 helm search hub <keyword>         # Search for charts in the Artifact Hub or your own hub instance
 ```
 -------------------------------------------------------------------------------------------------------------------------------------------------

--- a/docs/topics/registries.mdx
+++ b/docs/topics/registries.mdx
@@ -103,6 +103,7 @@ Here is a complete list:
 
 - `helm pull`
 - `helm push`
+- `helm search repo`
 - `helm show `
 - `helm template`
 - `helm install`
@@ -153,6 +154,56 @@ REVISION: 2
 NOTES:
 ...
 ```
+
+### Search OCI Registries
+
+Use `helm search repo` with an `oci://` reference to search for chart versions in an OCI registry. This queries the registry directly, so no local index file is needed.
+
+Helm fetches only the config layer (not the full chart tarball) for each semver-valid tag, making this operation lightweight and fast.
+
+#### Basic Usage
+
+Provide an `oci://` reference to `helm search repo`:
+
+```console
+$ helm search repo oci://ghcr.io/org/charts/mychart --versions
+NAME                                    CHART VERSION   APP VERSION   DESCRIPTION
+oci://ghcr.io/org/charts/mychart        1.2.0           2.0.0         My Helm chart
+oci://ghcr.io/org/charts/mychart        1.1.0           1.9.0         My Helm chart
+oci://ghcr.io/org/charts/mychart        1.0.0           1.0.0         My Helm chart
+```
+
+Without `--versions`, only the latest stable version is returned:
+
+```console
+$ helm search repo oci://ghcr.io/org/charts/mychart
+NAME                                    CHART VERSION   APP VERSION   DESCRIPTION
+oci://ghcr.io/org/charts/mychart        1.2.0           2.0.0         My Helm chart
+```
+
+#### Filter by Version
+
+Use `--version` to filter results by a semver constraint:
+
+```console
+$ helm search repo oci://ghcr.io/org/charts/mychart --version '^1.0.0' --versions
+```
+
+Use `--devel` to include pre-release versions (alpha, beta, release candidates):
+
+```console
+$ helm search repo oci://ghcr.io/org/charts/mychart --devel --versions
+```
+
+#### Authenticate to Private Registries
+
+For private registries, use the `--username` and `--password` flags:
+
+```console
+$ helm search repo oci://ghcr.io/org/charts/mychart --username myuser --password mypass --versions
+```
+
+Alternatively, log in first using `helm registry login`, and subsequent commands will use the stored credentials.
 
 ## Specifying dependencies
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/change-history/7e4c8c7b-d97f-416d-b365-0a1748841b3d)

Adds documentation for the new `helm search repo` capability to search OCI registries directly. Includes a new "Search OCI Registries" section in the OCI registries documentation with usage examples for listing versions, filtering by semver constraints, including pre-release versions, and authenticating to private registries. Also adds a quick reference example to the Cheat Sheet.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31837">helm/helm PR #31837: feat: add OCI registry search support for helm search repo</a></summary>
<br>

**Promptless Research** (1 GitHub PR)

- [Reviewed helm/helm#31837](https://github.com/helm/helm/pull/31837)

**Agent Response**

> I've completed the documentation updates for PR #31837 which adds OCI registry search support to `helm search repo`. 
> 
> ## Summary of Changes
> 
> I created a documentation suggestion with the following updates:
> 
> ### 1. OCI Registries Documentation (`docs/topics/registries.mdx`)
> - Added `helm search repo` to the list of commands supporting `oci://` protocol
> - Added a new **"Search OCI Registries"** section documenting:
>   - Basic usage with `oci://` references
>   - Listing all versions with `--versions`
>   - Filtering by semver constraints with `--version`
>   - Including pre-release versions with `--devel`
>   - Authentication options for private registries (`--username`/`--password`)
> 
> ### 2. Cheat Sheet (`docs/intro/CheatSheet.mdx`)
> - Added a quick reference example: `helm search repo oci://<registry>/<chart> --versions`
> 
> ## What This Feature Does
> 
> Previously, `helm search repo` returned "No results found" when using OCI registries since there was no local index to search. This new feature allows users to search for chart versions in OCI registries directly by querying the registry using the OCI Distribution Spec tag listing endpoint. The operation is lightweight since it only fetches the config layer (not the full chart tarball) for each semver-valid tag.
> 
> **Suggestion URL**: https://app.gopromptless.ai/change-history/7e4c8c7b-d97f-416d-b365-0a1748841b3d

</details>



---

_Tip: Set up a GitHub Issues trigger in [Projects](https://app.gopromptless.ai/projects) to enable @Promptless mentions in issues 🐙_