### PR TITLE
Clarify with scope note in control structures docs

### DIFF
--- a/docs/chart_template_guide/control_structures.md
+++ b/docs/chart_template_guide/control_structures.md
@@ -285,9 +285,10 @@ data:
   {{- end }}
 ```
 
-Note that we removed the `if` conditional from the previous exercise
-because it is now unnecessary - the block after `with` only executes
-if the value of `PIPELINE` is not empty.
+Note that this example omits the `mug` output from the previous exercise
+to focus on `with` scoping. The `with` block only executes if
+`.Values.favorite` is not empty, so a separate outer `if` guard is not
+needed.
 
 Notice that now we can reference `.drink` and `.food` without qualifying them.
 That is because the `with` statement sets `.` to point to `.Values.favorite`.


### PR DESCRIPTION
The previous note said the if conditional was removed because it was "unnecessary", which was confusing since the mug example relied on it. Reword to clarify that the example was simplified to focus on with scoping, and that with itself acts as an empty value guard.

Fixes #2070