### PR TITLE
docs: Clarify how alias interacts with dependency conditions and tags

### DIFF
--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -339,6 +339,25 @@ new-subchart-2
 The manual way of achieving this is by copy/pasting the same chart in the
 `charts/` directory multiple times with different names.
 
+When a dependency uses an `alias`, the alias becomes the dependency's name for
+the purposes of `condition` evaluation. The `condition` path and any enabling
+values in the top parent's values must therefore be keyed by the alias name
+rather than the original chart name. For example, with the `new-subchart-1`
+alias above you would use `condition: new-subchart-1.enabled` in `Chart.yaml`
+and set the value in the top parent's values:
+
+```yaml
+# parentchart/values.yaml
+new-subchart-1:
+  enabled: true
+```
+
+For a chart reached through an aliased dependency chain, the values path
+accumulates the alias name at each level (for example,
+`outer-alias.inner-alias.enabled`). Tags are not affected by an alias: they are
+matched by the labels listed in the dependency's `tags` field, not by the chart
+or alias name.
+
 #### Tags and Condition fields in dependencies
 
 In addition to the other fields above, each requirements entry may contain the
@@ -414,6 +433,9 @@ helm install --set tags.front-end=true --set subchart2.enabled=false
 - Tags and conditions values must be set in the top parent's values.
 - The `tags:` key in values must be a top level key. Globals and nested `tags:`
   tables are not currently supported.
+- When a dependency uses an `alias`, its `condition` path is keyed by the alias
+  name rather than the original chart name. Tags are not affected by aliasing;
+  they are matched by the labels in the dependency's `tags` field.
 
 #### Importing Child Values via dependencies
 

--- a/versioned_docs/version-3/topics/charts.md
+++ b/versioned_docs/version-3/topics/charts.md
@@ -335,6 +335,25 @@ new-subchart-2
 The manual way of achieving this is by copy/pasting the same chart in the
 `charts/` directory multiple times with different names.
 
+When a dependency uses an `alias`, the alias becomes the dependency's name for
+the purposes of `condition` evaluation. The `condition` path and any enabling
+values in the top parent's values must therefore be keyed by the alias name
+rather than the original chart name. For example, with the `new-subchart-1`
+alias above you would use `condition: new-subchart-1.enabled` in `Chart.yaml`
+and set the value in the top parent's values:
+
+```yaml
+# parentchart/values.yaml
+new-subchart-1:
+  enabled: true
+```
+
+For a chart reached through an aliased dependency chain, the values path
+accumulates the alias name at each level (for example,
+`outer-alias.inner-alias.enabled`). Tags are not affected by an alias: they are
+matched by the labels listed in the dependency's `tags` field, not by the chart
+or alias name.
+
 #### Tags and Condition fields in dependencies
 
 In addition to the other fields above, each requirements entry may contain the
@@ -410,6 +429,9 @@ helm install --set tags.front-end=true --set subchart2.enabled=false
 - Tags and conditions values must be set in the top parent's values.
 - The `tags:` key in values must be a top level key. Globals and nested `tags:`
   tables are not currently supported.
+- When a dependency uses an `alias`, its `condition` path is keyed by the alias
+  name rather than the original chart name. Tags are not affected by aliasing;
+  they are matched by the labels in the dependency's `tags` field.
 
 #### Importing Child Values via dependencies
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/6f41f785-731f-4a6c-ba36-933820344727)

Documents the interaction between a dependency `alias` and the `condition`/`tags` fields in the chart dependencies guide. Adds a note to the "Alias field in dependencies" section and a bullet to the "Tags and Condition Resolution" list explaining that when a dependency uses an alias, its `condition` path and enabling values in the top parent's values must be keyed by the alias name (not the original chart name); that a chart reached through an aliased dependency chain accumulates the alias name at each level of the values path; and that `tags` are matched by their declared labels and are unaffected by aliasing. Applied identically to `docs/topics/charts.mdx` (v4/next) and `versioned_docs/version-3/topics/charts.md` (released v3). Claims verified against helm/helm dependency-processing source.

**Trigger Events**
- [helm/helm PR #31847: fix(pkg): respect subchart conditions when dependency uses an alias](https://github.com/helm/helm/pull/31847)

---

_Tip: Enable auto-create PR in your [Configuration](https://app.gopromptless.ai/configuration) to review suggestions directly in GitHub 🤖_