### PR TITLE
Clarify helm registry login host format requirements

### DIFF
--- a/docs/topics/registries.mdx
+++ b/docs/topics/registries.mdx
@@ -55,6 +55,15 @@ Password:
 Login succeeded
 ```
 
+The host must be only the registry hostname, optionally with a port. Do not include a URL scheme or path:
+
+| Example | Valid |
+|---------|-------|
+| `ghcr.io` | Yes |
+| `localhost:5000` | Yes |
+| `https://ghcr.io` | No - scheme not allowed |
+| `ghcr.io/myrepo` | No - path not allowed |
+
 #### `logout`
 
 logout from a registry


### PR DESCRIPTION
Documents that the host parameter for `helm registry login` must be only the registry hostname with an optional port, without URL schemes (http://, https://) or paths. Adds a table with valid and invalid examples to the OCI registries documentation.