### PR TITLE
docs: Correct chart name validation rules to match helm lint (DNS-1123 subdomain)

### DIFF
--- a/docs/chart_best_practices/conventions.md
+++ b/docs/chart_best_practices/conventions.md
@@ -8,9 +8,12 @@ This part of the Best Practices Guide explains general conventions.
 
 ## Chart Names
 
-Chart names must follow DNS-1123 label conventions: only lowercase letters,
-numbers, and dashes are allowed, names must start and end with a lowercase
-letter or number, and names cannot exceed 63 characters:
+Chart names are used as a prefix for the resources a chart creates, so they must
+be valid Kubernetes resource names. Names must follow DNS-1123 subdomain
+conventions: only lowercase letters, numbers, dashes, and dots are allowed;
+names must start and end with a lowercase letter or number; each dot-separated
+segment must also start and end with a lowercase letter or number; and names
+cannot exceed 253 characters:
 
 Examples:
 
@@ -18,15 +21,17 @@ Examples:
 drupal
 nginx-lego
 aws-cluster-autoscaler
+my.chart
 ```
 
 Invalid chart names include:
 - Names with uppercase letters (e.g., `MyChart`)
 - Names with underscores (e.g., `my_chart`)
-- Names with dots (e.g., `my.chart`)
+- Names with spaces (e.g., `my chart`)
 - Names starting with a dash (e.g., `-mychart`)
 - Names ending with a dash (e.g., `mychart-`)
-- Names longer than 63 characters
+- Names containing path separators (e.g., `../mychart`)
+- Names longer than 253 characters
 
 The `helm lint` command validates chart names against these rules.
 

--- a/versioned_docs/version-3/chart_best_practices/conventions.md
+++ b/versioned_docs/version-3/chart_best_practices/conventions.md
@@ -8,9 +8,12 @@ This part of the Best Practices Guide explains general conventions.
 
 ## Chart Names
 
-Chart names must follow DNS-1123 label conventions: only lowercase letters,
-numbers, and dashes are allowed, names must start and end with a lowercase
-letter or number, and names cannot exceed 63 characters:
+Chart names are used as a prefix for the resources a chart creates, so they must
+be valid Kubernetes resource names. Names must follow DNS-1123 subdomain
+conventions: only lowercase letters, numbers, dashes, and dots are allowed;
+names must start and end with a lowercase letter or number; each dot-separated
+segment must also start and end with a lowercase letter or number; and names
+cannot exceed 253 characters:
 
 Examples:
 
@@ -18,15 +21,17 @@ Examples:
 drupal
 nginx-lego
 aws-cluster-autoscaler
+my.chart
 ```
 
 Invalid chart names include:
 - Names with uppercase letters (e.g., `MyChart`)
 - Names with underscores (e.g., `my_chart`)
-- Names with dots (e.g., `my.chart`)
+- Names with spaces (e.g., `my chart`)
 - Names starting with a dash (e.g., `-mychart`)
 - Names ending with a dash (e.g., `mychart-`)
-- Names longer than 63 characters
+- Names containing path separators (e.g., `../mychart`)
+- Names longer than 253 characters
 
 The `helm lint` command validates chart names against these rules.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/ee680df5-0034-4838-8e79-e7ddc47c07ce)

Updates the "Chart Names" best-practices section (v3 and v4 docs) to match the validation helm lint now enforces via chartutil.ValidateMetadataName: dots are allowed (e.g. my.chart), the length limit is 253 characters, and names follow DNS-1123 subdomain (not label) rules. The previous docs incorrectly listed dots as invalid and stated a 63-character limit.

**Trigger Events**
- [helm/helm PR #32278: fix(lint): validate kubernetes resource names for chart names](https://github.com/helm/helm/pull/32278)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_