### PR TITLE
Chart Tests: small wording modification

### DIFF
--- a/docs/topics/chart_tests.md
+++ b/docs/topics/chart_tests.md
@@ -9,10 +9,11 @@ together. As a chart author, you may want to write some tests that validate that
 your chart works as expected when it is installed. These tests also help the
 chart consumer understand what your chart is supposed to do.
 
-A **test** in a helm chart lives under the `templates/` directory and is a job
-definition that specifies a container with a given command to run. The container
-should exit successfully (exit 0) for a test to be considered a success. The job
-definition must contain the helm test hook annotation: `helm.sh/hook: test`.
+A **test** in a helm chart lives under the `templates/` directory and is a
+workload definition (commonly a Pod or Job) that specifies a container
+with a given command to run. The container should exit successfully (exit 0)
+for a test to be considered a success. The definition must contain the helm
+test hook annotation: `helm.sh/hook: test`.
 
 Note that until Helm v3, the job definition needed to contain one of these helm
 test hook annotations: `helm.sh/hook: test-success` or `helm.sh/hook: test-failure`.


### PR DESCRIPTION
On the Chart Tests page, the text previously said "a test is... a job definition."  
The problem with this, is that "Job" is an official kubernetes concept.      
A manifest might be "kind: Job".  If you are reading k8s documentation and see the word "job" it means something.  So this PR modifies the sentence slightly.  

