### PR TITLE
docs: Document symbolic link handling for OCI plugin installs

### DIFF
--- a/docs/plugins/user/index.md
+++ b/docs/plugins/user/index.md
@@ -35,6 +35,19 @@ Helm has a built-in command to install plugins that defaults to secure installat
 
 See `helm plugin install --help` for more information.
 
+### Symbolic Links in OCI Plugins
+
+When you install a plugin from an OCI registry with `helm plugin install oci://<registry>/<plugin>`, the plugin archive may contain symbolic links. Helm extracts these links subject to security validation (see [Plugin Security](#plugin-security)), which keeps a plugin from writing files outside its own installation directory:
+
+- Symbolic-link targets must be relative; absolute targets are rejected.
+- Symbolic-link targets must resolve inside the plugin's installation directory; targets that would escape the plugin directory are rejected.
+
+If a symbolic link fails these checks, the installation fails as a whole. A rejected symbolic link means the plugin archive is malformed or potentially unsafe, so obtain the plugin from a trusted source or contact its author.
+
+On Windows, creating symbolic links requires elevated privileges. Run your terminal as Administrator or [enable Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development); otherwise, installation fails.
+
+For more on OCI registries, see [OCI Registries](/topics/registries.mdx).
+
 ## Listing Installed Plugins
 
 The command to list plugins includes the plugin's name, version, type, API version, provenance, and source.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/3f302dd4-cb74-46b4-b094-5551a293ce51)

Adds a "Symbolic Links in OCI Plugins" subsection to the Plugins User Guide (`docs/plugins/user/index.md`), under "Installing Plugins".

Documents the symlink extraction security behavior added in helm/helm PR #32387 ("fix(plugins): secure symbolic link extraction and path validation in OCI plugins"): OCI plugin archives installed via `helm plugin install oci://...` may now contain symbolic links, which Helm extracts subject to validation — targets must be relative and must resolve inside the plugin's installation directory, or the install fails. Also documents that creating symlinks on Windows requires running the terminal as Administrator or enabling Developer Mode.

Written at the design-intent level (no exact error strings or path-traversal examples) because the source PR is open and unmerged. Single file changed; internal links to Plugin Security and OCI Registries verified.

**Trigger Events**
- [helm/helm PR #32387: fix(plugins): secure symbolic link extraction and path validation in …](https://github.com/helm/helm/pull/32387)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_