### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:cncf-helm-security@lists.cncf.io
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://helm.sh/.well-known/security.txt
+Policy: https://github.com/helm/community/blob/main/SECURITY.md


### PR DESCRIPTION
## What
Add `/.well-known/security.txt` under `static/` so helm.sh serves one.

## Why
`https://helm.sh/.well-known/security.txt` currently returns 404. [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) makes `/.well-known/security.txt` the standard, machine-discoverable place a researcher looks first to find how to report a security issue. Helm already publishes a reporting channel (the `cncf-helm-security@lists.cncf.io` list, per the community SECURITY.md); this just makes it discoverable by the RFC convention. The file is served verbatim from `static/` and carries a future `Expires` per §2.5.5. Signed off per DCO.

I used AI assistance to identify this and draft the file; I verified the live 404 and the reporting channel myself.