### PR TITLE
Fix grammar and spacing in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,9 @@ There are 5 types of issues (each with their own corresponding [label](#labels))
 future reference. Generally these are questions that are too complex or large to store in the
 Slack channel or have particular interest to the community as a whole. Depending on the discussion,
 these can turn into `feature` or `bug` issues.
-- `proposal`: Used for items (like this one) that propose a new ideas or functionality that require
+- `proposal`: Used for items (like this one) that propose new ideas or functionality that require
 a larger community discussion. This allows for feedback from others in the community before a
-feature is actually  developed. This is not needed for small additions. Final word on whether or
+feature is actually developed. This is not needed for small additions. Final word on whether or
 not a feature needs a proposal is up to the core maintainers. All issues that are proposals should
 both have a label and an issue title of "Proposal: [the rest of the title]." A proposal can become
 a `feature` and does not require a milestone.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/31f417ba-7208-49e8-a811-a35077f4ed50)

Fix two grammatical issues in CONTRIBUTING.md that mirror fixes from helm/helm PR #32057: remove stray article ("propose a new ideas" → "propose new ideas") and remove double space ("actually  developed" → "actually developed").

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_