### PR TITLE
Document helm lint warning for unresolved dependency conditions

### DIFF
--- a/docs/topics/charts.mdx
+++ b/docs/topics/charts.mdx
@@ -397,6 +397,32 @@ Since `subchart2` is tagged with `back-end` and that tag evaluates to `true`,
 specified, there is no corresponding path and value in the parent's values so
 that condition has no effect.
 
+##### Validating Conditions with `helm lint`
+
+[helm lint](/helm/helm_lint.md) flags dependency conditions that do not resolve
+to a value, warning you about the "no effect" case described above. It resolves
+each condition against the chart's coalesced values. These combine the chart's
+own `values.yaml`, the default values of the subcharts vendored in `charts/`, and
+any overrides you pass to `helm lint` with `-f` or `--set`. Because a condition
+can list several comma-separated paths, `helm lint` treats the condition as
+resolved if any one of those paths resolves to a value. In the example above,
+`subchart2`'s condition (`subchart2.enabled,global.subchart2.enabled`) has no
+matching value, so `helm lint` flags it. To resolve or silence the warning,
+define one of the condition keys in `values.yaml` (or in a subchart's defaults),
+or lint with your actual install values, as shown below.
+
+For example, `helm lint` reports:
+
+```text
+[WARNING] parentchart: conditions of these dependencies do not resolve to a value and have no effect: subchart2 (condition "subchart2.enabled,global.subchart2.enabled")
+```
+
+You can silence it by linting with the values you install with:
+
+```console
+$ helm lint --set subchart2.enabled=false
+```
+
 ##### Using the CLI with Tags and Conditions
 
 The `--set` parameter can be used as usual to alter tag and condition values.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/80f6bcf6-faa3-481d-9ab9-245fe9325cc2)

The chart dependencies guide already notes that a dependency `condition` which resolves to no value "has no effect," but until now that case was silent at build time. helm/helm#32472 adds a `helm lint` warning that surfaces it.

This adds a short "Validating Conditions with `helm lint`" subsection to the "Tags and Condition fields in dependencies" section of `docs/topics/charts.mdx`. It explains that `helm lint` flags a dependency condition that does not resolve to a value, how conditions are resolved (against the chart's coalesced values — its own `values.yaml`, vendored subchart defaults, and any `-f`/`--set` overrides passed to `helm lint`, with first-match semantics across comma-separated paths), and how to resolve or silence the warning. It reuses the section's existing `subchart2` example and includes an example warning message.

Files touched: `docs/topics/charts.mdx`.

**Trigger Events**
- [helm/helm PR #32472: feat(lint): warn when dependency conditions do not resolve to a value](https://github.com/helm/helm/pull/32472)
