### PR TITLE
Document deprecated helm template flags

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -92,6 +92,15 @@ The existing flags remain, but emit a deprecated warning:
 
 Update any automation that uses these renamed CLI flags.
 
+#### CLI Flags deprecated
+
+The following flags for `helm template` are deprecated and will be removed in Helm 5:
+
+- `--hide-notes`
+- `--render-subchart-notes`
+
+These flags have no effect because template output never includes notes. They remain in Helm 4 for backwards compatibility but are hidden from help output.
+
 ## Upgrading to Helm 4
 
 While we work hard to make Helm 4 rock-solid for everyone, Helm 4 is brand new. To that end, before upgrading, we've added some tips below for specific things to look out for when testing Helm 4 with your existing workflows. As always, we welcome all feedback about what works, what breaks, and what could be better.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/1d3a4d4e-3a67-45ef-be83-b28fa81cf1b6)

Add documentation noting that --hide-notes and --render-subchart-notes flags are deprecated for helm template since they have no effect (template output never includes notes). These flags will be removed in Helm 5.

**Trigger Events**
- [helm/helm PR #31755: fix(template): deprecate unused --hide-notes and --render-subchart-notes flags](https://github.com/helm/helm/pull/31755)

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_