### PR TITLE
"Charts" Artifact Hub link to charts search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -275,7 +275,7 @@ const config = {
           { to: "community", label: "Community", position: "left" },
           { to: "blog", label: "Blog", position: "left" },
           {
-            href: "https://artifacthub.io/",
+            href: "https://artifacthub.io/packages/search?kind=0",
             label: "Charts",
             position: "left",
           },


### PR DESCRIPTION
Land users on Artifact Hub's chart search -  https://artifacthub.io/packages/search?kind=0, rather than general "home" page.