### PR TITLE
Document Helm ownership annotations in Labels and Annotations guide

### DIFF
--- a/docs/chart_best_practices/labels.md
+++ b/docs/chart_best_practices/labels.md
@@ -44,3 +44,23 @@ Name|Status|Description
 You can find more information on the Kubernetes labels, prefixed with
 `app.kubernetes.io`, in the [Kubernetes
 documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
+
+## Helm Ownership Annotations
+
+Along with the labels above, Helm adds two annotations to every resource it
+manages. Together with the `app.kubernetes.io/managed-by=Helm` label, Helm uses
+these annotations to record which release owns a resource and to confirm that
+ownership before upgrading or uninstalling it.
+
+Name|Description
+-----|----------
+`meta.helm.sh/release-name` | The name of the release that owns the resource.
+`meta.helm.sh/release-namespace` | The namespace of the release that owns the resource.
+
+Helm sets these annotations for you, so there is no need to add them to your
+chart templates. If you install or upgrade a release and Helm encounters a
+pre-existing resource that lacks these annotations (for example, one created
+with `kubectl apply`), the operation fails because the resource is not owned by
+the release. To skip the ownership check, pass the `--take-ownership` flag to
+`helm install` or `helm upgrade`. Helm then adds these annotations and adopts
+the existing resource into the release.

--- a/versioned_docs/version-3/chart_best_practices/labels.md
+++ b/versioned_docs/version-3/chart_best_practices/labels.md
@@ -44,3 +44,23 @@ Name|Status|Description
 You can find more information on the Kubernetes labels, prefixed with
 `app.kubernetes.io`, in the [Kubernetes
 documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
+
+## Helm Ownership Annotations
+
+Along with the labels above, Helm adds two annotations to every resource it
+manages. Together with the `app.kubernetes.io/managed-by=Helm` label, Helm uses
+these annotations to record which release owns a resource and to confirm that
+ownership before upgrading or uninstalling it.
+
+Name|Description
+-----|----------
+`meta.helm.sh/release-name` | The name of the release that owns the resource.
+`meta.helm.sh/release-namespace` | The namespace of the release that owns the resource.
+
+Helm sets these annotations for you, so there is no need to add them to your
+chart templates. If you install or upgrade a release and Helm encounters a
+pre-existing resource that lacks these annotations (for example, one created
+with `kubectl apply`), the operation fails because the resource is not owned by
+the release. To skip the ownership check, pass the `--take-ownership` flag to
+`helm install` or `helm upgrade`. Helm then adds these annotations and adopts
+the existing resource into the release.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/ad34e93b-01b7-4bac-beec-bffd910bcecc)

Adds the `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` ownership annotations to the Labels and Annotations best-practices page (v4 and version-3), closing a long-standing reference-docs gap (helm/helm issue #12869). Explains that Helm sets them automatically and how `--take-ownership` adopts pre-existing resources.

**Trigger Events**
- [helm/helm PR #32228: docs: clarify Helm ownership annotations in CLI help](https://github.com/helm/helm/pull/32228)

---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_