### PR TITLE
Fix typos and update stale documentation links

### DIFF
--- a/docs/chart_template_guide/functions_and_pipelines.mdx
+++ b/docs/chart_template_guide/functions_and_pipelines.mdx
@@ -10,7 +10,7 @@ import Helm4 from "/docs/_v4-in-progress.mdx"
 
 So far, we've seen how to place information into a template. But that
 information is placed into the template unmodified. Sometimes we want to
-transform the supplied data in a way that makes it more useable to us.
+transform the supplied data in a way that makes it more usable to us.
 
 Let's start with a best practice: When injecting strings from the `.Values`
 object into the template, we ought to quote these strings. We can do that by

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -26,7 +26,7 @@ The main reason is plugins that add `helm` CLI sub-commands can leverage Helm-sp
 
 ### Getter Plugins
 
-Helm has build-in support for working with [Charts](/glossary/index.mdx#chart) and Plugins on your local filesystem or stored as artifacts in [OCI Registries](/topics/registries.mdx). Charts can additionally be stored in [HTTP repositories](/topics/chart_repository.md), and plugins can additionally be stored in VCS repositories like Git.
+Helm has built-in support for working with [Charts](/glossary/index.mdx#chart) and Plugins on your local filesystem or stored as artifacts in [OCI Registries](/topics/registries.mdx). Charts can additionally be stored in [HTTP repositories](/topics/chart_repository.md), and plugins can additionally be stored in VCS repositories like Git.
 
 Helm Getter plugins allow you to extend this storage and download behavior to support other storage locations. There are community Getter plugins for storing Charts and Plugins in [s3 buckets](/community/related#helm-plugins), and elsewhere. You will want to use getter plugins if you need additional storage options for your Helm workflows.
 

--- a/docs/plugins/user/index.md
+++ b/docs/plugins/user/index.md
@@ -31,7 +31,7 @@ The `helm plugin list` command also includes high-level provenance information a
 
 ## Installing Plugins
 
-Helm has a build-in command to install plugins that defaults to secure installation. However, be sure to read [Plugin Security](#plugin-security) to understand what to check before installing.
+Helm has a built-in command to install plugins that defaults to secure installation. However, be sure to read [Plugin Security](#plugin-security) to understand what to check before installing.
 
 See `helm plugin install --help` for more information.
 

--- a/docs/topics/kubernetes_distros.md
+++ b/docs/topics/kubernetes_distros.md
@@ -100,4 +100,4 @@ KUBECONFIG=/etc/kubernetes/admin.conf` or create a `~/.kube/config`.
 
 Helm runs on VMware Tanzu Kubernetes Grid, TKG, without needing configuration changes.
 The Tanzu CLI can manage installing packages for [helm-controller](https://fluxcd.io/flux/components/helm/) allowing for declaratively managing Helm chart releases.
-Further details available in the TKG documentation for [CLI-Managed Packages](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.6/vmware-tanzu-kubernetes-grid-16/GUID-packages-user-managed-index.html#package-locations-and-dependencies-5).
+Further details are available in the [Tanzu Kubernetes Grid documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-kubernetes-grid/2-5/tkg/index.html).

--- a/docs/topics/plugins.mdx
+++ b/docs/topics/plugins.mdx
@@ -153,7 +153,7 @@ it will be used.
 ### The `platformHooks` Field
 
 The `platformHooks` configures the commands that the plugin will execute for lifecycle
-events. You can't set both `platformHooks` & `hooks` as this will resultin an error.
+events. You can't set both `platformHooks` & `hooks` as this will result in an error.
 The following rules will apply in deciding which hook command to use:
 
 - If `platformHooks` is present, it will be used and the commands for the lifecycle

--- a/docs/topics/registries.mdx
+++ b/docs/topics/registries.mdx
@@ -21,7 +21,7 @@ A [Helm repository](/topics/chart_repository.md) is a way to house and distribut
 There are several hosted container registries with OCI support that you can use for your Helm charts. For example:
 
 - [Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/push-oci-artifact.html)
-- [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-helm-repos#push-chart-to-registry-as-oci-artifact)
+- [Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-helm-repos#push-chart-to-registry-as-oci-artifact)
 - [Cloudsmith](https://help.cloudsmith.io/docs/oci-repository)
 - [Docker Hub](https://docs.docker.com/docker-hub/oci-artifacts/)
 - [Google Artifact Registry](https://cloud.google.com/artifact-registry/docs/helm/manage-charts)


### PR DESCRIPTION
Fix four typos and update two stale links across six documentation files.

**Typos:**
- `docs/plugins/overview.md`: "build-in" → "built-in"
- `docs/plugins/user/index.md`: "build-in" → "built-in"
- `docs/chart_template_guide/functions_and_pipelines.mdx`: "useable" → "usable"
- `docs/topics/plugins.mdx`: "resultin" → "result in"

**Stale links:**
- `docs/topics/kubernetes_distros.md`: TKG documentation link was pinned to version 1.6 and pointed to the old `docs.vmware.com` domain. Updated to the current TKG documentation on `techdocs.broadcom.com` following Broadcom's acquisition of VMware. Also corrected grammatically incomplete sentence and updated link text to match the target page.
- `docs/topics/registries.mdx`: Azure Container Registry docs link updated from `docs.microsoft.com` to `learn.microsoft.com`, with the original `#push-chart-to-registry-as-oci-artifact` anchor preserved.