### PR TITLE
APT installation validate gpg key ID

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -22,9 +22,12 @@ psuedo = "psuedo"  # Legacy typo in vendor code
 AKS = "AKS"  # Azure Kubernetes Service
 ba = "ba"
 ede = "ede"  # Git commit hash
+fpr = "fpr"  # GnuPG abbreviation for 'fingerprint'
 
 # German words in translations
 Paket = "Paket"  # German for "package"
+
+
 
 [files]
 extend-exclude = [

--- a/.typos.toml
+++ b/.typos.toml
@@ -27,8 +27,6 @@ fpr = "fpr"  # GnuPG abbreviation for 'fingerprint'
 # German words in translations
 Paket = "Paket"  # German for "package"
 
-
-
 [files]
 extend-exclude = [
   # Internationalization files (Docusaurus i18n directory)

--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -113,10 +113,8 @@ curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMP
 # Ensure that the key ID matches to prevent a repository compromise from establishing an attacker controlled key
 if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Unexpected Helm APT key ID: potential key compromise"; exit 1; fi
 
-gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+cat "${TMPDIR:-/tmp}/helm.gpg" | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-
-cat /etc/apt/sources.list.d/helm-stable-debian.list
 
 sudo apt-get update
 sudo apt-get install helm

--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -111,7 +111,7 @@ sudo apt-get install curl gpg apt-transport-https --yes
 curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMPDIR:-/tmp}/helm.gpg"
 
 # Ensure that the key ID matches to prevent a repository compromise from establishing an attacker controlled key
-if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Invalid Helm APT key ID"; exit 1; fi
+if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Unexpected Helm APT key ID: potential key compromise"; exit 1; fi
 
 gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list

--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -103,7 +103,7 @@ winget install Helm.Helm
 Members of the Helm community have contributed an Apt package for Debian/Ubuntu. This package is
 generally up to date. Thanks to [Buildkite](https://buildkite.com/organizations/helm-linux/packages/registries/helm-debian) for hosting the repo.
 
-```shell
+```console
 HELM_BUILDKITE_APT_KEY_ID="DDF78C3E6EBB2D2CC223C95C62BA89D07698DBC6"
 
 sudo apt-get install curl gpg apt-transport-https --yes

--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -104,9 +104,19 @@ Members of the Helm community have contributed an Apt package for Debian/Ubuntu.
 generally up to date. Thanks to [Buildkite](https://buildkite.com/organizations/helm-linux/packages/registries/helm-debian) for hosting the repo.
 
 ```console
+HELM_BUILDKITE_APT_KEY_ID="DDF78C3E6EBB2D2CC223C95C62BA89D07698DBC6"
+
 sudo apt-get install curl gpg apt-transport-https --yes
-curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMPDIR:-/tmp}/helm.gpg"
+
+if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Invalid Helm APT key ID"; exit 1; fi
+
+gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+
+cat /etc/apt/sources.list.d/helm-stable-debian.list
+
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -103,13 +103,14 @@ winget install Helm.Helm
 Members of the Helm community have contributed an Apt package for Debian/Ubuntu. This package is
 generally up to date. Thanks to [Buildkite](https://buildkite.com/organizations/helm-linux/packages/registries/helm-debian) for hosting the repo.
 
-```console
+```shell
 HELM_BUILDKITE_APT_KEY_ID="DDF78C3E6EBB2D2CC223C95C62BA89D07698DBC6"
 
 sudo apt-get install curl gpg apt-transport-https --yes
 
 curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMPDIR:-/tmp}/helm.gpg"
 
+# Ensure that the key ID matches to prevent a repository compromise from establishing an attacker controlled key
 if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Invalid Helm APT key ID"; exit 1; fi
 
 gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null

--- a/versioned_docs/version-3/intro/install.md
+++ b/versioned_docs/version-3/intro/install.md
@@ -112,10 +112,8 @@ curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMP
 # Ensure that the key ID matches to prevent a repository compromise from establishing an attacker controlled key
 if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Unexpected Helm APT key ID: potential key compromise"; exit 1; fi
 
-gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+cat "${TMPDIR:-/tmp}/helm.gpg" | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-
-cat /etc/apt/sources.list.d/helm-stable-debian.list
 
 sudo apt-get update
 sudo apt-get install helm

--- a/versioned_docs/version-3/intro/install.md
+++ b/versioned_docs/version-3/intro/install.md
@@ -110,7 +110,7 @@ sudo apt-get install curl gpg apt-transport-https --yes
 curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMPDIR:-/tmp}/helm.gpg"
 
 # Ensure that the key ID matches to prevent a repository compromise from establishing an attacker controlled key
-if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Invalid Helm APT key ID"; exit 1; fi
+if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Unexpected Helm APT key ID: potential key compromise"; exit 1; fi
 
 gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list

--- a/versioned_docs/version-3/intro/install.md
+++ b/versioned_docs/version-3/intro/install.md
@@ -102,13 +102,14 @@ winget install Helm.Helm
 Members of the Helm community have contributed an Apt package for Debian/Ubuntu. This package is
 generally up to date. Thanks to [Buildkite](https://buildkite.com/organizations/helm-linux/packages/registries/helm-debian) for hosting the repo.
 
-```console
+```shell
 HELM_BUILDKITE_APT_KEY_ID="DDF78C3E6EBB2D2CC223C95C62BA89D07698DBC6"
 
 sudo apt-get install curl gpg apt-transport-https --yes
 
 curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMPDIR:-/tmp}/helm.gpg"
 
+# Ensure that the key ID matches to prevent a repository compromise from establishing an attacker controlled key
 if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Invalid Helm APT key ID"; exit 1; fi
 
 gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null

--- a/versioned_docs/version-3/intro/install.md
+++ b/versioned_docs/version-3/intro/install.md
@@ -103,9 +103,19 @@ Members of the Helm community have contributed an Apt package for Debian/Ubuntu.
 generally up to date. Thanks to [Buildkite](https://buildkite.com/organizations/helm-linux/packages/registries/helm-debian) for hosting the repo.
 
 ```console
+HELM_BUILDKITE_APT_KEY_ID="DDF78C3E6EBB2D2CC223C95C62BA89D07698DBC6"
+
 sudo apt-get install curl gpg apt-transport-https --yes
-curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey > "${TMPDIR:-/tmp}/helm.gpg"
+
+if [ "$(gpg --show-keys --with-colons "${TMPDIR:-/tmp}/helm.gpg" | awk -F: '$1 == "fpr" {print $10}' | head -n 1)" != "${HELM_BUILDKITE_APT_KEY_ID}" ]; then echo "ERROR: Invalid Helm APT key ID"; exit 1; fi
+
+gpg --dearmor "${TMPDIR:-/tmp}/helm.gpg" | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+
+cat /etc/apt/sources.list.d/helm-stable-debian.list
+
 sudo apt-get update
 sudo apt-get install helm
 ```

--- a/versioned_docs/version-3/intro/install.md
+++ b/versioned_docs/version-3/intro/install.md
@@ -102,7 +102,7 @@ winget install Helm.Helm
 Members of the Helm community have contributed an Apt package for Debian/Ubuntu. This package is
 generally up to date. Thanks to [Buildkite](https://buildkite.com/organizations/helm-linux/packages/registries/helm-debian) for hosting the repo.
 
-```shell
+```console
 HELM_BUILDKITE_APT_KEY_ID="DDF78C3E6EBB2D2CC223C95C62BA89D07698DBC6"
 
 sudo apt-get install curl gpg apt-transport-https --yes


### PR DESCRIPTION
The APT installation instructions download the repository signing GPG key from the same source as the GPG mirror itself. Should the repository be compromised, any user to initializes the repository configuration would end up trusting a compromised signing key

(and reinitialization is common, as today users will frequent initialize a repository during a Container or VM build e.g. Dockerfile/Containerfile or Ansible configuration run; compared to historically, where an "admin" might have initialized the key on a system once).

This PR includes a fragment to validate the GPG Key ID matches the (currently) expected Key ID / fingerprint during the repository initialization. And to error if not.
