### PR TITLE
Add default_lang_commit front matter to de locale

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/de/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -1,6 +1,7 @@
 ---
 title: "Release-Zeitplan-Richtlinie"
 description: "Beschreibt Helms Release-Zeitplan-Richtlinie."
+default_lang_commit: cd5ad1e1593c50677909d7c618cf31cd4036fac7
 ---
 
 Helm gibt Veröffentlichungstermine im Voraus bekannt, damit Anwender besser planen
@@ -27,10 +28,11 @@ einmal im Monat am zweiten Mittwoch jedes Monats veröffentlicht.
 Ein Patch-Release zur Behebung einer kritischen Regression oder eines
 Sicherheitsproblems kann jederzeit bei Bedarf erfolgen.
 
-Ein Patch-Release wird aus einem der folgenden Gründe abgesagt:
+Ein geplanter Patch-Release wird aus einem der folgenden Gründe abgesagt:
 - wenn seit dem letzten Release kein neuer Inhalt hinzugekommen ist
 - wenn das Patch-Release-Datum innerhalb einer Woche vor dem ersten Release Candidate (RC1) einer anstehenden Nebenversion liegt
 - wenn das Patch-Release-Datum innerhalb von vier Wochen nach einer Nebenversion liegt
+- wenn für denselben Monat ein Major- oder Minor-Release geplant ist
 
 ## Nebenversionen
 

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
@@ -2,6 +2,7 @@
 title: Allgemeine Konventionen
 description: Allgemeine Konventionen für Charts.
 sidebar_position: 1
+default_lang_commit: cd6112565cf10522d4f1bd0928165cb5a91922c5
 ---
 
 Dieser Teil des Best-Practices-Leitfadens erklärt allgemeine Konventionen.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/custom_resource_definitions.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/custom_resource_definitions.md
@@ -2,6 +2,7 @@
 title: Custom Resource Definitions
 description: Erstellen und Verwenden von CRDs.
 sidebar_position: 7
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieser Teil des Best-Practices-Leitfadens behandelt die Erstellung und Verwendung von Custom-Resource-Definition-Objekten.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/dependencies.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/dependencies.md
@@ -2,6 +2,7 @@
 title: Abhängigkeiten
 description: Behandelt Best Practices für Chart-Abhängigkeiten.
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Dieser Teil des Best-Practices-Leitfadens behandelt die in `Chart.yaml` deklarierten `dependencies`.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/labels.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/labels.md
@@ -2,6 +2,7 @@
 title: Labels und Annotationen
 description: Behandelt Best Practices für die Verwendung von Labels und Annotationen in Ihrem Chart.
 sidebar_position: 5
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieser Teil des Best-Practices-Leitfadens behandelt Best Practices für die Verwendung von Labels und Annotationen in Ihrem Chart.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/pods.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/pods.md
@@ -2,6 +2,7 @@
 title: Pods und PodTemplates
 description: Behandelt die Formatierung von Pod- und PodTemplate-Bereichen in Chart-Manifesten.
 sidebar_position: 6
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieser Teil des Best-Practices-Leitfadens behandelt die Formatierung von Pod- und PodTemplate-Bereichen in Chart-Manifesten.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
@@ -2,6 +2,7 @@
 title: Rollenbasierte Zugriffskontrolle
 description: Behandelt die Erstellung und Formatierung von RBAC-Ressourcen in Chart-Manifesten.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieser Teil des Best-Practices-Leitfadens behandelt die Erstellung und Formatierung von

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/templates.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/templates.md
@@ -2,6 +2,7 @@
 title: Templates
 description: Ein genauerer Blick auf Best Practices rund um Templates.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Dieser Teil des Best-Practices-Leitfadens konzentriert sich auf Templates.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/values.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_best_practices/values.md
@@ -2,6 +2,7 @@
 title: Values
 description: Beschreibt, wie Sie Ihre Values strukturieren und verwenden sollten.
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieser Teil des Best-Practices-Leitfadens behandelt die Verwendung von Values. Hier geben wir Empfehlungen, wie Sie Ihre Values strukturieren und verwenden sollten, mit Fokus auf die Gestaltung der `values.yaml`-Datei eines Charts.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
@@ -2,6 +2,7 @@
 title: Zugriff auf Dateien innerhalb von Templates
 description: Wie Sie auf Dateien innerhalb eines Templates zugreifen können.
 sidebar_position: 10
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Im vorherigen Abschnitt haben wir mehrere Möglichkeiten kennengelernt, benannte

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/builtin_objects.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/builtin_objects.md
@@ -2,6 +2,7 @@
 title: Integrierte Objekte
 description: Integrierte Objekte, die in Templates verfügbar sind.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Objekte werden von der Template-Engine an ein Template übergeben. Ihr Code kann

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/control_structures.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/control_structures.md
@@ -2,6 +2,7 @@
 title: Ablaufsteuerung
 description: Ein kurzer Überblick über die Ablaufstrukturen in Templates.
 sidebar_position: 7
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Kontrollstrukturen (in der Template-Terminologie "Aktionen" genannt) bieten

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/data_types.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/data_types.md
@@ -2,6 +2,7 @@
 title: "Anhang: Go-Datentypen und Templates"
 description: Ein kurzer Überblick über Variablen in Templates.
 sidebar_position: 16
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Die Helm-Template-Sprache ist in der stark typisierten Programmiersprache Go

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
@@ -2,6 +2,7 @@
 title: Templates debuggen
 description: Fehlerbehebung bei Charts, die nicht bereitgestellt werden können.
 sidebar_position: 13
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Das Debuggen von Templates kann schwierig sein, da die gerenderten Templates an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
@@ -2,6 +2,7 @@
 title: Liste der Template-Funktionen
 description: Eine Liste der in Helm verfügbaren Template-Funktionen
 sidebar_position: 6
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm enthält viele Template-Funktionen, die Sie in Templates nutzen können.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
@@ -2,6 +2,7 @@
 title: Template-Funktionen und Pipelines
 description: Verwendung von Funktionen in Templates.
 sidebar_position: 5
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Bisher haben wir gesehen, wie man Informationen in ein Template einfügt. Aber

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
@@ -2,6 +2,7 @@
 title: Erste Schritte
 description: Eine Kurzanleitung zu Chart-Templates.
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 In diesem Abschnitt der Anleitung erstellen wir ein Chart und fügen dann ein

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/helm_ignore_file.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/helm_ignore_file.md
@@ -2,6 +2,7 @@
 title: Die .helmignore-Datei
 description: Die `.helmignore`-Datei wird verwendet, um Dateien anzugeben, die Sie nicht in Ihr Helm Chart aufnehmen möchten.
 sidebar_position: 12
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Die `.helmignore`-Datei wird verwendet, um Dateien anzugeben, die Sie nicht in

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/named_templates.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/named_templates.md
@@ -2,6 +2,7 @@
 title: Benannte Templates
 description: Wie man benannte Templates definiert.
 sidebar_position: 9
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Nun ist es an der Zeit, über ein einzelnes Template hinauszugehen und weitere zu

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/notes_files.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/notes_files.md
@@ -2,6 +2,7 @@
 title: Eine NOTES.txt-Datei erstellen
 description: Wie Sie Ihren Chart-Benutzern Anweisungen bereitstellen.
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 In diesem Abschnitt betrachten wir das Helm-Werkzeug zur Bereitstellung von

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/subcharts_and_globals.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/subcharts_and_globals.md
@@ -2,6 +2,7 @@
 title: Subcharts und globale Werte
 description: Arbeiten mit Subchart-Werten und globalen Werten.
 sidebar_position: 11
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Bis zu diesem Punkt haben wir nur mit einem einzelnen Chart gearbeitet. Aber

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/values_files.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/values_files.md
@@ -2,6 +2,7 @@
 title: Values-Dateien
 description: Anleitung zur Verwendung des --values-Flags.
 sidebar_position: 4
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Im vorherigen Abschnitt haben wir die eingebauten Objekte betrachtet, die Helm

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/variables.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/variables.md
@@ -2,6 +2,7 @@
 title: Variablen
 description: Verwendung von Variablen in Templates.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Nachdem wir nun mit Funktionen, Pipelines, Objekten und Kontrollstrukturen

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/wrapping_up.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/wrapping_up.md
@@ -2,6 +2,7 @@
 title: Nächste Schritte
 description: Abschluss - einige nützliche Hinweise auf weitere Dokumentation, die Ihnen helfen wird.
 sidebar_position: 14
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Diese Anleitung soll Ihnen als Chart-Entwickler ein fundiertes Verständnis

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/yaml_techniques.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/chart_template_guide/yaml_techniques.md
@@ -2,6 +2,7 @@
 title: "Anhang: YAML-Techniken"
 description: Ein genauerer Blick auf die YAML-Spezifikation und wie sie auf Helm angewendet wird.
 sidebar_position: 15
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Der Großteil dieser Anleitung hat sich auf das Schreiben der Template-Sprache

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/faq/changes_since_helm2.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/faq/changes_since_helm2.md
@@ -1,6 +1,7 @@
 ---
 title: "Änderungen seit Helm 2"
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 ## Änderungen seit Helm 2

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/faq/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/faq/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Fragen und Antworten"
-sidebar_position: 8
+sidebar_position: 9
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Fragen und Antworten

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/faq/installing.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/faq/installing.md
@@ -1,6 +1,7 @@
 ---
 title: "Installieren"
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 ## Installieren

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: "Fehlersuche"
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 ## Fehlersuche

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/faq/uninstalling.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/faq/uninstalling.md
@@ -1,6 +1,7 @@
 ---
 title: "Deinstallieren"
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 ## Deinstallieren

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/glossary/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/glossary/index.mdx
@@ -1,7 +1,8 @@
 ---
 title: "Glossar" 
 description: "Benutzte Ausdrücke zur Beschreibung der Komponenten der Helm Architektur."
-sidebar_position: 9
+sidebar_position: 10
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Glossar

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm.md
@@ -1,6 +1,7 @@
 ---
 title: helm
 slug: helm
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Der Helm-Paketmanager für Kubernetes.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Generiert Autovervollständigungsskripte für die angegebene Shell

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_bash.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_bash.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion bash
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Generiert das Autovervollständigungsskript für bash

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_fish.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_fish.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion fish
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Generiert das Autovervollständigungsskript für fish

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_powershell.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_powershell.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion powershell
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Generiert das Autovervollständigungsskript für PowerShell

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_zsh.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_completion_zsh.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion zsh
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Generiert das Autovervollständigungsskript für zsh

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_create.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_create.md
@@ -1,5 +1,6 @@
 ---
 title: helm create
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Erstellt ein neues Chart mit dem angegebenen Namen

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Verwaltet die Abhängigkeiten eines Charts

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_build.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_build.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency build
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Erstellt das Verzeichnis charts/ basierend auf der Chart.lock-Datei neu

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_list.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency list
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Listet die Abhängigkeiten für das angegebene Chart auf

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_update.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency update
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Aktualisiert charts/ entsprechend dem Inhalt von Chart.yaml

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_env.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_env.md
@@ -1,5 +1,6 @@
 ---
 title: helm env
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Informationen zur Helm-Client-Umgebung

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get.md
@@ -1,5 +1,6 @@
 ---
 title: helm get
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Lädt erweiterte Informationen für ein benanntes Release herunter

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_all.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_all.md
@@ -1,5 +1,6 @@
 ---
 title: helm get all
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Lädt alle Informationen für ein benanntes Release herunter

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_hooks.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_hooks.md
@@ -1,5 +1,6 @@
 ---
 title: helm get hooks
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Lädt alle Hooks für ein benanntes Release herunter

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_manifest.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_manifest.md
@@ -1,5 +1,6 @@
 ---
 title: helm get manifest
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Lädt das Manifest für ein benanntes Release herunter

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md
@@ -1,5 +1,6 @@
 ---
 title: helm get metadata
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Ruft die Metadaten für ein bestimmtes Release ab

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_notes.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_notes.md
@@ -1,5 +1,6 @@
 ---
 title: helm get notes
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Lädt die Notizen für ein benanntes Release herunter

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_values.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_get_values.md
@@ -1,5 +1,6 @@
 ---
 title: helm get values
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Lädt die Values-Datei für ein benanntes Release herunter

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_history.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_history.md
@@ -1,5 +1,6 @@
 ---
 title: helm history
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt die Release-Historie an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_install.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_install.md
@@ -1,5 +1,6 @@
 ---
 title: helm install
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Installiert ein Chart

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_lint.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_lint.md
@@ -1,5 +1,6 @@
 ---
 title: helm lint
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Untersucht ein Chart auf mögliche Probleme

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_list.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm list
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Listet Releases auf

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_package.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_package.md
@@ -1,5 +1,6 @@
 ---
 title: helm package
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Ein Chart-Verzeichnis in ein Chart-Archiv paketieren

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Helm Plugins installieren, auflisten oder deinstallieren

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_install.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_install.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin install
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Installiert ein Helm-Plugin

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_list.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin list
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Listet installierte Helm Plugins auf

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_uninstall.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_uninstall.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin uninstall
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Deinstalliert ein oder mehrere Helm Plugins

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_update.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin update
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Aktualisiert ein oder mehrere Helm Plugins

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_pull.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_pull.md
@@ -1,5 +1,6 @@
 ---
 title: helm pull
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Ein Chart aus einem Repository herunterladen und (optional) lokal entpacken

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_push.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_push.md
@@ -1,5 +1,6 @@
 ---
 title: helm push
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Ein Chart in eine Registry hochladen

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_registry.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_registry.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Bei einer Registry an- oder abmelden

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_registry_login.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_registry_login.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry login
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Bei einer Registry anmelden

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_registry_logout.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_registry_logout.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry logout
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Von einer Registry abmelden

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Chart Repositories hinzufügen, auflisten, entfernen, aktualisieren und indizieren

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_add.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_add.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo add
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Fügt ein Chart Repository hinzu

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_index.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_index.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo index
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Erstellt eine Indexdatei aus einem Verzeichnis mit gepackten Charts

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_list.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo list
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Listet Chart Repositories auf

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_remove.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_remove.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo remove
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Entfernt ein oder mehrere Chart Repositories

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_update.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_repo_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo update
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Aktualisiert lokal die Informationen über verfügbare Charts aus den Chart Repositories

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md
@@ -1,5 +1,6 @@
 ---
 title: helm rollback
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Setzt ein Release auf eine vorherige Revision zurück

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_search.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_search.md
@@ -1,5 +1,6 @@
 ---
 title: helm search
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Durchsucht Charts nach einem Suchbegriff

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_search_hub.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_search_hub.md
@@ -1,5 +1,6 @@
 ---
 title: helm search hub
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Durchsucht den Artifact Hub oder Ihre eigene Hub-Instanz nach Charts

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_search_repo.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_search_repo.md
@@ -1,5 +1,6 @@
 ---
 title: helm search repo
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Durchsucht Repositories nach Charts anhand eines Suchbegriffs

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show.md
@@ -1,5 +1,6 @@
 ---
 title: helm show
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt Informationen zu einem Chart an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_all.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_all.md
@@ -1,5 +1,6 @@
 ---
 title: helm show all
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt alle Informationen eines Charts an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_chart.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_chart.md
@@ -1,5 +1,6 @@
 ---
 title: helm show chart
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt die Definition des Charts an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_crds.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_crds.md
@@ -1,5 +1,6 @@
 ---
 title: helm show crds
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt die CRDs des Charts an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_readme.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_readme.md
@@ -1,5 +1,6 @@
 ---
 title: helm show readme
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt die README-Datei des Charts an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_values.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_show_values.md
@@ -1,5 +1,6 @@
 ---
 title: helm show values
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt die Werte des Charts an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_status.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_status.md
@@ -1,5 +1,6 @@
 ---
 title: helm status
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Zeigt den Status eines benannten Releases an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_template.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_template.md
@@ -1,5 +1,6 @@
 ---
 title: helm template
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Rendert Templates lokal

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_test.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_test.md
@@ -1,5 +1,6 @@
 ---
 title: helm test
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Führt Tests für ein Release aus

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_uninstall.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_uninstall.md
@@ -1,5 +1,6 @@
 ---
 title: helm uninstall
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Deinstalliert ein Release

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_upgrade.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: helm upgrade
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Aktualisiert ein Release auf eine neue Version eines Charts

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_verify.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_verify.md
@@ -1,5 +1,6 @@
 ---
 title: helm verify
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Überprüft, ob ein Chart am angegebenen Pfad signiert wurde und gültig ist

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_version.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/helm/helm_version.md
@@ -1,5 +1,6 @@
 ---
 title: helm version
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Gibt die Client-Versionsinformationen aus

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/howto/chart_releaser_action.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/howto/chart_releaser_action.md
@@ -2,6 +2,7 @@
 title: Chart Releaser Action zur Automatisierung von GitHub Pages Charts
 description: Beschreibt, wie Sie die Chart Releaser Action verwenden, um die Veröffentlichung von Charts über GitHub Pages zu automatisieren.
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Diese Anleitung beschreibt, wie Sie die [Chart Releaser

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
@@ -2,6 +2,7 @@
 title: "Synchronisieren Ihres Chart Repository"
 description: "Beschreibt wie Sie lokale und entfernte Chart Repositories synchronisieren."
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 *Hinweis: Dieses Beispiel richtet sich an einen Google Cloud Storage (GCS) Bucket,

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/howto/charts_tips_and_tricks.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/howto/charts_tips_and_tricks.md
@@ -2,6 +2,7 @@
 title: "Chart Entwicklung Tipps und Tricks"
 description: "Bespricht Tipps und Tricks,die Helm Chart Entwickler bei der Entwicklung von produktionsreifer Charts gelernt haben."
 sidebar_position: 1
+default_lang_commit: dab98b270b8063741fb595e80f706fa0b867a8be
 ---
 
 Dieses Handbuch bespricht Tipps und Tricks, die Helm Chart Entwickler bei der Entwicklung von produktionsreifen Charts gelernt haben.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/howto/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/howto/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Lernprogramme"
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 # Wie-geht-Anleitungen (How-Tos)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Dokumentation"
 description: "Alles Wissenswerte zur Organisation der Dokumentation."
+sidebar_position: 1
+default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 # Willkommen
@@ -14,7 +16,7 @@ Manager für Kubernetes. Genauere Hintergrundinformationen gibt es im
 Helm hat eine Menge Dokumentation. Eine Hauptübersicht ist hilfreich, nach
 bestimmten Dingen zu suchen:
 
-- [Lernprogramme](/intro/index.mdx) sind eine gute Handhabe, um das erste Helm Chart zu
+- [Lernprogramme](/chart_template_guide/getting_started.md) sind eine gute Handhabe, um das erste Helm Chart zu
   erstellen. Starten Sie hier, wenn Sie neu bei Helm sind.
 - [Themenhandbücher](/topics/index.mdx) diskutieren Hauptthemen und Konzepte auf einem
   hohen Niveau und stellen nützliche Hintergrundinformationen und Erklärungen

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/intro/CheatSheet.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/intro/CheatSheet.md
@@ -2,6 +2,7 @@
 title: Spickzettel
 description: Helm Spickzettel
 sidebar_position: 4
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieser Helm Spickzettel enthält alle notwendigen Befehle, die Sie zur Verwaltung einer Anwendung mit Helm benötigen.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/intro/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/intro/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Einführung"
 sidebar_position: 1
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Einführung in Helm

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -2,6 +2,7 @@
 title: "Helm installieren"
 description: "Lernen Sie wie man Helm installiert und zum Laufen kriegt."
 sidebar_position: 2
+default_lang_commit: 042b2178fb9384a9d4fe774f210d6db402f3da02
 ---
 
 Diese Anleitung zeigt, wie Helm CLI zu installieren ist. Helm kann sowohl

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
@@ -2,6 +2,7 @@
 title: "Schnellstartanleitung"
 description: "Wie mit Helm anfangen, incl. Anleitungen für Distributionen, FAQs und Plugins."
 sidebar_position: 1
+default_lang_commit: e5a8a262fa2a2852a8f3dc0c83260363fff4dced
 ---
 
 Mit dieser Anleitung können Sie schnell mit Helm starten.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
@@ -2,6 +2,7 @@
 title: "Helm benutzen"
 description: "Erklärt die Grundsätze zu Helm."
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Diese Anleitung erklärt die Grundlagen zur Benutzung von Helm, um Pakete in Ihrem Kubernetes

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/sdk/gosdk.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/sdk/gosdk.md
@@ -2,6 +2,7 @@
 title: Einführung
 description: Stellt das Helm Go SDK vor
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 Das Go SDK von Helm ermöglicht es benutzerdefinierter Software, Helm Charts und die Funktionalität von Helm für die Verwaltung von Kubernetes-Software-Deployments zu nutzen.
 (Die Helm CLI ist im Grunde selbst nur ein solches Werkzeug!)

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -2,6 +2,7 @@
 title: Fortgeschrittene Helm-Techniken
 description: Erläutert verschiedene fortgeschrittene Funktionen für erfahrene Helm-Benutzer
 sidebar_position: 9
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Dieser Abschnitt erläutert verschiedene fortgeschrittene Funktionen und Techniken für die Verwendung von Helm.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/architecture.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/architecture.md
@@ -2,6 +2,7 @@
 title: Helm Architektur
 description: Beschreibt die Architektur von Helm auf hoher Ebene.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 # Helm Architektur

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -2,6 +2,7 @@
 title: Leitfaden für Chart Repositories
 description: So erstellen und arbeiten Sie mit Helm Chart Repositories.
 sidebar_position: 6
+default_lang_commit: 944aeaca4df514e7c5ba091995fcbbc08e505f65
 ---
 
 Dieser Abschnitt erklärt, wie Sie Chart Repositories erstellen und damit arbeiten.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
@@ -2,6 +2,7 @@
 title: Chart Tests
 description: Beschreibt, wie Sie Ihre Charts ausführen und testen können.
 sidebar_position: 3
+default_lang_commit: 81fa9227414a9c99d74705bdc159c4c21c9aac7c
 ---
 
 Ein Chart enthält eine Reihe von Kubernetes-Ressourcen und Komponenten, die zusammenarbeiten. Als Chart-Autor möchten Sie möglicherweise Tests schreiben, die überprüfen, ob Ihr Chart bei der Installation wie erwartet funktioniert. Diese Tests helfen auch dem Chart-Benutzer zu verstehen, was Ihr Chart tun soll.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -2,6 +2,7 @@
 title: Charts
 description: Erklärt das Chart-Format und bietet grundlegende Anleitungen zum Erstellen von Charts mit Helm.
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm verwendet ein Paketformat namens _Charts_. Ein Chart ist eine Sammlung von Dateien, die zusammengehörige Kubernetes-Ressourcen beschreiben. Mit einem einzelnen Chart lässt sich etwas Einfaches wie ein Memcached-Pod bereitstellen, aber auch etwas Komplexes wie ein vollständiger Web-App-Stack mit HTTP-Servern, Datenbanken, Caches usw.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
@@ -2,6 +2,7 @@
 title: Chart Hooks
 description: Beschreibt die Arbeit mit Chart Hooks.
 sidebar_position: 2
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Helm bietet einen _Hook_-Mechanismus, der es Chart-Entwicklern ermöglicht, an

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md
@@ -1,6 +1,7 @@
 ---
 title: Veraltete Kubernetes-APIs
 description: Erläutert veraltete Kubernetes-APIs im Kontext von Helm
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Kubernetes ist ein API-gesteuertes System. Die API entwickelt sich im Laufe der

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/kubernetes_distros.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/kubernetes_distros.md
@@ -2,6 +2,7 @@
 title: Leitfaden für Kubernetes-Distributionen
 description: Enthält Informationen zur Verwendung von Helm in bestimmten Kubernetes-Umgebungen.
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Helm sollte mit jeder [konformen Version von

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/library_charts.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/library_charts.md
@@ -2,6 +2,7 @@
 title: Library Charts
 description: Erläutert Library Charts und zeigt Anwendungsbeispiele
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Ein Library Chart ist ein spezieller Typ von [Helm Chart](/topics/charts.md),

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/permissions_sql_storage_backend.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/permissions_sql_storage_backend.md
@@ -1,6 +1,7 @@
 ---
 title: Berechtigungsverwaltung für das SQL-Speicher-Backend
 description: Erfahren Sie, wie Sie Berechtigungen bei Verwendung des SQL-Speicher-Backends einrichten.
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dieses Dokument bietet eine Anleitung zur Einrichtung und Verwaltung von

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -2,6 +2,7 @@
 title: Der Helm Plugins Leitfaden
 description: Erklärt, wie Sie Plugins verwenden und erstellen können, um die Funktionalität von Helm zu erweitern.
 sidebar_position: 12
+default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 Ein Helm Plugin ist ein Werkzeug, das über die `helm` CLI aufgerufen werden kann,

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/provenance.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/provenance.md
@@ -2,6 +2,7 @@
 title: Helm-Provenienz und -Integrität
 description: Beschreibt, wie Sie die Integrität und Herkunft eines Charts überprüfen können.
 sidebar_position: 5
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm verfügt über Provenienz-Werkzeuge, die Chart-Benutzern helfen, die Integrität und

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/rbac.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/rbac.md
@@ -2,6 +2,7 @@
 title: Rollenbasierte Zugriffskontrolle
 description: Erläutert, wie Helm mit der rollenbasierten Zugriffskontrolle (RBAC) von Kubernetes interagiert.
 sidebar_position: 11
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 In Kubernetes ist es eine Best Practice, Benutzern oder anwendungsspezifischen

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/registries.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/registries.md
@@ -2,6 +2,7 @@
 title: OCI-basierte Registries verwenden
 description: Beschreibt die Verwendung von OCI für die Chart-Verteilung.
 sidebar_position: 7
+default_lang_commit: 2e15490c82d246093e11e418a7c23907a4afa89e
 ---
 
 Seit Helm 3 können Sie Container-Registries mit [OCI](https://www.opencontainers.org/)-Unterstützung verwenden, um Chart-Pakete zu speichern und zu teilen. Ab Helm v3.8.0 ist die OCI-Unterstützung standardmäßig aktiviert.

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/v2_v3_migration.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/v2_v3_migration.md
@@ -2,6 +2,7 @@
 title: Migration von Helm v2 auf v3
 description: Erfahren Sie, wie Sie Helm v2 auf v3 migrieren.
 sidebar_position: 13
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Diese Anleitung zeigt, wie Sie Helm v2 auf v3 migrieren. Helm v2 muss installiert sein

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
@@ -1,6 +1,7 @@
 ---
 title: "Helm Versionsunterstützung"
 description: "Beschreibt die Patch-Release-Richtlinie von Helm sowie die maximal unterstützte Versionsabweichung zwischen Helm und Kubernetes."
+default_lang_commit: d9bd24cdc719cd5ddef925552a7049cfbd6f469e
 ---
 
 Dieses Dokument beschreibt die maximal unterstützte Versionsabweichung zwischen Helm und


### PR DESCRIPTION
## Description

Follow up to https://github.com/helm/helm-www/pull/2156

This PR adds the `default_lang_commit` field to the front matter of all the translated files for the `de` locale. The purpose of this PR is to ensure that all files in the `de` locale are being tracked by the i18n dift checks, _not_ that all files are in sync with their English source.

To test, run `npm run check:i18n-drift -- --locale de` and see `Untracked: 0`:

```
npm run check:i18n-drift -- --locale de                 

> helm-www@0.0.0 check:i18n-drift
> node scripts/check-i18n-drift.mjs --locale de

Locales checked: de
Localized Markdown files checked: 115
In sync: 98
Drifted: 17
Untracked: 0
Source missing: 0
Invalid commit: 0

[...list of drifted files...]
```
## Reconciling drifted `de` files
The following files in the de locale have mismatches with the latest commit for their English source that need to be reconciled before adding the default_lang_commit front matter (ie, need to either make the update to bring de up-to-date with the latest English source file commit, or need to identify which English source file commit it actually maps to):

### /chart_template_guide
- [x] `chart_template_guide/accessing_files.md`: Template examples differ from English source; German uses indent instead of nindent, omits {{-, and has different indentation.
  - Solution: Pin to https://github.com/helm/helm-www/commit/f1c342d7bbd8fca5494262a93699b27012859e24
- [x] `chart_template_guide/function_list.md`: Missing fromYaml
  - Solution: Pin to f1c342d7bbd8fca5494262a93699b27012859e24 
- [x] `chart_template_guide/helm_ignore_file.md`: .helmignore example differs; English uses draft* / draft?, German uses temp* / temp?.
  - Solution: Pin to https://github.com/helm/helm-www/commit/07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
- [x] `chart_template_guide/named_templates.md`: Template examples differ from English source; German uses indent instead of nindent, omits {{-, and has different indentation.
  - Solution: Pin to https://github.com/helm/helm-www/commit/f1c342d7bbd8fca5494262a93699b27012859e24
- [x] `chart_template_guide/yaml_techniques.md`: Template example differs from English source; German uses indent instead of nindent, omits {{-, and has different indentation.
  - Solution: Pin to https://github.com/helm/helm-www/commit/f1c342d7bbd8fca5494262a93699b27012859e24 

### /faq
- [x] `faq/index.mdx`: Frontmatter differs; English has sidebar_position: 9, German has sidebar_position: 8.
  - Solution: Update sidebar position to match English source and then add the latest commit hash for English source 
- [x] `faq/troubleshooting.md`: Code block sequence/content differs; German has fewer code fences and different troubleshooting error examples.
  - Solution: Pin to https://github.com/helm/helm-www/commit/f1c342d7bbd8fca5494262a93699b27012859e24 

### /glossary
- [x] `glossary/index.mdx`: Frontmatter differs; English has sidebar_position: 10, German has sidebar_position: 9.
  - Solution: Update sidebar position to match English source and then add the latest commit hash for English source 

### /howto
- [x] `howto/charts_tips_and_tricks.md`: Annotation example differs; German quotes "helm.sh/resource-policy" while English leaves it unquoted.
  - Solution: Pin to https://github.com/helm/helm-www/commit/dab98b270b8063741fb595e80f706fa0b867a8be 

### index.mdx
- [x] index.mdx: Frontmatter differs because German lacks sidebar_position: 1; content links also differ from English, including the tutorials link target.
  - Solution: add `sidebar_position: 1`, update Tutorials link from`(/intro/index.mdx)` to `(/chart_template_guide/getting_started.md)` and then pin to the latest English source commit

### /intro
- [x] intro/CheatSheet.md: Missing --rollback-on-failure updates
  - Solution: Pin to https://github.com/helm/helm-www/commit/07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a 
- [x] intro/install.md: APT install snippet is older in German and missing the key fingerprint verification block from English.
  - Solution: Pin to https://github.com/helm/helm-www/commit/042b2178fb9384a9d4fe774f210d6db402f3da02 
- [x] intro/quickstart.md: Command example differs; German uses $ helm ls, English uses $ helm list.
  - Solution: no change needed since ls is an alias for list. pin to the latest English source commit

### /helm
These are missing the latest updates. Need to pin all of them to https://github.com/helm/helm-www/commit/f1c342d7bbd8fca5494262a93699b27012859e24

- [x] helm/helm_completion_bash.md: Generated CLI help block is localized/different from the English generated output.
- [x] helm/helm_completion_fish.md: Generated CLI help block is localized/different from the English generated output.
- [x] helm/helm_completion_powershell.md: Generated CLI help block is localized/different from the English generated output.
- [x] helm/helm_completion_zsh.md: Generated CLI help block is localized/different from the English generated output.
- [x] helm/helm_completion.md: Generated CLI help block is localized/different from the English generated output.
- [x] helm/helm_create.md: Generated CLI help block is localized/different from the English generated output.
- [x] helm/helm_get_metadata.md: German file has extra translated summary sections and an older generated date than the English source.
- [x] helm/helm_package.md: Generated CLI help block is localized/different from the English generated output.

### Community
- [X] release_policy missing the word "scheduled" and the fourth bullet point from the English source (https://github.com/helm/helm-www/commit/cd5ad1e1593c50677909d7c618cf31cd4036fac7)
  - Solution: Update to the latest from the english source and then pin to cd5ad1e1593c50677909d7c618cf31cd4036fac7