### PR TITLE
Document helmtest build tag for running tests

### DIFF
--- a/community/developers.md
+++ b/community/developers.md
@@ -29,10 +29,20 @@ To run Helm locally, you can run `bin/helm`.
 
 ## Running tests
 
-To run all the tests, run `make test`.
-As a pre-requisite, you would need to have
-[golangci-lint](https://golangci-lint.run)
-installed.
+To run all tests, run `make test`. You need
+[golangci-lint](https://golangci-lint.run) installed.
+
+The Makefile targets (`make test`, `make test-unit`, `make test-coverage`)
+automatically include the `helmtest` build tag, which is required for tests to
+run correctly. If you run tests outside the Makefile (IDE test runners, `go
+test` directly, or custom CI), pass `-tags helmtest`:
+
+```console
+$ go test -tags helmtest ./...
+```
+
+Without this tag, tests fail during package initialization because test
+binaries lack module version information that the production code paths expect.
 
 ## Running Locally
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/caf6c39b-3e57-44a2-9446-881c9580d37a)

Add information about the helmtest build tag requirement for contributors who run tests outside the Makefile. This documents that IDE test runners, direct go test invocations, and custom CI need to pass -tags helmtest to avoid package initialization failures.

**Trigger Events**
- [helm/helm PR #32169: fix: avoid importing testing package in release builds](https://github.com/helm/helm/pull/32169)

---

_Tip: Use Vale? Add your vale.ini when setting up your [Docs Collection](https://app.gopromptless.ai/doc-collections)._