### PR TITLE
Adds default_lang_commit to front matter for es pages

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/es/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -1,6 +1,7 @@
 ---
 title: "Política de Calendario de Releases"
 description: "Describe la política de calendario de releases de Helm."
+default_lang_commit: cd5ad1e1593c50677909d7c618cf31cd4036fac7
 ---
 
 Para beneficio de sus usuarios, Helm define y anuncia las fechas de release con
@@ -33,6 +34,7 @@ Un release de parche se cancelará por cualquiera de las siguientes razones:
 - si no hay contenido nuevo desde el release anterior
 - si la fecha del release de parche cae dentro de la semana anterior al primer release candidate (RC1) de un próximo release menor
 - si la fecha del release de parche cae dentro de las cuatro semanas siguientes a un release menor
+- si un release mayor o menor está programado para el mismo mes
 
 ## Releases Menores
 

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
@@ -2,6 +2,7 @@
 title: Convenciones Generales
 description: Convenciones generales para charts.
 sidebar_position: 1
+default_lang_commit: 35e200fbcba7033358a6e2b414b6a5499da0282d
 ---
 
 Esta parte de la Guía de Mejores Prácticas explica las convenciones generales.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/custom_resource_definitions.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/custom_resource_definitions.md
@@ -2,6 +2,7 @@
 title: Custom Resource Definitions
 description: Cómo manejar la creación y uso de CRDs.
 sidebar_position: 7
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta sección de la Guía de Mejores Prácticas trata sobre la creación y uso de

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/dependencies.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/dependencies.md
@@ -2,6 +2,7 @@
 title: Dependencias
 description: Cubre las mejores prácticas para las dependencias de un Chart.
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Esta sección de la guía cubre las mejores prácticas para las `dependencies` declaradas

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/labels.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/labels.md
@@ -2,6 +2,7 @@
 title: Etiquetas y Anotaciones
 description: Cubre las mejores prácticas para usar etiquetas y anotaciones en su Chart.
 sidebar_position: 5
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta parte de la Guía de Mejores Prácticas cubre las mejores prácticas para usar

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/pods.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/pods.md
@@ -2,6 +2,7 @@
 title: Pods y PodTemplates
 description: Discute el formato de las secciones Pod y PodTemplate en los manifiestos de Chart.
 sidebar_position: 6
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta parte de la Guía de Mejores Prácticas discute el formato de las secciones

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
@@ -2,6 +2,7 @@
 title: Control de Acceso Basado en Roles
 description: Discute la creación y formato de recursos RBAC en manifiestos de Charts.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta parte de la Guía de Mejores Prácticas cubre la creación y formato de

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/templates.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/templates.md
@@ -2,6 +2,7 @@
 title: Plantillas
 description: Mejores prácticas para trabajar con plantillas.
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta parte de la Guía de Mejores Prácticas se enfoca en plantillas.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/values.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_best_practices/values.md
@@ -2,6 +2,7 @@
 title: Valores
 description: Se enfoca en cómo debe estructurar y usar sus values.
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta parte de la guía de mejores prácticas cubre el uso de values. En esta sección,

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
@@ -2,6 +2,7 @@
 title: Acceso a Archivos en las Plantillas
 description: Cómo acceder a archivos desde dentro de una plantilla.
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 En la sección anterior vimos varias formas de crear y acceder a plantillas con

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/builtin_objects.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/builtin_objects.md
@@ -2,6 +2,7 @@
 title: Objetos Integrados
 description: Objetos integrados disponibles para las plantillas.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 El motor de plantillas pasa los objetos a la plantilla. Su código también puede

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/control_structures.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/control_structures.md
@@ -2,6 +2,7 @@
 title: Control de Flujo
 description: Una descripción rápida de la estructura de flujo dentro de las plantillas.
 sidebar_position: 7
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Las estructuras de control (llamadas "acciones" en la terminología de plantillas)

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/data_types.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/data_types.md
@@ -2,6 +2,7 @@
 title: "Apéndice: Tipos de datos de Go y plantillas"
 description: Un resumen rápido sobre las variables en las plantillas.
 sidebar_position: 16
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 El lenguaje de plantillas de Helm está implementado en Go, un lenguaje de

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
@@ -2,6 +2,7 @@
 title: Depuración de Plantillas
 description: Solución de problemas de charts que no se despliegan correctamente.
 sidebar_position: 13
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 La depuración de plantillas puede ser complicada porque las plantillas renderizadas

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
@@ -2,6 +2,7 @@
 title: Lista de Funciones de Plantilla
 description: Una lista de funciones de plantilla disponibles en Helm
 sidebar_position: 6
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Helm incluye muchas funciones de plantilla que puede aprovechar en sus plantillas.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
@@ -2,6 +2,7 @@
 title: Funciones de Plantilla y Pipelines
 description: Uso de funciones en plantillas.
 sidebar_position: 5
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Hasta ahora, hemos visto cómo colocar información en una plantilla. Pero esa

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
@@ -2,6 +2,7 @@
 title: Primeros Pasos
 description: Una guía rápida sobre plantillas de Chart.
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 En esta sección de la guía, crearemos un chart y luego agregaremos una primera

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/helm_ignore_file.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/helm_ignore_file.md
@@ -2,6 +2,7 @@
 title: El archivo .helmignore
 description: El archivo `.helmignore` se usa para especificar archivos que no desea incluir en su chart de Helm.
 sidebar_position: 12
+default_lang_commit: c4624cd8526f3d0927fa871facd19c9a0cf5b810
 ---
 
 El archivo `.helmignore` se usa para especificar archivos que no desea incluir

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/named_templates.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/named_templates.md
@@ -2,6 +2,7 @@
 title: Plantillas con Nombre
 description: Cómo definir plantillas con nombre.
 sidebar_position: 9
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Ha llegado el momento de ir más allá de una sola plantilla y comenzar a crear

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/notes_files.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/notes_files.md
@@ -2,6 +2,7 @@
 title: Creación de un Archivo NOTES.txt
 description: Cómo proporcionar instrucciones a los usuarios de su Chart.
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 En esta sección vamos a ver la herramienta de Helm para proporcionar

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/subcharts_and_globals.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/subcharts_and_globals.md
@@ -2,6 +2,7 @@
 title: Subcharts y Valores Globales
 description: Interacción con subcharts y valores globales.
 sidebar_position: 11
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Hasta este punto hemos trabajado solo con un chart. Pero los charts pueden tener

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/values_files.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/values_files.md
@@ -2,6 +2,7 @@
 title: Archivos Values
 description: Instrucciones sobre cómo usar la opción --values.
 sidebar_position: 4
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 En la sección anterior vimos los objetos integrados que ofrecen las plantillas

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/variables.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/variables.md
@@ -2,6 +2,7 @@
 title: Variables
 description: Uso de variables en plantillas.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Con funciones, pipelines, objetos y estructuras de control ya dominados, podemos

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/wrapping_up.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/wrapping_up.md
@@ -2,6 +2,7 @@
 title: Próximos Pasos
 description: Conclusión - algunos enlaces útiles a otra documentación que le será de ayuda.
 sidebar_position: 14
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Esta guía está diseñada para darle a usted, el desarrollador de charts, una

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/yaml_techniques.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/chart_template_guide/yaml_techniques.md
@@ -2,6 +2,7 @@
 title: "Apéndice: Técnicas de YAML"
 description: Una mirada más detallada a la especificación YAML y cómo se aplica a Helm.
 sidebar_position: 15
+default_lang_commit: ba552a20cbe232493e23226f44bce119adb704e1
 ---
 
 La mayor parte de esta guía se ha centrado en escribir el lenguaje de plantillas.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/faq/changes_since_helm2.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/faq/changes_since_helm2.md
@@ -1,6 +1,7 @@
 ---
 title: Cambios desde Helm 2
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 ## Cambios desde Helm 2

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/faq/installing.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/faq/installing.md
@@ -1,6 +1,7 @@
 ---
 title: Instalación
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 ## Instalación

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: Solución de Problemas
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 ## Solución de Problemas

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/faq/uninstalling.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/faq/uninstalling.md
@@ -1,6 +1,7 @@
 ---
 title: Desinstalación
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 ## Desinstalación

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm.md
@@ -1,6 +1,7 @@
 ---
 title: helm
 slug: helm
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 El gestor de paquetes Helm para Kubernetes.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 genera scripts de autocompletado para el shell especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_bash.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_bash.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion bash
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 genera el script de autocompletado para bash

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_fish.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_fish.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion fish
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 genera el script de autocompletado para fish

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_powershell.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_powershell.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion powershell
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 genera el script de autocompletado para powershell

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_zsh.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_completion_zsh.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion zsh
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 genera el script de autocompletado para zsh

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_create.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_create.md
@@ -1,5 +1,6 @@
 ---
 title: helm create
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 crea un nuevo chart con el nombre proporcionado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 gestiona las dependencias de un chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_build.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_build.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency build
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 reconstruye el directorio charts/ basándose en el archivo Chart.lock

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_list.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency list
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 lista las dependencias del chart dado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_update.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency update
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 actualiza charts/ basándose en el contenido de Chart.yaml

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_env.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_env.md
@@ -1,5 +1,6 @@
 ---
 title: helm env
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 información del entorno del cliente Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get.md
@@ -1,5 +1,6 @@
 ---
 title: helm get
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 descarga información extendida de un release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_all.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_all.md
@@ -1,5 +1,6 @@
 ---
 title: helm get all
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 descarga toda la información de un release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_hooks.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_hooks.md
@@ -1,5 +1,6 @@
 ---
 title: helm get hooks
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 descarga todos los hooks de un release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_manifest.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_manifest.md
@@ -1,5 +1,6 @@
 ---
 title: helm get manifest
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 descarga el manifest de un release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md
@@ -1,12 +1,9 @@
 ---
 title: helm get metadata
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 Este comando obtiene los metadatos de un release especificado
-
-### Sinopsis
-
-Este comando obtiene los metadatos de un release especificado.
 
 ```
 helm get metadata RELEASE_NAME [flags]

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_notes.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_notes.md
@@ -1,5 +1,6 @@
 ---
 title: helm get notes
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 descarga las notas de un release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_values.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_values.md
@@ -1,5 +1,6 @@
 ---
 title: helm get values
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 descarga el archivo de valores de un release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_history.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_history.md
@@ -1,5 +1,6 @@
 ---
 title: helm history
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 obtiene el historial del release

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_install.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_install.md
@@ -1,5 +1,6 @@
 ---
 title: helm install
+default_lang_commit: 0b2144b0b330eb7e45b1cb37342186114dd02f50
 ---
 
 instala un chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_lint.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_lint.md
@@ -1,5 +1,6 @@
 ---
 title: helm lint
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 examina un chart en busca de posibles problemas

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_list.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm list
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 lista los releases

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_package.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_package.md
@@ -1,5 +1,6 @@
 ---
 title: helm package
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 empaqueta un directorio de chart en un archivo de chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 instala, lista o desinstala plugins de Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_install.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_install.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin install
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 instala un plugin de Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_list.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin list
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 lista los plugins de Helm instalados

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_uninstall.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_uninstall.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin uninstall
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 desinstala uno o más plugins de Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_update.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin update
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 actualiza uno o más plugins de Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_pull.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_pull.md
@@ -1,5 +1,6 @@
 ---
 title: helm pull
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 descarga un chart de un repositorio y (opcionalmente) lo desempaqueta en un directorio local

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_push.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_push.md
@@ -1,5 +1,6 @@
 ---
 title: helm push
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 sube un chart a un registro remoto

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_registry.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_registry.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 iniciar o cerrar sesión en un registro

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_registry_login.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_registry_login.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry login
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 iniciar sesión en un registro

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_registry_logout.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_registry_logout.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry logout
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 cerrar sesión de un registro

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 añade, lista, elimina, actualiza e indexa repositorios de charts

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_add.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_add.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo add
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 añade un repositorio de charts

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_index.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_index.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo index
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 genera un archivo de índice a partir de un directorio con charts empaquetados

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_list.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo list
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 lista repositorios de charts

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_remove.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_remove.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo remove
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 elimina uno o más repositorios de charts

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_update.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_repo_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo update
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 actualiza la información local de los charts disponibles en los repositorios

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md
@@ -1,5 +1,6 @@
 ---
 title: helm rollback
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 revierte un release a una revisión anterior

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_search.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_search.md
@@ -1,5 +1,6 @@
 ---
 title: helm search
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 busca una palabra clave en charts

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_search_hub.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_search_hub.md
@@ -1,5 +1,6 @@
 ---
 title: helm search hub
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 busca charts en Artifact Hub o en su propia instancia de hub

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_search_repo.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_search_repo.md
@@ -1,5 +1,6 @@
 ---
 title: helm search repo
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 busca charts por palabra clave en los repositorios

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show.md
@@ -1,5 +1,6 @@
 ---
 title: helm show
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra información de un chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_all.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_all.md
@@ -1,5 +1,6 @@
 ---
 title: helm show all
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra toda la información del chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_chart.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_chart.md
@@ -1,5 +1,6 @@
 ---
 title: helm show chart
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra la definición del chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_crds.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_crds.md
@@ -1,5 +1,6 @@
 ---
 title: helm show crds
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra los CRDs del chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_readme.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_readme.md
@@ -1,5 +1,6 @@
 ---
 title: helm show readme
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra el README del chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_values.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_show_values.md
@@ -1,5 +1,6 @@
 ---
 title: helm show values
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra los valores del chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_status.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_status.md
@@ -1,5 +1,6 @@
 ---
 title: helm status
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra el estado del release especificado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_template.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_template.md
@@ -1,5 +1,6 @@
 ---
 title: helm template
+default_lang_commit: 0b2144b0b330eb7e45b1cb37342186114dd02f50
 ---
 
 renderiza plantillas localmente

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_test.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_test.md
@@ -1,5 +1,6 @@
 ---
 title: helm test
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 ejecuta las pruebas de un release

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_uninstall.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_uninstall.md
@@ -1,5 +1,6 @@
 ---
 title: helm uninstall
+default_lang_commit: 5882b9b38eba10f3ecb6da25566f9809baf797f0
 ---
 
 desinstala un release

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_upgrade.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: helm upgrade
+default_lang_commit: 0b2144b0b330eb7e45b1cb37342186114dd02f50
 ---
 
 actualiza un release a una nueva versión de un chart

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_verify.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_verify.md
@@ -1,5 +1,6 @@
 ---
 title: helm verify
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 verifica que un chart en la ruta dada ha sido firmado y es válido

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_version.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_version.md
@@ -1,5 +1,6 @@
 ---
 title: helm version
+default_lang_commit: 1cc11e63e3925756fe4c71921fd7c854fcf23dc5
 ---
 
 muestra la información de versión del cliente

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/howto/chart_releaser_action.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/howto/chart_releaser_action.md
@@ -2,6 +2,7 @@
 title: "Chart Releaser Action para automatizar la publicación de Charts en GitHub Pages"
 description: "Describe cómo utilizar Chart Releaser Action para automatizar la publicación de charts a través de GitHub Pages."
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Esta guía describe cómo utilizar [Chart Releaser

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
@@ -2,6 +2,7 @@
 title: "Sincronizar su Repositorio de Charts"
 description: "Describe cómo sincronizar sus repositorios de charts locales y remotos."
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 *Nota: Este ejemplo es específico para un bucket de Google Cloud Storage (GCS)

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/howto/charts_tips_and_tricks.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/howto/charts_tips_and_tricks.md
@@ -2,6 +2,7 @@
 title: "Consejos y Trucos para el Desarrollo de Charts"
 description: "Cubre algunos de los consejos y trucos que los desarrolladores de charts de Helm han aprendido al crear charts con calidad de producción."
 sidebar_position: 1
+default_lang_commit: ba552a20cbe232493e23226f44bce119adb704e1
 ---
 
 Esta guía cubre algunos de los consejos y trucos que los desarrolladores de charts

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/howto/index.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/howto/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cómo Hacer"
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 # Guías de Cómo Hacer

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/index.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/index.mdx
@@ -3,6 +3,7 @@ title: "Docs Inicio"
 description: "Todo lo que necesita saber sobre cómo está organizada la documentación."
 sidebar_position: 1
 hide_table_of_contents: true
+default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 # Bienvenidos
@@ -16,7 +17,7 @@ el [CNCF Informe de Viaje del Proyecto de Helm](https://www.cncf.io/cncf-helm-pr
 Helm tiene mucha documentación. Una descripción general de alto nivel de cómo está
 organizado lo ayudará a saber dónde buscar ciertas cosas:
 
-- [Tutoriales](/intro/index.mdx) te llevan de la mano a través de una serie de pasos para crear
+- [Tutoriales](/chart_template_guide/getting_started.md) te llevan de la mano a través de una serie de pasos para crear
   tu primer Helm chart. Empieza aquí si eres nuevo en Helm.
 - [Guías de temas](/topics/index.mdx) discute temas y
   conceptos clave a un nivel bastante alto y proporcionar información de antecedentes

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/intro/CheatSheet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/intro/CheatSheet.md
@@ -2,6 +2,7 @@
 title: Guía Rápida
 description: Guía rápida de comandos de Helm
 sidebar_position: 4
+default_lang_commit: 0b2144b0b330eb7e45b1cb37342186114dd02f50
 ---
 
 Guía rápida de Helm con todos los comandos necesarios para gestionar una aplicación a través de Helm.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/intro/index.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/intro/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Introducción"
 sidebar_position: 1
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Introducción a Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -2,6 +2,7 @@
 title: Instalar Helm
 description: Aprenda a instalar y poner Helm en funcionamiento.
 sidebar_position: 2
+default_lang_commit: 042b2178fb9384a9d4fe774f210d6db402f3da02
 ---
 
 Esta guía muestra cómo instalar Helm CLI. Helm se puede instalar desde la fuente

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
@@ -2,6 +2,7 @@
 title: Guía de inicio rápido
 description: Cómo instalar y comenzar con Helm, incluidas instrucciones para distribuciones, preguntas frecuentes y plugins.
 sidebar_position: 1
+default_lang_commit: e5a8a262fa2a2852a8f3dc0c83260363fff4dced
 ---
 
 Esta guía explica cómo empezar a utilizar Helm rápidamente.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
@@ -2,6 +2,7 @@
 title: Uso de Helm
 description: Explica los conceptos básicos de Helm.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Esta guía explica los conceptos básicos del uso de Helm para administrar paquetes

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/sdk/gosdk.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/sdk/gosdk.md
@@ -2,6 +2,7 @@
 title: Introducción
 description: Presenta el SDK de Go para Helm
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 El SDK de Go de Helm permite que software personalizado aproveche los charts de Helm y la funcionalidad de Helm para gestionar el despliegue de software en Kubernetes.
 ¡De hecho, la CLI de Helm es efectivamente una herramienta de este tipo!

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -2,6 +2,7 @@
 title: Técnicas avanzadas de Helm
 description: Explica varias características avanzadas para usuarios avanzados de Helm
 sidebar_position: 9
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Esta sección explica varias características avanzadas y técnicas para usar Helm.
@@ -48,57 +49,7 @@ type PostRenderer interface {
 Para más información sobre el uso del Go SDK, consulte la siguiente [sección Go SDK](#go-sdk).
 
 ## Go SDK
-Helm 3 debutó con un Go SDK completamente reestructurado para una mejor experiencia cuando se construye software y herramientas que aprovechan Helm. La documentación completa se puede encontrar en la [sección Go SDK](/sdk/gosdk.md), pero a continuación se ofrece una breve descripción de algunos de los paquetes más comunes y un ejemplo sencillo.
-
-### Resumen de paquetes
-Esta es una lista de los paquetes más utilizados con una explicación sencilla sobre cada uno de ellos:
-
-- `pkg/action`: Contiene el "cliente" principal para realizar acciones de Helm. Este es el mismo paquete que usa el CLI. Si solo necesita ejecutar comandos básicos de Helm desde otro programa Go, este paquete es para usted.
-- `pkg/{chart,chartutil}`:  Métodos y ayudantes usados para cargar y manipular charts.
-- `pkg/cli` y sus subpaquetes: Contiene todos los manejadores para las variables de entorno estándar de Helm y sus subpaquetes contienen el manejo de ficheros de salida y valores.
-- `pkg/release`: Define el objeto `Release` y sus estados.
-
-Obviamente hay muchos más paquetes además de estos, ¡así que revise la documentación para más información!
-
-### Ejemplo simple
-Este es un ejemplo simple para hacer un `helm list` usando el Go SDK:
-
-```go
-package main
-
-import (
-    "log"
-    "os"
-
-    "helm.sh/helm/v3/pkg/action"
-    "helm.sh/helm/v3/pkg/cli"
-)
-
-func main() {
-    settings := cli.New()
-
-    actionConfig := new(action.Configuration)
-    // You can pass an empty string instead of settings.Namespace() to list
-    // all namespaces
-    if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), log.Printf); err != nil {
-        log.Printf("%+v", err)
-        os.Exit(1)
-    }
-
-    client := action.NewList(actionConfig)
-    // Only list deployed
-    client.Deployed = true
-    results, err := client.Run()
-    if err != nil {
-        log.Printf("%+v", err)
-        os.Exit(1)
-    }
-
-    for _, rel := range results {
-        log.Printf("%+v", rel)
-    }
-}
-```
+Helm 3 debutó con un Go SDK completamente reestructurado para una mejor experiencia cuando se construye software y herramientas que aprovechan Helm. La documentación completa se puede encontrar en la [sección Go SDK](/sdk/gosdk.md).
 
 ## Backends de almacenamiento {#storage-backends}
 Helm 3 cambió el almacenamiento por defecto de la información de la release a Secrets en el namespace de la release. Helm 2 por defecto almacena la información de la release como ConfigMaps en el namespace de la instancia de Tiller. Las subsecciones siguientes muestran cómo configurar diferentes backends. Esta configuración se basa en la variable de entorno `HELM_DRIVER`. Se puede establecer a uno de los valores:

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/architecture.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/architecture.md
@@ -2,6 +2,7 @@
 title: Arquitectura Helm
 description: Describe la arquitectura de Helm a alto nivel.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 # Arquitectura de Helm

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -2,6 +2,7 @@
 title: Guía del Repositorio de Charts
 description: Cómo crear y trabajar con repositorios de charts de Helm.
 sidebar_position: 6
+default_lang_commit: 944aeaca4df514e7c5ba091995fcbbc08e505f65
 ---
 
 Esta sección explica cómo crear y trabajar con repositorios de charts de Helm.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
@@ -2,6 +2,7 @@
 title: Pruebas de Chart
 description: Describe cómo ejecutar y probar sus charts.
 sidebar_position: 3
+default_lang_commit: 81fa9227414a9c99d74705bdc159c4c21c9aac7c
 ---
 
 Un chart contiene varios recursos y componentes de Kubernetes que funcionan

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -2,6 +2,7 @@
 title: "Charts"
 description: "Explica el formato del chart y proporciona una guía básica para crear charts con Helm."
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm usa un formato de empaquetado llamado _charts_. Un chart es una colección
@@ -157,13 +158,13 @@ no compatible.
 Las restricciones de versión pueden comprender comparaciones AND separadas por
 espacios, como
 
-```text
+```
 >= 1.13.0 < 1.15.0
 ```
 
 que pueden combinarse con el operador OR `||` como en el siguiente ejemplo
 
-```text
+```
 >= 1.13.0 < 1.14.0 || >= 1.14.1 < 1.15.0
 ```
 
@@ -427,8 +428,6 @@ helm install --set tags.front-end=true --set subchart2.enabled=false
   verdadera, habilite el chart'.
 - Los valores de etiquetas y condiciones deben establecerse en los values
   del chart padre superior.
-- The `tags:` key in values must be a top level key. Globals and nested `tags:`
-  tables are not currently supported.
 - La clave `tags:` en values debe ser una clave de nivel superior. Los `tags:`
   globales y anidados no son soportados actualmente.
 
@@ -449,10 +448,6 @@ formato [hijo-padre](#usando-el-formato-padre-hijo). A continuación se describe
 ejemplos de ambos formatos.
 
 ##### Usando el formato de exportación
-
-If a child chart's `values.yaml` file contains an `exports` field at the root,
-its contents may be imported directly into the parent's values by specifying the
-keys to import as in the example below:
 
 Si el archivo `values.yaml` de un chart secundario contiene un campo de `exports`
 en la raíz, su contenido se puede importar directamente a los values del padre
@@ -497,10 +492,6 @@ final del padre. Si necesita especificar la clave principal, utilice el formato 
 Para acceder a los valores que no están contenidos en la clave `exports` del values
 del chart hijo, deberá especificar la clave de origen del values que se
 importarán (`child`) y la ruta de destino en el values del chart padre (`parent`).
-
-The `import-values` in the example below instructs Helm to take any values found
-at `child:` path and copy them to the parent's values at the path specified in
-`parent:`
 
 Los `import-values` en el siguiente ejemplo le indican a Helm que tome los valores
 encontrados en la ruta `child:` y los copie a los valores del padre en la ruta
@@ -1022,9 +1013,6 @@ renderizará el resto del chart y lo cargará en Kubernetes. Debido a este orden
 la información de CRD está disponible en el objeto `.Capabilities` en las
 plantillas de Helm, y las plantillas de Helm pueden crear nuevas instancias de
 objetos que fueron declarados en los CRD.
-
-For example, if your chart had a CRD for `CronTab` in the `crds/` directory, you
-may create instances of the `CronTab` kind in the `templates/` directory:
 
 Por ejemplo, si su chart tenía un CRD para `CronTab` en el directorio `crds/`,
 puede crear instancias del tipo `CronTab` en el directorio `templates/`:

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
@@ -2,6 +2,7 @@
 title: "Ganchos de Chart"
 description: "Describe como trabajar con ganchos de chart."
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Helm proporciona un mecanismo de _gancho_ (hook) que permite a los desarrolladores

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/index.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Temas"
 sidebar_position: 3
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Guías de Temas

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md
@@ -1,6 +1,7 @@
 ---
 title: APIs de Kubernetes Obsoletas
 description: Explica las APIs de Kubernetes obsoletas en Helm
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Kubernetes es un sistema basado en APIs y estas evolucionan con el tiempo para

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/kubernetes_distros.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/kubernetes_distros.md
@@ -2,6 +2,7 @@
 title: "Guía de distribución de Kubernetes"
 description: "Captura información sobre el uso de Helm en entornos específicos de Kubernetes"
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Helm debería funcionar con cualquier [versión conforme de Kubernetes](https://github.com/cncf/k8s-conformance) (ya sea [certificada](https://www.cncf.io/certification/software-conformance/) o no).

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/library_charts.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/library_charts.md
@@ -2,6 +2,7 @@
 title: "Charts de Biblioteca"
 description: "Explica los charts de biblioteca y ejemplos de uso."
 sidebar_position: 4
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Un chart de biblioteca es un tipo de [chart de Helm](/topics/charts.md)

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/permissions_sql_storage_backend.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/permissions_sql_storage_backend.md
@@ -1,6 +1,7 @@
 ---
 title: Gestión de permisos para el backend de almacenamiento SQL
 description: Aprenda a configurar permisos cuando utilice el backend de almacenamiento SQL.
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Este documento proporciona orientación para configurar y gestionar permisos al

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -2,6 +2,7 @@
 title: Guía de Plugins de Helm
 description: Introduce cómo usar y crear plugins para extender la funcionalidad de Helm.
 sidebar_position: 12
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Un plugin de Helm es una herramienta a la que se puede acceder a través del CLI

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/provenance.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/provenance.md
@@ -2,6 +2,7 @@
 title: "Procedencia e Integridad de Helm"
 description: "Describe cómo verificar la integridad y el origen de un Chart."
 sidebar_position: 5
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm tiene herramientas de procedencia que ayudan a los usuarios de charts a

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/rbac.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/rbac.md
@@ -2,6 +2,7 @@
 title: Control de Acceso Basado en Roles
 description: Explica cómo Helm interactúa con el Control de Acceso Basado en Roles (RBAC) de Kubernetes.
 sidebar_position: 11
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 En Kubernetes, otorgar roles a un usuario o a una cuenta de servicio específica

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/registries.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/registries.md
@@ -2,6 +2,7 @@
 title: Uso de registros basados en OCI
 description: Describe cómo usar OCI para la distribución de Charts.
 sidebar_position: 7
+default_lang_commit: 2e15490c82d246093e11e418a7c23907a4afa89e
 ---
 
 A partir de Helm 3, puede usar registros de contenedores con soporte [OCI](https://www.opencontainers.org/) para almacenar y compartir paquetes de charts. A partir de Helm v3.8.0, el soporte OCI está habilitado por defecto.

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/v2_v3_migration.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/v2_v3_migration.md
@@ -2,6 +2,7 @@
 title: Migración de Helm v2 a v3
 description: Aprenda cómo migrar de Helm v2 a v3.
 sidebar_position: 13
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Esta guía muestra cómo migrar de Helm v2 a v3. Helm v2 debe estar instalado

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
@@ -1,6 +1,7 @@
 ---
 title: "Política de Soporte de Versiones de Helm"
 description: "Describe la política de lanzamiento de parches de Helm, así como la diferencia máxima de versiones soportada entre Helm y Kubernetes."
+default_lang_commit: 838e8c053469d6f676d145efc305470a23765f0b
 ---
 
 Este documento describe la diferencia máxima de versiones soportada entre Helm y


### PR DESCRIPTION
Follow up to https://github.com/helm/helm-www/pull/2156

This PR adds the `default_lang_commit` field to the front matter of all the translated files for the `es` locale.

To test, run `npm run check:i18n-drift -- --locale es` and see `Untracked: 0`:

```
npm run check:i18n-drift -- --locale es                   

> helm-www@0.0.0 check:i18n-drift
> node scripts/check-i18n-drift.mjs --locale es

Locales checked: es
Localized Markdown files checked: 114
In sync: 67
Drifted: 47
Untracked: 0
Source missing: 0
Invalid commit: 0
```

## Summary of changes

This section explains both the drifted files, as well as a few files that I manually updated since they were so far out of date with the latest English source. All pages not listed here were already up to date with the latest english version

### Drifted (Pinned to earlier English source commits)

These files are intentionally pinned to an older source commit because the Spanish page structurally/semantically matched that older version, not the latest English source:
  - chart_best_practices/conventions.md  
  - chart_best_practices/templates.md
  - chart_template_guide/accessing_files.md
  - chart_template_guide/function_list.md
  - chart_template_guide/named_templates.md
  - faq/troubleshooting.md
  - intro/install.md
  - topics/version_skew.md
  - topics/charts_hooks.md
  - topics/library_charts.md
  - topics/plugins.md
  - helm/helm_history.md
  - helm/helm_install.md
  - helm/helm_lint.md
  - helm/helm_list.md
  - helm/helm_package.md
  - helm/helm_plugin*.md
  - helm/helm_pull.md
  - helm/helm_push.md
  - helm/helm_registry*.md
  - helm/helm_repo*.md
  - helm/helm_rollback.md
  - helm/helm_search*.md
  - helm/helm_show*.md
  - helm/helm_status.md
  - helm/helm_template.md
  - helm/helm_test.md
  - helm/helm_upgrade.md
  - helm/helm_verify.md
  - helm/helm_version.md

### Manually updated pages to match the latest English source commit

These pages were either so far out of date with the latest (it looked like they dated back 3 to 5 years to the old Hugo site), or included some sort of error that was easy to fix. There were some minor updates to make to manually bring these up-to-date with the latest English commit, which felt easier. Here are the details:
  - i18n/es/docusaurus-plugin-content-docs-community/current/release_policy.md (Updated missing release-policy bullet.)
  - i18n/es/docusaurus-plugin-content-docs/version-3/topics/advanced.md (Removed stale extra Go SDK package/example content.)
  - i18n/es/docusaurus-plugin-content-docs/version-3/topics/charts.md (Removed stale duplicate English text and aligned structure with current English and preserved Spanish explicit anchors needed by existing links.)
  - i18n/es/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md (removed a duplicate synopsis. not sure where/when it was added. maybe an ai error when we first translated these)