### PR TITLE
Document YAML injection risks in chart templates

### DIFF
--- a/docs/chart_template_guide/functions_and_pipelines.mdx
+++ b/docs/chart_template_guide/functions_and_pipelines.mdx
@@ -31,6 +31,42 @@ Template functions follow the syntax `functionName arg1 arg2...`. In the snippet
 above, `quote .Values.favorite.drink` calls the `quote` function and passes it a
 single argument.
 
+## Avoid YAML injection
+
+Values may come from users or other untrusted sources. Rendering an untrusted
+string directly into a template can allow the string to change the structure of
+the generated YAML. For example, this template renders a scalar value without
+quoting it:
+
+```yaml
+data:
+  drink: {{ .Values.favorite.drink }}
+```
+
+A value containing YAML syntax, such as a newline followed by another key, may
+then add unexpected data to the rendered manifest. Quote string values so that
+YAML treats the result as a scalar:
+
+```yaml
+data:
+  drink: {{ .Values.favorite.drink | quote }}
+```
+
+When a value is intentionally structured data, serialize the complete value
+with `toYaml` and indent it for its location in the manifest:
+
+```yaml
+metadata:
+  annotations:
+    {{- .Values.podAnnotations | toYaml | nindent 4 }}
+```
+
+Using `toYaml` with the correct indentation preserves the intended YAML
+structure, but it does not make arbitrary content safe or validate that the
+result is appropriate for a particular Kubernetes field. Chart authors should
+validate and constrain accepted values when they may come from untrusted
+sources.
+
 Helm has over 60 available functions. Some of them are defined by the [Go
 template language](https://godoc.org/text/template) itself. Most of the others
 are part of the [Sprig template library](https://masterminds.github.io/sprig/).

--- a/docs/chart_template_guide/functions_and_pipelines.mdx
+++ b/docs/chart_template_guide/functions_and_pipelines.mdx
@@ -31,42 +31,6 @@ Template functions follow the syntax `functionName arg1 arg2...`. In the snippet
 above, `quote .Values.favorite.drink` calls the `quote` function and passes it a
 single argument.
 
-## Avoid YAML injection
-
-Values may come from users or other untrusted sources. Rendering an untrusted
-string directly into a template can allow the string to change the structure of
-the generated YAML. For example, this template renders a scalar value without
-quoting it:
-
-```yaml
-data:
-  drink: {{ .Values.favorite.drink }}
-```
-
-A value containing YAML syntax, such as a newline followed by another key, may
-then add unexpected data to the rendered manifest. Quote string values so that
-YAML treats the result as a scalar:
-
-```yaml
-data:
-  drink: {{ .Values.favorite.drink | quote }}
-```
-
-When a value is intentionally structured data, serialize the complete value
-with `toYaml` and indent it for its location in the manifest:
-
-```yaml
-metadata:
-  annotations:
-    {{- .Values.podAnnotations | toYaml | nindent 4 }}
-```
-
-Using `toYaml` with the correct indentation preserves the intended YAML
-structure, but it does not make arbitrary content safe or validate that the
-result is appropriate for a particular Kubernetes field. Chart authors should
-validate and constrain accepted values when they may come from untrusted
-sources.
-
 Helm has over 60 available functions. Some of them are defined by the [Go
 template language](https://godoc.org/text/template) itself. Most of the others
 are part of the [Sprig template library](https://masterminds.github.io/sprig/).

--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -100,6 +100,53 @@ All inline styles must be on one line.
   characters. The only escape sequence is `''`, which is decoded as a single
   `'`.
 
+### Strings in Templates
+
+When string values are inserted from `.Values`, they are parsed as part of the
+final YAML document. If a value can come from a user or another system,
+rendering it as a bare word can allow YAML syntax in the value to change the
+generated structure.
+
+```yaml
+data:
+  drink: {{ .Values.favorite.drink }}
+```
+
+For example, a string that contains a newline followed by another key could add
+unexpected data to the rendered manifest. Quote string values so YAML treats the
+rendered value as a scalar:
+
+```yaml
+data:
+  drink: {{ .Values.favorite.drink | quote }}
+```
+
+The same rule applies after constructing a string from multiple values. For
+example, apply `quote` to the final string produced by `printf` or `print`.
+
+This guidance is for string values. Other scalar types, such as integers and
+booleans, may need to remain unquoted when the Kubernetes field expects that
+type. Define the expected type in the chart values and render it accordingly.
+
+When a value is intentionally structured data, serialize the complete value and
+indent it for its location in the manifest:
+
+```yaml
+metadata:
+  annotations:
+    {{- .Values.podAnnotations | toYaml | nindent 4 }}
+```
+
+Using `toYaml` with the correct indentation preserves the intended YAML
+structure, but it does not make arbitrary content safe or validate that the
+result is appropriate for a particular Kubernetes field. For values that may
+come from untrusted sources, chart authors should constrain the accepted values.
+Helm can validate chart values with a
+[`values.schema.json`](/topics/charts.mdx#schema-files) schema, and templates can
+fail rendering with functions such as
+[`required`](/chart_template_guide/function_list.mdx#required) or
+[`fail`](/chart_template_guide/function_list.mdx#fail) for simple checks.
+
 In addition to the one-line strings, you can declare multi-line strings:
 
 ```yaml

--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -75,6 +75,68 @@ port: !!int "80"
 In the above, `!!str` tells the parser that `age` is a string, even if it looks
 like an int. And `port` is treated as an int, even though it is quoted.
 
+### Scalar Values in Templates
+
+When values from `.Values` are inserted into a template, they are parsed as part
+of the final YAML document. If a value can come from a user or another system,
+rendering it as a bare word can allow YAML syntax in the value to change the
+generated structure.
+
+```yaml
+data:
+  drink: {{ .Values.favorite.drink }}
+```
+
+For example, a string that contains a newline followed by another key could add
+unexpected data to the rendered manifest. Quote string values so YAML treats the
+rendered value as a scalar:
+
+```yaml
+data:
+  drink: {{ .Values.favorite.drink | quote }}
+```
+
+The same rule applies after constructing a string from multiple values. For
+example, apply `quote` to the final string produced by `printf` or `print`.
+
+When a Kubernetes field expects another scalar type, use a YAML node tag
+together with `quote`. This renders the value as a YAML string first, then asks
+the YAML parser to convert it to the expected scalar type:
+
+```yaml
+spec:
+  enabled: !!bool {{ .Values.server.enabled | quote }}
+  port: !!int {{ .Values.server.port | quote }}
+```
+
+If the quoted value does not match the requested type, the YAML parser will
+report an error.
+
+### Collection Values in Templates
+
+When a value is intentionally a map or sequence, serialize the complete value and
+indent it for its location in the manifest:
+
+```yaml
+metadata:
+  annotations:
+    {{- .Values.podAnnotations | toYaml | nindent 4 }}
+```
+
+Using `toYaml` with the correct indentation preserves the intended YAML
+structure, but it does not make arbitrary content appropriate for a particular
+Kubernetes field.
+
+### Constraining Template Values
+
+Encoding values correctly keeps the rendered YAML well-formed, but chart authors
+may still need to constrain values that can come from untrusted sources. Helm can
+validate chart values with a
+[`values.schema.json`](/topics/charts.mdx#schema-files) schema, and templates can
+fail rendering with functions such as
+[`required`](/chart_template_guide/function_list.mdx#required) or
+[`fail`](/chart_template_guide/function_list.mdx#fail) for simple checks.
+
 
 ## Strings in YAML
 
@@ -100,52 +162,6 @@ All inline styles must be on one line.
   characters. The only escape sequence is `''`, which is decoded as a single
   `'`.
 
-### Strings in Templates
-
-When string values are inserted from `.Values`, they are parsed as part of the
-final YAML document. If a value can come from a user or another system,
-rendering it as a bare word can allow YAML syntax in the value to change the
-generated structure.
-
-```yaml
-data:
-  drink: {{ .Values.favorite.drink }}
-```
-
-For example, a string that contains a newline followed by another key could add
-unexpected data to the rendered manifest. Quote string values so YAML treats the
-rendered value as a scalar:
-
-```yaml
-data:
-  drink: {{ .Values.favorite.drink | quote }}
-```
-
-The same rule applies after constructing a string from multiple values. For
-example, apply `quote` to the final string produced by `printf` or `print`.
-
-This guidance is for string values. Other scalar types, such as integers and
-booleans, may need to remain unquoted when the Kubernetes field expects that
-type. Define the expected type in the chart values and render it accordingly.
-
-When a value is intentionally structured data, serialize the complete value and
-indent it for its location in the manifest:
-
-```yaml
-metadata:
-  annotations:
-    {{- .Values.podAnnotations | toYaml | nindent 4 }}
-```
-
-Using `toYaml` with the correct indentation preserves the intended YAML
-structure, but it does not make arbitrary content safe or validate that the
-result is appropriate for a particular Kubernetes field. For values that may
-come from untrusted sources, chart authors should constrain the accepted values.
-Helm can validate chart values with a
-[`values.schema.json`](/topics/charts.mdx#schema-files) schema, and templates can
-fail rendering with functions such as
-[`required`](/chart_template_guide/function_list.mdx#required) or
-[`fail`](/chart_template_guide/function_list.mdx#fail) for simple checks.
 
 In addition to the one-line strings, you can declare multi-line strings:
 


### PR DESCRIPTION
## Summary

Addresses #2154.

This PR adds a focused section to the Chart Template Guide documenting YAML injection risks when rendering untrusted values directly into chart templates.

It intentionally keeps the scope small:

* explains how direct scalar rendering can allow unexpected YAML structure changes;
* shows a safer scalar example using `quote`;
* shows how to serialize and indent structured values with `toYaml` and `nindent`;
* notes that chart authors should still validate and constrain values from untrusted sources.

This does not attempt to introduce a broader chart security guide in the first pass.

## Testing

* `yarn build`
* `git diff --check`