### PR TITLE
Document wait progress output and SDK logging configuration

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -41,6 +41,15 @@ Existing plugins work as before. The new WebAssembly runtime is optional but rec
 #### Better resource monitoring
 New kstatus integration shows detailed status of your deployments. Test with complex applications to see if it catches issues better.
 
+When you use `--wait` with `helm install` or `helm upgrade`, Helm displays progress messages by default:
+
+```
+level=INFO msg="waiting for resources" count=6 timeout=5m0s
+level=INFO msg="all resources achieved desired status" desiredStatus=Current resourceCount=6
+```
+
+To see detailed per-resource status updates (such as "StatefulSet is not ready: 1 out of 2 pods scheduled"), add the `--debug` flag.
+
 #### Enhanced OCI Support
 Install charts by digest for better supply chain security. For example, `helm install myapp oci://registry.example.com/charts/app@sha256:abc123...`. Charts with non-matching digests are not installed.
 

--- a/docs/sdk/gosdk.mdx
+++ b/docs/sdk/gosdk.mdx
@@ -74,6 +74,47 @@ func main() {
 
 ```
 
+## Logging
+
+Helm uses Go's `log/slog` package for structured logging. By default, the SDK logs at Info level, including wait progress messages when using `WaitStrategy`. To customize logging, call `actionConfig.SetLogger()` with your own slog handler:
+
+```go
+package main
+
+import (
+    "log/slog"
+    "os"
+
+    "helm.sh/helm/v4/pkg/action"
+    "helm.sh/helm/v4/pkg/cli"
+)
+
+func main() {
+    // Create a custom logger with Debug level to see detailed output
+    logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+        Level: slog.LevelDebug,
+    }))
+
+    settings := cli.New()
+    actionConfig := action.NewConfiguration()
+    actionConfig.SetLogger(logger.Handler())
+
+    if err := actionConfig.Init(
+        settings.RESTClientGetter(),
+        settings.Namespace(),
+        os.Getenv("HELM_DRIVER"),
+    ); err != nil {
+        logger.Error("Failed to initialize", "error", err)
+        os.Exit(1)
+    }
+
+    // ... perform actions
+}
+```
+
+**Log levels:**
+- **Info**: Wait progress messages ("waiting for resources", "all resources achieved desired status")
+- **Debug**: Detailed per-resource status and internal operations
 
 ## Compatibility
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/4e4b668e-32e7-4fe1-bcb5-668ff5f2a9a0)

Documents the wait progress messages that are now visible by default when using --wait with Helm commands (from PR #32053). Also adds SDK logging section explaining how to configure slog handlers to control log levels for detailed output.

---

_Tip: Tag @Promptless in GitHub PR comments to guide documentation changes during code review 🐙_