### PR TITLE
docs: Document JSON Schema $ref support for modular schemas

### DIFF
--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -957,6 +957,40 @@ parent chart. This also works backwards - if a subchart has a requirement that
 is not met in the subchart's `values.yaml` file, the parent chart *must* satisfy
 those restrictions in order to be valid.
 
+#### Using Schema References
+
+You can use JSON Schema `$ref` to split your schema into multiple files for better organization and reuse.
+
+For example, define a base schema in `base.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}
+```
+
+Then reference it from `values.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "user": { "$ref": "./base.schema.json" }
+  }
+}
+```
+
+Relative references are resolved from the chart directory.
+You can reference files in the same directory (`"$ref": "./other.schema.json"`) or in parent directories (`"$ref": "../shared.schema.json"`).
+
 Schema validation can be disabled by setting the option shown below.
 This is particularly useful in air-gapped environments when a chart's JSON Schema file contains remote references.
 ```console

--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -991,6 +991,11 @@ Then reference it from `values.schema.json`:
 Relative references are resolved from the chart directory.
 You can reference files in the same directory (`"$ref": "./other.schema.json"`) or in parent directories (`"$ref": "../shared.schema.json"`).
 
+:::note
+Schema `$ref` resolution only works for unpacked chart directories.
+For archived charts (`.tgz` files), references cannot be resolved because the chart is loaded into memory without filesystem extraction.
+:::
+
 Schema validation can be disabled by setting the option shown below.
 This is particularly useful in air-gapped environments when a chart's JSON Schema file contains remote references.
 ```console


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/f483ec85-011b-42f1-8e94-a72c0dce71f5)

Adds a new "Using Schema References" subsection to the Schema Files documentation explaining how to use JSON Schema `$ref` to split schemas into multiple files for better organization and reuse. Includes examples showing how to define a base schema and reference it from `values.schema.json`, plus notes on relative path resolution from the chart directory.

This documents functionality that is properly supported after the fix in helm/helm#31274.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31274">helm/helm PR #31274: Resolve JSON schema reference paths for relative imports</a></summary>
<br>

**Promptless Research** (1 webpage, 1 GitHub PR)

- [Reviewed helm/helm#31274](https://github.com/helm/helm/pull/31274)
- [Read webpage from github.com](https://github.com/helm/helm-www/blob/main/style-guide.md)

**Agent Response**

> I've reviewed PR #31274 and created a documentation suggestion.
> 
> ## Summary
> 
> **PR #31274** fixes a bug where relative `$ref` paths in JSON schemas weren't resolving correctly. Previously, schemas using relative references like `"$ref": "./other-schema.json"` would fail during validation with `helm lint`, `helm install`, `helm upgrade`, and `helm template`.
> 
> While the PR author marked this as not requiring documentation (since it's a bug fix), I noticed the existing Schema Files documentation doesn't mention that `$ref` is supported at all. Since this feature now works properly, documenting it helps users who want to split their schemas into multiple files for better organization and reuse.
> 
> ## Documentation Change
> 
> I've created a suggestion that adds a new **"Using Schema References"** subsection to the Schema Files documentation in `docs/topics/charts.mdx`. The new section includes:
> 
> - An explanation that JSON Schema `$ref` can be used to split schemas into multiple files
> - A practical example showing a base schema (`base.schema.json`) and how to reference it from `values.schema.json`
> - Notes on relative path resolution from the chart directory
> 
> This fills a documentation gap and helps users take advantage of modular schema organization now that the bug is fixed.

</details>



---

_Tip: Request one-off documentation tasks in the Dashboard under [New Task](https://app.gopromptless.ai/new-task) 🚀_