### PR TITLE
docs: Document mustToToml template function in version-3 docs

### DIFF
--- a/versioned_docs/version-3/chart_template_guide/function_list.md
+++ b/versioned_docs/version-3/chart_template_guide/function_list.md
@@ -702,7 +702,7 @@ The following type conversion functions are provided by Helm:
 - `fromJsonArray`: Convert a JSON array to a list.
 - `toYaml`: Convert list, slice, array, dict, or object to indented yaml, can be used to copy chunks of yaml from any source. This function is equivalent to GoLang yaml.Marshal function, see docs here: https://pkg.go.dev/gopkg.in/yaml.v2#Marshal
 - `toYamlPretty`: Convert list, slice, array, dict, or object to indented yaml. Equivalent to `toYaml` but will additionally indent lists by 2 spaces.
-- `toToml`: Convert list, slice, array, dict, or object to toml, can be used to copy chunks of toml from any source.
+- `toToml` (`mustToToml`): Convert list, slice, array, dict, or object to toml, can be used to copy chunks of toml from any source.
 - `fromYamlArray`: Convert a YAML array to a list.
 
 Only `atoi` requires that the input be a specific type. The others will attempt
@@ -871,6 +871,18 @@ greeting: |
   Hi, my name is {{ $person.name }} and I am {{ $person.age }} years old.
 {{ end }}
 ```
+
+### toToml, mustToToml
+
+The `toToml` function encodes an item into a TOML string. If the item cannot be
+converted to TOML the function will return an empty string. `mustToToml` will
+return an error in case the item cannot be encoded in TOML.
+
+```
+toToml .Item
+```
+
+The above returns TOML string representation of `.Item`.
 
 
 ## Regular Expressions

--- a/versioned_docs/version-3/chart_template_guide/function_list.md
+++ b/versioned_docs/version-3/chart_template_guide/function_list.md
@@ -875,8 +875,9 @@ greeting: |
 ### toToml, mustToToml
 
 The `toToml` function encodes an item into a TOML string. If the item cannot be
-converted to TOML the function will return an empty string. `mustToToml` will
-return an error in case the item cannot be encoded in TOML.
+converted to TOML, `toToml` returns the error message as a string. `mustToToml`
+will return an error to the template engine if the item cannot be encoded in
+TOML.
 
 ```
 toToml .Item


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/2204db78-a555-4585-9cc3-238631ba50a6)

Adds documentation for the new `mustToToml` template function to the version-3 function list. Updates the summary to include `mustToToml` alongside `toToml`, and adds a detailed section explaining that `toToml` returns an empty string on error while `mustToToml` returns an error—matching the behavior of `toJson`/`mustToJson`.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31949">helm/helm PR #31949: fix(engine): make toToml return empty string on error, add mustToToml</a></summary>
<br>

**Promptless Research** (5 files, 1 GitHub PR)

- [Reviewed helm/helm#31949](https://github.com/helm/helm/pull/31949)
- Viewed `.long_term_context/product_knowledge/product_overview.md`
- Viewed `.long_term_context/doc_workflow/client_instructions.md`
- Viewed `.long_term_context/style/client_style_guide.md`
- Viewed `versioned_docs/version-3/chart_template_guide/function_list.md`
- Viewed `docs/chart_template_guide/function_list.mdx`

**Agent Response**

> I've reviewed the PR and created a documentation suggestion.
> 
> ## Summary
> 
> **PR helm/helm#31949** makes two changes to the `toToml` template function:
> 1. **Bug fix**: `toToml` now returns an empty string on error (previously it returned the error message, inconsistent with `toYaml`/`toJson`)
> 2. **New function**: Adds `mustToToml` which returns an error on encoding failure (consistent with `mustToYaml`/`mustToJson`)
> 
> ## Documentation Changes
> 
> I found that the **current docs** (`docs/chart_template_guide/function_list.mdx`) already have `mustToToml` documented, but the **version-3 docs** were missing this documentation.
> 
> I updated `versioned_docs/version-3/chart_template_guide/function_list.md`:
> - Added `mustToToml` to the function summary list alongside `toToml`
> - Added a new `### toToml, mustToToml` section explaining the error handling behavior for both functions
> 
> The documentation follows the same pattern used for `toJson`/`mustToJson` and other similar function pairs.
> 
> **Suggestion URL**: https://app.gopromptless.ai/suggestions/2204db78-a555-4585-9cc3-238631ba50a6

</details>



---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_