### PR TITLE
docs: Document helm env --output json|yaml on the cheat sheet

### DIFF
--- a/docs/intro/CheatSheet.mdx
+++ b/docs/intro/CheatSheet.mdx
@@ -111,6 +111,8 @@ helm status <release> --revision <number>   # if set, display the status of the 
 helm history <release>          # Historical revisions for a given release.
 helm history <release> --show-rollback-revision # Add a ROLLBACK column showing which revision each rollback targeted
 helm env                        # Env prints out all the environment information in use by Helm.
+helm env -o json                # Prints the environment information in the specified format. Allowed values: env, json, yaml (default env)
+helm env HELM_BIN               # Print the value of a single environment variable
 ```
 -------------------------------------------------------------------------------------------------------------------------------------------------
 ### Download Release Information


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/8ee7aadf-f621-4b0c-8d16-601107a7dd8d)

Adds the new `--output`/`-o` flag for `helm env` (accepting `env`, `json`, `yaml`) to the Helm cheat sheet, alongside the existing single-variable example, so the structured output capability is discoverable in curated prose docs. The auto-generated CLI reference already picks up the flag from cobra help.

**Trigger Events**
- [helm/helm PR #32282: feat(env): add --output json|yaml to 'helm env'](https://github.com/helm/helm/pull/32282)

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_