### PR TITLE
Clarify templates directory is optional for umbrella charts

### DIFF
--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -39,13 +39,17 @@ wordpress/
   values.schema.json  # OPTIONAL: A JSON Schema for imposing a structure on the values.yaml file
   charts/             # A directory containing any charts upon which this chart depends.
   crds/               # Custom Resource Definitions
-  templates/          # A directory of templates that, when combined with values,
+  templates/          # OPTIONAL: A directory of templates that, when combined with values,
                       # will generate valid Kubernetes manifest files.
   templates/NOTES.txt # OPTIONAL: A plain text file containing short usage notes
 ```
 
 Helm reserves use of the `charts/`, `crds/`, and `templates/` directories, and
 of the listed file names. Other files will be left as they are.
+
+The `templates/` directory is optional. Umbrella charts that only aggregate
+subcharts typically omit it. Such charts pass `helm lint --strict` without
+issue.
 
 ## The Chart.yaml File
 

--- a/versioned_docs/version-3/topics/charts.md
+++ b/versioned_docs/version-3/topics/charts.md
@@ -35,13 +35,17 @@ wordpress/
   values.schema.json  # OPTIONAL: A JSON Schema for imposing a structure on the values.yaml file
   charts/             # A directory containing any charts upon which this chart depends.
   crds/               # Custom Resource Definitions
-  templates/          # A directory of templates that, when combined with values,
+  templates/          # OPTIONAL: A directory of templates that, when combined with values,
                       # will generate valid Kubernetes manifest files.
   templates/NOTES.txt # OPTIONAL: A plain text file containing short usage notes
 ```
 
 Helm reserves use of the `charts/`, `crds/`, and `templates/` directories, and
 of the listed file names. Other files will be left as they are.
+
+The `templates/` directory is optional. Umbrella charts that only aggregate
+subcharts typically omit it. Such charts pass `helm lint --strict` without
+issue.
 
 ## The Chart.yaml File
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/f757f04c-1060-4846-a79b-3d8454c9016b)

Marks the templates/ directory as OPTIONAL in the chart file structure documentation and adds a note explaining that umbrella charts (which aggregate subcharts without having their own templates) pass helm lint --strict without issue.

**Trigger Events**
- [helm/helm PR #32208: fix: downgrade templates directory check severity back to Info](https://github.com/helm/helm/pull/32208)

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_