### PR TITLE
fix(deps): bump js-yaml and ws to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node": ">=20.0"
   },
   "resolutions": {
-    "gray-matter/js-yaml": "3.14.2",
+    "gray-matter/js-yaml": "3.15.0",
     "serialize-javascript": ">=7.0.5",
     "path-to-regexp": "0.1.13",
     "minimatch": ">=3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6451,10 +6451,10 @@ joi@^17.9.2:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.14.2, js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+js-yaml@3.15.0, js-yaml@^3.13.1:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -10417,14 +10417,14 @@ write-file-atomic@^3.0.3:
     typedarray-to-buffer "^3.1.5"
 
 ws@^7.3.1:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+  version "7.5.11"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 ws@^8.18.0, ws@^8.18.3:
-  version "8.18.3"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+  version "8.21.1"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 wsl-utils@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## What

Resolves open Dependabot security advisories reported against `yarn.lock`.

| Package | Change | Advisory |
|---|---|---|
| `js-yaml` (via `gray-matter/js-yaml` resolution) | `3.14.2` → `3.15.0` | Quadratic-complexity DoS via YAML merge-key chains / repeated aliases (patched in 3.15.0) |
| `ws` (`^7.3.1`, webpack-bundle-analyzer) | `7.5.10` → `7.5.11` | Memory-exhaustion DoS from tiny fragments/data chunks |
| `ws` (`^8.18.x`, webpack-dev-server) | `8.18.3` → `8.21.1` | Memory-exhaustion DoS + uninitialized memory disclosure (patched by 8.20.1 / 8.21.0) |

All bumps stay **within the existing semver ranges** — only the `gray-matter/js-yaml` pin in `resolutions` was edited; the `ws` changes are transitive re-resolutions.

## Testing

- `yarn install --frozen-lockfile` ✅
- `yarn build` ✅ (only a pre-existing unrelated broken-anchor warning)

## Not addressed here

The remaining `uuid` advisory (`uuid@^8.3.2`) is pulled **only** by `sockjs`, a dev-only `webpack-dev-server` transitive dependency. The patched release is `11.1.1` — a 3-major jump outside the requested range that would require a global `resolutions` override and break sockjs's CommonJS `require('uuid')` usage. The flagged issue affects `v3`/`v5`/`v6` buffer handling, which is not reachable through sockjs's `v4`-only usage. Left as-is to avoid breaking the dev server; can be revisited when `webpack-dev-server`/`sockjs` update upstream.