### PR TITLE
Document post-renderer hooks and filename annotation in version-3 docs

### DIFF
--- a/versioned_docs/version-3/topics/advanced.md
+++ b/versioned_docs/version-3/topics/advanced.md
@@ -50,6 +50,31 @@ simple as `renderer1 | renderer2 | renderer3`.
 You can see an example of using `kustomize` as a post renderer
 [here](https://github.com/thomastaylor312/advanced-helm-demos/tree/master/post-render).
 
+#### Filenames
+Before passing manifests to the post-renderer, Helm merges them into a single
+stream and adds a temporary annotation to each document recording the original
+template filename:
+
+```yaml
+metadata:
+  annotations:
+    postrenderer.helm.sh/postrender-filename: <original-template-filename>
+```
+
+When reading the post-renderer's output back, Helm uses this annotation to
+determine which filename to associate with each manifest for further processing.
+If the annotation is missing, Helm generates a filename in the format
+`generated-by-postrender-<id>.yaml`. Helm removes the annotation before sending
+the manifests to Kubernetes.
+
+#### Hooks
+As of Helm 3.21, [chart hooks](/topics/charts_hooks.md) are sent to the
+post-renderer along with regular templates. In earlier 3.x releases, hooks were
+rendered but never passed to the post-renderer, so the post-renderer only saw
+non-hook manifests. If your post-renderer applies broad transformations, such as
+injecting labels or sidecars, keep in mind that it now receives hook manifests as
+well.
+
 ### Caveats
 When using post renderers, there are several important things to keep in mind.
 The most important of these is that when using a post-renderer, all people


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/04aa6c16-80af-4099-add4-5bec890bbe14)

Helm 3.21 (helm/helm#32227) changes post-rendering: chart hooks are now sent to the post-renderer along with regular templates, and each manifest carries a temporary `postrenderer.helm.sh/postrender-filename` annotation while it passes through the post-renderer. Documents both behaviors in the version-3 Post Rendering section, which previously covered neither.

**Trigger Events**
- [helm/helm PR #32227: Helm release 3.21](https://github.com/helm/helm/pull/32227)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_