### PR TITLE
build: enable @docusaurus/faster build optimization

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,6 +42,7 @@ const config = {
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
+    faster: true, // Enable @docusaurus/faster build optimizations (Rspack, SWC, Lightning CSS)
   },
 
   // Opt-in to less strict, standard CommonMark support with options


### PR DESCRIPTION
`@docusaurus/faster@^3.10.1` was added to `package.json` (#2119) but never enabled — `docusaurus.config.js` only sets `future: { v4: true }`, so the Rspack / SWC / Lightning CSS optimizations the dependency provides are currently dead weight. Per the [Docusaurus 3.10 release notes](https://docusaurus.io/blog/releases/3.10), Faster is opt-in via `future.faster: true` and is **not** auto-enabled by the `v4` compatibility flag.

This sets `future.faster: true`, activating the build optimization the dependency was installed for.

### Validation

- `yarn build --locale en` → `[SUCCESS] Generated static files in "build". Done in 9.87s.` (exit 0)
- Confirmed `@rspack` is engaged in the build with the flag enabled (Faster active, not dead weight).
- The only build warning is a pre-existing broken anchor (`/docs/intro/install` → quickstart) unrelated to this change.

closes: #2120