### PR TITLE
Document helm history --show-rollback-revision flag

### DIFF
--- a/docs/intro/CheatSheet.mdx
+++ b/docs/intro/CheatSheet.mdx
@@ -109,6 +109,7 @@ helm list -o yaml               # Prints the output in the specified format. All
 helm status <release>           # This command shows the status of a named release.
 helm status <release> --revision <number>   # if set, display the status of the named release with revision
 helm history <release>          # Historical revisions for a given release.
+helm history <release> --show-rollback-revision # Add a ROLLBACK column showing which revision each rollback targeted
 helm env                        # Env prints out all the environment information in use by Helm.
 ```
 -------------------------------------------------------------------------------------------------------------------------------------------------

--- a/docs/intro/using_helm.mdx
+++ b/docs/intro/using_helm.mdx
@@ -420,6 +420,10 @@ rollback happens, the revision number is incremented by 1. The first revision
 number is always 1. And we can use `helm history [RELEASE]` to see revision
 numbers for a certain release.
 
+If a release was created by a rollback, pass `--show-rollback-revision` to
+`helm history` to add a `ROLLBACK` column to the output. This column shows which
+revision each rollback targeted.
+
 ## Helpful Options for Install/Upgrade/Rollback
 
 There are several other helpful options you can specify for customizing the


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/41d02c75-2364-4d63-b043-6dc8cd844fb6)

Documents the new `--show-rollback-revision` flag added to `helm history` in Helm v4, which adds a ROLLBACK column to the table output showing which revision a rollback targeted. Updates the CheatSheet and the rollback narrative in the Using Helm guide (current/v4 docs only).

**Trigger Events**
- [helm/helm PR #31859: feat(history): add rollback revision column to helm history output](https://github.com/helm/helm/pull/31859)

---

_Tip: Configure how Promptless handles changelogs in [Agent Settings](https://app.gopromptless.ai/configure/settings) 📋_