### PR TITLE
Document uninstall hook apply method follows release latching behavior

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -52,11 +52,12 @@ Better conflict resolution when multiple tools manage the same resources. Test i
 
 Helm 4 will default to server-side apply when installing a new Chart release.
 
-When upgrading (or rolling back), Helm will by default follow the previous apply method of the release.
-This latching behavior is done to ensure continuity of operation for existing releases that used client-side apply.
-The behavior can be overridden by setting the `--server-side` flag explicitly.
+When you upgrade, roll back, or uninstall a release, Helm follows the release's previous apply method by default.
+This latching behavior ensures continuity of operation for existing releases that used client-side apply.
+For `helm uninstall`, the previous apply method governs the pre-delete and post-delete hooks.
+To override this behavior, set the `--server-side` flag explicitly to `true` or `false`.
 
-As such, all releases created by Helm 3 will default to using client-side apply after upgrading to Helm 4.
+As such, all releases created by Helm 3 default to using client-side apply after upgrading to Helm 4.
 
 #### Custom Template Functions
 Extend Helm's templating with your own functions through plugins. Great for organization-specific templating needs.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/1b47358e-a17f-49f0-8e66-244586ef205a)

Updates the Server-Side Apply section in the Helm 4 overview to note that uninstall (pre-delete and post-delete hooks) follows the release's previous apply method by default, and can be overridden with the `--server-side` flag — matching upgrade and rollback. Reflects helm/helm PR #32232.

**Trigger Events**
- [helm/helm PR #32232: feat(uninstall): add --server-side flag to control hook apply method](https://github.com/helm/helm/pull/32232)

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_