### PR TITLE
docs: Document SOURCE_DATE_EPOCH for reproducible chart archives

### DIFF
--- a/docs/howto/charts_tips_and_tricks.md
+++ b/docs/howto/charts_tips_and_tricks.md
@@ -309,3 +309,45 @@ existing release will be upgraded.
 ```console
 $ helm upgrade --install <release name> --values <values file> <chart directory>
 ```
+
+## Build Reproducible Chart Archives
+
+By default, the files inside a packaged chart archive (`.tgz`)
+carry the modification times of the source files on disk.
+As a result, repackaging the same chart produces archives that differ from one build to the next.
+To make chart archives reproducible,
+Helm honors the `SOURCE_DATE_EPOCH` environment variable defined by the
+[Reproducible Builds](https://reproducible-builds.org/docs/source-date-epoch/) project.
+When you set it,
+Helm stamps every file in the archive with the modification time you provide
+instead of the build time.
+
+Set `SOURCE_DATE_EPOCH` to a Unix timestamp,
+the number of whole seconds since 1970-01-01 in UTC,
+and run `helm package`:
+
+```console
+$ SOURCE_DATE_EPOCH=1609459200 helm package ./mychart
+```
+
+Helm stamps every file in the resulting archive with 2021-01-01T00:00:00Z,
+so packaging the same source again produces the same timestamps.
+To track your source history,
+derive the timestamp from your last commit:
+
+```console
+$ SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) helm package ./mychart
+```
+
+Keep the following in mind when you use `SOURCE_DATE_EPOCH`:
+
+- The value must be a non-negative integer.
+  Helm interprets it as whole seconds in UTC and does not support sub-second precision.
+  A non-numeric or negative value fails the command with an `invalid SOURCE_DATE_EPOCH` error.
+- When the variable is unset or empty,
+  Helm keeps the default behavior,
+  where archive entries reflect the actual file modification times.
+- `helm install`, `helm upgrade`, `helm dependency build`, and `helm dependency update`
+  also honor `SOURCE_DATE_EPOCH`,
+  but only when they re-archive a dependency sourced from a local `file://` repository.
+  Helm stores remotely downloaded dependencies as it fetched them.

--- a/docs/howto/charts_tips_and_tricks.md
+++ b/docs/howto/charts_tips_and_tricks.md
@@ -347,6 +347,12 @@ Keep the following in mind when you use `SOURCE_DATE_EPOCH`:
 - When the variable is unset or empty,
   Helm keeps the default behavior,
   where archive entries reflect the actual file modification times.
+- When you package a chart that contains a `Chart.lock` file,
+  Helm also stamps that file's `generated:` timestamp with the `SOURCE_DATE_EPOCH` value,
+  normalized to UTC and whole seconds.
+  As a result, charts that declare dependencies produce byte-identical archives across builds and machines
+  when you use the same `SOURCE_DATE_EPOCH`,
+  because the `Chart.lock` content matches, not just the file modification times.
 - `helm install`, `helm upgrade`, `helm dependency build`, and `helm dependency update`
   also honor `SOURCE_DATE_EPOCH`,
   but only when they re-archive a dependency sourced from a local `file://` repository.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/9ffcb32b-9f96-4517-acb5-a40b91f3b68b)

Adds a "Build Reproducible Chart Archives" section to the Chart Development Tips and Tricks how-to, documenting how `SOURCE_DATE_EPOCH` stamps archive file modification times via `helm package`, its value semantics (non-negative integer seconds, UTC, error on invalid/negative), and the limited scope for install/upgrade/dependency commands. Covers helm/helm#32162.

**Trigger Events**
- [helm/helm PR #32162: feat: honor SOURCE_DATE_EPOCH for chart archives](https://github.com/helm/helm/pull/32162)

---

_Tip: Filter the [Dashboard](https://app.gopromptless.ai) by labels or assignees to focus on what matters to you 🔎_