### PR TITLE
Enhance .helmignore documentation with command details

### DIFF
--- a/docs/chart_template_guide/helm_ignore_file.md
+++ b/docs/chart_template_guide/helm_ignore_file.md
@@ -7,16 +7,17 @@ sidebar_position: 12
 The `.helmignore` file is used to specify files you don't want to include in
 your helm chart.
 
-If this file exists, the `helm package` command will ignore all the files that
-match the pattern specified in the `.helmignore` file while packaging your
-application.
+If this file exists, Helm commands will ignore all the files that
+match the pattern specified in the `.helmignore` file. The ignore file affects
+most Helm commands including `helm package`, `helm template` and `helm install`.
 
 This can help in avoiding unnecessary or sensitive files or directories from
 being added in your helm chart.
 
 The `.helmignore` file supports Unix shell glob matching, relative path
-matching, and negation (prefixed with !). Only one pattern per line is
-considered.
+matching. Only one pattern per line is considered. 
+
+⚠️ The semantics of `.helmignore` are [significantly different to other common ignore files like `.gitignore`](#differences-from-gitignore).
 
 Here is an example `.helmignore` file:
 
@@ -51,13 +52,19 @@ a[b-d].txt
 temp?
 ```
 
+## Differences from `.gitignore`
+
 Some notable differences from .gitignore:
+
 - The '**' syntax is not supported.
+- **[Negation with `!` is unusable](https://github.com/helm/helm/issues/8688)** - `!file` adds everthing _except_ `file` to the ignore list, rather than removing `file` from the ignore list.
 - The globbing library is Go's 'filepath.Match', not fnmatch(3)
 - Trailing spaces are always ignored (there is no supported escape sequence)
 - There is no support for '\!' as a special leading sequence.
 - It does not exclude itself by default, you have to add an explicit entry for `.helmignore`
+- evaluation order is reversed vs `.gitignore`
 
+See [HIP 027: Bring .helmignore to parity with .gitignore file targeting syntax](https://github.com/helm/community/blob/main/hips/hip-0027.md) for details.
 
 **We'd love your help** making this document better. To add, correct, or remove
 information, [file an issue](https://github.com/helm/helm-www/issues) or send us a


### PR DESCRIPTION
Expanded the explanation of the `.helmignore` file to clarify its impact on various Helm commands and highlighted differences from `.gitignore`. Add an explicit warning about broken negation. Link to [HIP 27](https://github.com/helm/community/blob/main/hips/hip-0027.md) to surface proposed changes.

Fixes https://github.com/helm/helm-www/issues/1171

Improves docs to clarify behaviour referred to in https://github.com/helm/helm/issues/8688, https://github.com/helm/helm/issues/3622