### PR TITLE
docs: Document toPrettyJson HTML character preservation

### DIFF
--- a/docs/chart_template_guide/function_list.mdx
+++ b/docs/chart_template_guide/function_list.mdx
@@ -698,7 +698,7 @@ The following type conversion functions are provided by Helm:
 - `toStrings`: Convert a list, slice, or array to a list of strings.
 - `toJson` (`mustToJson`): Convert list, slice, array, dict, or object to JSON.
 - `toPrettyJson` (`mustToPrettyJson`): Convert list, slice, array, dict, or
-  object to indented JSON.
+  object to indented JSON with HTML characters unescaped.
 - `toRawJson` (`mustToRawJson`): Convert list, slice, array, dict, or object to
   JSON with HTML characters unescaped.
 - `fromYaml`: Convert a YAML string to an object.
@@ -749,7 +749,9 @@ The above returns JSON string representation of `.Item`.
 ### toPrettyJson, mustToPrettyJson
 
 The `toPrettyJson` function encodes an item into a pretty (indented) JSON
-string.
+string with HTML characters (`&`, `<`, `>`) preserved. This means URLs and
+other strings containing these characters will render correctly without
+escaping them to `\u0026`, `\u003c`, `\u003e`.
 
 ```
 toPrettyJson .Item

--- a/versioned_docs/version-3/chart_template_guide/function_list.md
+++ b/versioned_docs/version-3/chart_template_guide/function_list.md
@@ -694,7 +694,7 @@ The following type conversion functions are provided by Helm:
 - `toStrings`: Convert a list, slice, or array to a list of strings.
 - `toJson` (`mustToJson`): Convert list, slice, array, dict, or object to JSON.
 - `toPrettyJson` (`mustToPrettyJson`): Convert list, slice, array, dict, or
-  object to indented JSON.
+  object to indented JSON with HTML characters unescaped.
 - `toRawJson` (`mustToRawJson`): Convert list, slice, array, dict, or object to
   JSON with HTML characters unescaped.
 - `fromYaml`: Convert a YAML string to an object.
@@ -745,7 +745,9 @@ The above returns JSON string representation of `.Item`.
 ### toPrettyJson, mustToPrettyJson
 
 The `toPrettyJson` function encodes an item into a pretty (indented) JSON
-string.
+string with HTML characters (`&`, `<`, `>`) preserved. This means URLs and
+other strings containing these characters will render correctly without
+escaping them to `\u0026`, `\u003c`, `\u003e`.
 
 ```
 toPrettyJson .Item


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/396e193f-3010-4cdd-847c-1a84a8f14bf6)

Updates the `toPrettyJson` and `mustToPrettyJson` documentation to clarify that these functions preserve HTML characters (`&`, `<`, `>`) without escaping them to Unicode sequences like `\u0026`. This documents the bug fix from helm/helm#31964, which makes URLs and other strings containing these characters render correctly in JSON output.

### Trigger Events

<details>
<summary><a href="https://github.com/helm/helm/pull/31964">helm/helm PR #31964: fix(engine): override toPrettyJson to disable HTML escaping</a></summary>
<br>

**Promptless Research** (5 files, 1 GitHub PR)

- [Reviewed helm/helm#31964](https://github.com/helm/helm/pull/31964)
- Viewed `.long_term_context/product_knowledge/product_overview.md`
- Viewed `.long_term_context/doc_workflow/client_instructions.md`
- Viewed `.long_term_context/style/client_style_guide.md`
- Viewed `docs/chart_template_guide/function_list.mdx`
- Viewed `versioned_docs/version-3/chart_template_guide/function_list.md`

**Agent Response**

> I've reviewed PR #31964 and created a documentation suggestion.
> 
> ## Summary
> 
> **PR #31964** fixes a bug where `toPrettyJson` and `mustToPrettyJson` were HTML-escaping special characters (`&`, `<`, `>`) to Unicode sequences (`\u0026`, `\u003c`, `\u003e`), which broke URLs and other strings in chart templates. The fix overrides these functions to preserve the characters literally.
> 
> ## Documentation Update
> 
> I created a suggestion that updates the `toPrettyJson` documentation in:
> - `docs/chart_template_guide/function_list.mdx` (current docs)
> - `versioned_docs/version-3/chart_template_guide/function_list.md` (version 3 docs)
> 
> **Changes made:**
> 1. Updated the summary bullet point to mention "with HTML characters unescaped"
> 2. Expanded the detailed section to explain that HTML characters (`&`, `<`, `>`) are preserved without being escaped to Unicode sequences, making URLs render correctly
> 
> **Suggestion:** [Document toPrettyJson HTML character preservation](https://app.gopromptless.ai/suggestions/396e193f-3010-4cdd-847c-1a84a8f14bf6)

</details>



---

_Tip: Tag @Promptless in GitHub PR comments to guide documentation changes during code review 🐙_