### PR TITLE
docs: Clarify HELM_PLUGINS can be a path list

### DIFF
--- a/docs/topics/plugins.mdx
+++ b/docs/topics/plugins.mdx
@@ -29,9 +29,7 @@ Helm plugins have the following features:
 - They can be written in any programming language.
 - They integrate with Helm, and will show up in `helm help` and other places.
 
-Helm plugins live in `$HELM_PLUGINS`. You can find the current value of this,
-including the default value when not set in the environment, using the
-`helm env` command.
+Helm plugins live in `$HELM_PLUGINS`. This variable can be a single directory or a list of directories separated by your system's path separator (`:` on Unix/macOS, `;` on Windows). Helm searches directories in order, with earlier entries taking precedence. You can find the current value of this, including the default value when not set in the environment, using the `helm env` command.
 
 The Helm plugin model is partially based on Git's plugin model. To that end,
 you may sometimes hear `helm` referred to as the _porcelain_ layer, with plugins
@@ -44,8 +42,9 @@ the user experience and top level processing logic, while the plugins do the
 Plugins are installed using the `$ helm plugin install <path|url>` command. You
 can pass in a path to a plugin on your local file system or a url of a remote
 VCS repo. The `helm plugin install` command clones or copies the plugin at the
-path/url given into `$HELM_PLUGINS`. If you are installing from a VCS you can specify
-the version with the `--version` argument.
+given path or URL into `$HELM_PLUGINS`. When `$HELM_PLUGINS` contains multiple
+directories, plugins are installed to the first one. To specify a version when
+installing from a VCS, use the `--version` flag.
 
 ```console
 $ helm plugin install https://github.com/adamreese/helm-env
@@ -314,7 +313,7 @@ environment.
 
 The following variables are guaranteed to be set:
 
-- `HELM_PLUGINS`: The path to the plugins directory.
+- `HELM_PLUGINS`: The path to the plugins directory. Can be a single directory or multiple directories separated by the OS path separator (`:` on Unix/macOS, `;` on Windows).
 - `HELM_PLUGIN_NAME`: The name of the plugin, as invoked by `helm`. So `helm
   myplug` will have the short name `myplug`.
 - `HELM_PLUGIN_DIR`: The directory that contains the plugin.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/29d164a9-2aa8-4c55-b7df-32616fc82bbd)

Documents that the `HELM_PLUGINS` environment variable can contain multiple directories separated by the system path separator (`:` on Unix/macOS, `;` on Windows). Clarifies that Helm searches directories in order with earlier entries taking precedence, and that plugins are installed to the first directory in the list. This documents behavior that was fixed in helm/helm#31906.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31906">helm/helm PR #31906: fix(plugin): install to first HELM_PLUGINS path entry</a></summary>
<br>

**Promptless Research** (1 GitHub PR)

- [Reviewed helm/helm#31906](https://github.com/helm/helm/pull/31906)

**Agent Response**

> I've completed my review of this PR and created a documentation update.
> 
> ## Summary
> 
> **PR #31906** fixes a bug where `helm plugin install` was treating `HELM_PLUGINS` as a literal string instead of parsing it as a path list. For example, if `HELM_PLUGINS=/tmp/abc:/tmp/xyz`, plugins were incorrectly being installed to `/tmp/abc:/tmp/xyz/<plugin>` (a literal path) instead of `/tmp/abc/<plugin>` (the first directory in the list).
> 
> ## Documentation Update
> 
> While reviewing this fix, I identified that the plugin documentation didn't explain that `HELM_PLUGINS` can contain multiple directories (like the `PATH` environment variable). I've created a documentation suggestion that clarifies:
> 
> 1. **Overview section**: `HELM_PLUGINS` can be a single directory or a list of directories separated by the system path separator (`:` on Unix/macOS, `;` on Windows), and Helm searches directories in order with earlier entries taking precedence
> 
> 2. **Installing a Plugin section**: When `HELM_PLUGINS` contains multiple directories, plugins are installed to the first one
> 
> 3. **Environment Variables section**: Updated the `HELM_PLUGINS` description to mention it supports multiple directories
> 
> This documentation improvement will help users who want to configure multiple plugin directories (e.g., system-wide plugins alongside user-specific plugins) understand how Helm handles plugin discovery and installation.

</details>



---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_