### PR TITLE
docs: Document helm push --oci-strict-version flag

### DIFF
--- a/docs/topics/registries.mdx
+++ b/docs/topics/registries.mdx
@@ -105,6 +105,20 @@ Users of the [helm-push plugin](https://github.com/chartmuseum/helm-push) (for u
 may experience issues, since the plugin conflicts with the new, built-in `push`.
 As of version v0.10.0, the plugin has been renamed to `cm-push`.
 
+#### Publishing non-strict-semver versions
+
+Helm accepts lenient semantic versions in a chart's `version` field, such as `v1.2.3`. By default, `helm push` uses that raw string as the OCI tag. When Helm resolves versions from a registry, however, such as during `helm pull`, it ignores any tag that is not a strict semantic version. A chart pushed with the tag `v1.2.3` is uploaded successfully, but it is silently skipped when Helm later lists the available versions.
+
+To avoid this mismatch, pass the `--oci-strict-version` flag to `helm push`. When it is set, Helm derives the OCI tag from the parsed, canonical semver representation of the chart version instead of the raw string. For example, a chart whose `version` is `v1.2.3` is pushed with the tag `1.2.3`:
+
+```console
+$ helm push mychart-v1.2.3.tgz oci://localhost:5000/helm-charts --oci-strict-version
+Pushed: localhost:5000/helm-charts/mychart:1.2.3
+Digest: sha256:ec5f08ee7be8b557cd1fc5ae1a0ac985e8538da7c93f51a51eff4b277509a723
+```
+
+The flag is opt-in and disabled by default, so existing workflows are unaffected. It applies only to OCI (`oci://`) pushes, and the push fails if the chart version cannot be parsed as a semantic version.
+
 ### Other subcommands
 
 Support for the `oci://` protocol is also available in various other subcommands.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/f19518ea-f1ea-465e-bf52-396dcfc3e270)

Adds a "Publishing non-strict-semver versions" subsection to the OCI-based registries topic. It explains the new `--oci-strict-version` flag on `helm push`, which derives the OCI tag from the canonical strict-semver representation of the chart version (e.g. `v1.2.3` → `1.2.3`) so pushed tags round-trip through `helm pull`. Based on helm/helm#32349 (open, unmerged).

**Trigger Events**
- [helm/helm PR #32349: feat(push): Add --oci-strict-version flag](https://github.com/helm/helm/pull/32349)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_