### PR TITLE
Add troubleshooting entry for uninstall ownership verification

### DIFF
--- a/versioned_docs/version-3/faq/troubleshooting.md
+++ b/versioned_docs/version-3/faq/troubleshooting.md
@@ -181,3 +181,38 @@ Or if a different version is needed, use the --tiller-image flag to override the
 `helm init --tiller-image ghcr.io/helm/tiller:v2.16.9`
 
 **Note:** The Helm maintainers recommend migration to a currently-supported version of Helm. Helm v2.17.0 was the final release of Helm v2; Helm v2 is unsupported since November 2020, as detailed in [Helm 2 and the Charts Project Are Now Unsupported](https://helm.sh/blog/helm-2-becomes-unsupported/). Many CVEs have been flagged against Helm since then, and those exploits are patched in Helm v3 but will never be patched in Helm v2. See the [current list of published Helm advisories](https://github.com/helm/helm/security/advisories?state=published) and make a plan to [migrate to Helm v3](/topics/v2_v3_migration.md) today.
+
+### Uninstall skips some resources with "not owned by this release" warning
+
+When running `helm uninstall`, you may see warnings like:
+
+```
+WARN skipping delete of resource not owned by this release kind=ConfigMap name=myconfig namespace=default release=my-release
+```
+
+Or in the output:
+
+```
+N resource(s) were not deleted because they are not owned by this release:
+[ConfigMap] myconfig
+```
+
+Helm verifies resource ownership before deletion to prevent accidentally removing resources that belong to a different release. Helm checks these metadata fields:
+
+- Label: `app.kubernetes.io/managed-by=Helm`
+- Annotation: `meta.helm.sh/release-name=<release-name>`
+- Annotation: `meta.helm.sh/release-namespace=<release-namespace>`
+
+Resources are skipped during uninstall when:
+
+1. **The resource belongs to another release** - The resource was previously managed by a different Helm release. This can happen if a resource without a templated name was manually deleted, then recreated by a different release.
+2. **The resource lacks ownership metadata** - The resource exists but does not have Helm's ownership labels and annotations. This can happen with resources created outside of Helm.
+3. **Ownership cannot be verified** - Helm could not fetch the resource from the cluster (for example, due to RBAC restrictions or network issues).
+
+To preview which resources would be deleted versus skipped, use `--dry-run` with `--debug`:
+
+```console
+$ helm uninstall my-release --dry-run --debug
+```
+
+If you need to delete a resource that Helm is skipping, remove it manually using `kubectl delete`.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/cadac135-ce0a-4bc9-a38b-a9576488ce03)

Documents the new ownership verification behavior during `helm uninstall`. Helm now verifies resource ownership before deletion and skips resources that belong to other releases or lack proper ownership metadata, preventing accidental data loss.

**Trigger Events**
- [helm/helm PR #31584: feat: add ownership verification before deleting resources during uni…](https://github.com/helm/helm/pull/31584)

---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_