### PR TITLE
docs(topics/plugins): mark page as legacy and link to Helm 4 plugin docs

### DIFF
--- a/docs/topics/plugins.mdx
+++ b/docs/topics/plugins.mdx
@@ -1,12 +1,12 @@
 ---
-title: The Helm Plugins Guide
-description: Introduces how to use and create plugins to extend Helm's functionality.
+title: The Helm Plugins Guide (Legacy)
+description: Legacy plugin guide covering the subprocess runtime used in Helm 3 and still supported in Helm 4. For new plugins, see the Helm Plugins Guide.
 sidebar_position: 12
 ---
 
-import Helm4 from "/docs/_v4-in-progress.mdx"
-
-<Helm4/>
+:::note
+This page covers the **legacy subprocess plugin system** introduced in Helm 3, which continues to be supported in Helm 4. If you are building a new plugin or migrating an existing one for Helm 4, see the [Helm Plugins Guide](/plugins/index.mdx) for the full Helm 4 plugin documentation, including the new [Wasm (Extism) runtime](/plugins/developer/index.mdx).
+:::
 
 A Helm plugin is a tool that can be accessed through the `helm` CLI, but which
 is not part of the built-in Helm codebase.


### PR DESCRIPTION
## What this does

The `docs/topics/plugins.mdx` page was carrying the generic _"not yet updated for Helm 4"_ warning. The content itself is accurate — the subprocess plugin runtime still works in Helm 4 — but there was no signpost telling Helm 4 users where to go for the full v4 plugin experience.

This PR replaces the stale warning with a focused `:::note` callout that:
- Identifies the page as the **legacy guide** for the subprocess runtime
- Confirms the runtime continues to be supported in Helm 4
- Links to the new `/plugins/` section for the Helm 4 plugin guide
- Links to `/plugins/developer/` for the new Wasm (Extism) runtime docs

## Why

This is one of the closing criteria listed in #2075 (v4 docs milestone):

> No pages in the `docs/` directory (v4) carry the generic "not yet updated for Helm 4" warning without a clear plan.

The subprocess page is not broken — it just needed context. A targeted note is more accurate and more helpful than the blanket warning, and removes one unresolved item from milestone #5.

## Related

- Closes part of #1889
- Contributes to #2075 (v4 docs milestone)