### PR TITLE
Update release checklist to reference get-helm-4 script

### DIFF
--- a/community/release_checklist.md
+++ b/community/release_checklist.md
@@ -379,7 +379,7 @@ Download Helm X.Y. The common platform binaries are here:
 - [Linux s390x](https://get.helm.sh/helm-vX.Y.Z-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-vX.Y.Z-linux-s390x.tar.gz.sha256sum) / CHECKSUM_VAL)
 - [Windows amd64](https://get.helm.sh/helm-vX.Y.Z-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-vX.Y.Z-windows-amd64.zip.sha256sum) / CHECKSUM_VAL)
 
-The [Quickstart Guide](/intro/quickstart.md) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](/intro/install.mdx). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.
+The [Quickstart Guide](/intro/quickstart.md) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](/intro/install.mdx). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4) on any system with `bash`.
 
 ## What's Next
 


### PR DESCRIPTION
Updates the example release notes template in the maintainer release checklist to reference the `get-helm-4` install script instead of `get-helm-3`, aligning with Helm v4 release practices.