### PR TITLE
docs: Document JSON Schema format keyword validation

### DIFF
--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -920,6 +920,27 @@ something like this:
 }
 ```
 
+JSON Schema supports the `format` keyword for validating string formats like
+email addresses, IP addresses, and URIs. For example:
+
+```json
+{
+  "properties": {
+    "serverIP": {
+      "type": "string",
+      "format": "ipv4"
+    },
+    "contactEmail": {
+      "type": "string",
+      "format": "email"
+    }
+  }
+}
+```
+
+Common format keywords include `ipv4`, `ipv6`, `email`, `uri`, `hostname`, and
+`date-time`. Validation fails if a value doesn't match the specified format.
+
 This schema will be applied to the values to validate it. Validation occurs when
 any of the following commands are invoked:
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/ea1ec96a-139d-4e67-8c40-fa6ec0c57853)

Documents that `values.schema.json` supports the JSON Schema `format` keyword for validating string formats like `ipv4`, `ipv6`, `email`, `uri`, `hostname`, and `date-time`. Adds an example showing how to use format validation in the Schema Files section.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31937">helm/helm PR #31937: fix(chartutil): enable format assertions in JSON schema validation</a></summary>
<br>

**Promptless Research** (5 files, 1 webpage, 1 GitHub PR)

- [Reviewed helm/helm#31937](https://github.com/helm/helm/pull/31937)
- Viewed `.long_term_context/product_knowledge/product_overview.md`
- Viewed `.long_term_context/doc_workflow/client_instructions.md`
- Viewed `.long_term_context/style/client_style_guide.md`
- [Read webpage from github.com](https://github.com/helm/helm-www/blob/main/style-guide.md)
- Viewed `docs/topics/charts.mdx`
- Viewed `docs/helm/helm_lint.md`

**Agent Response**

> I've reviewed PR #31937 and created a documentation suggestion.
> 
> ## Summary
> 
> **PR #31937** fixes a bug where `helm lint` and other schema validation commands were not enforcing JSON Schema `format` keywords (like `ipv4`, `ipv6`, `email`, `uri`, etc.) in `values.schema.json` files. This was a behavioral change that users should be aware of.
> 
> ## Documentation Update
> 
> I added a new section to the Schema Files documentation in `docs/topics/charts.mdx` that:
> 
> 1. Explains that JSON Schema `format` keywords are supported for validating string formats
> 2. Provides an example showing how to use `format: "ipv4"` and `format: "email"` in a schema
> 3. Lists common format keywords: `ipv4`, `ipv6`, `email`, `uri`, `hostname`, and `date-time`
> 
> **Suggestion created**: [Document JSON Schema format keyword validation](https://app.gopromptless.ai/suggestions/ea1ec96a-139d-4e67-8c40-fa6ec0c57853)
> 
> The existing documentation covered type validation, minimum/maximum constraints, and required fields, but did not mention format keywords at all. This update fills that gap and documents the feature that PR #31937 ensures is now properly working.

</details>



---

_Tip: Tag @Promptless in GitHub PR comments to guide documentation changes during code review 🐙_