### PR TITLE
Add troubleshooting entry for resource ownership conflicts

### DIFF
--- a/versioned_docs/version-3/faq/troubleshooting.md
+++ b/versioned_docs/version-3/faq/troubleshooting.md
@@ -128,6 +128,36 @@ For example:
 helm list -v 6
 ```
 
+### Install or upgrade fails because a resource already exists
+
+When running `helm install` or `helm upgrade`, you may see an error like:
+
+```
+Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists.
+Unable to continue with install: ConfigMap "myconfig" in namespace "default" exists and
+cannot be imported into the current release
+```
+
+This happens when Helm finds a resource in the cluster that either lacks Helm's ownership metadata or belongs to a different release. Helm tracks ownership using three pieces of metadata:
+
+- Label: `app.kubernetes.io/managed-by=Helm`
+- Annotation: `meta.helm.sh/release-name=<release-name>`
+- Annotation: `meta.helm.sh/release-namespace=<release-namespace>`
+
+To have Helm adopt the existing resource and manage it as part of your release, use the `--take-ownership` flag:
+
+```console
+$ helm install my-release my-chart --take-ownership
+```
+
+Or for upgrades:
+
+```console
+$ helm upgrade my-release my-chart --take-ownership
+```
+
+This adds Helm's ownership metadata to the existing resource and manages it going forward. Use this flag when migrating resources created outside of Helm (such as with `kubectl apply`) into a Helm-managed release.
+
 ### Rollback fails with "no [Resource] with the name '[name]' found"
 
 When running `helm rollback`, you may see an error like:


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/bb5fd032-ff6d-450a-b832-9f8533e1b55c)

Adds a FAQ entry explaining the error users encounter when Helm finds a resource without ownership metadata. Documents the `--take-ownership` flag for adopting pre-existing cluster resources into Helm-managed releases.

**Trigger Events**
- [helm/helm PR #32199: docs: Missing docs on ownership annotations](https://github.com/helm/helm/pull/32199)

---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_