### PR TITLE
Document FieldValidationDirective on the SDK Upgrade action

### DIFF
--- a/docs/sdk/examples.mdx
+++ b/docs/sdk/examples.mdx
@@ -34,6 +34,12 @@ This example upgrades the given release, with the given chart, version and value
 
 <CodeBlock language="go" title="sdkexamples/upgrade.go" showLineNumbers>{UpgradeExampleGo}</CodeBlock>
 
+`action.Upgrade` exposes an optional `FieldValidationDirective` field.
+It takes effect only when you set `ForceReplace` to `true` and set the field to a non-empty value.
+If you leave the field empty in that case, Helm keeps the default `Strict` validation.
+Valid values are the `kube.FieldValidationDirective` constants: `kube.FieldValidationDirectiveIgnore`, `kube.FieldValidationDirectiveWarn`, and `kube.FieldValidationDirectiveStrict`.
+Setting `kube.FieldValidationDirectiveWarn` makes a forced upgrade warn on unknown or deprecated fields instead of failing, which matches Helm 3 behavior.
+
 ### Uninstall Action
 
 This example uninstalls the given release:

--- a/sdkexamples/upgrade.go
+++ b/sdkexamples/upgrade.go
@@ -26,6 +26,12 @@ func runUpgrade(ctx context.Context, logger *log.Logger, settings *cli.EnvSettin
 	upgradeClient.Version = chartVersion
 	upgradeClient.WaitStrategy = "watcher"
 
+	// During a force-replace upgrade (ForceReplace = true), Helm 4 defaults to Strict field validation.
+	// Setting FieldValidationDirective overrides that default.
+	// Use kube.FieldValidationDirectiveWarn to warn on unknown or deprecated fields instead of failing, matching Helm 3 behavior.
+	// upgradeClient.ForceReplace = true
+	// upgradeClient.FieldValidationDirective = kube.FieldValidationDirectiveWarn
+
 	registryClient, err := newRegistryClient(
 		settings,
 		upgradeClient.CertFile,


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](<https://app.gopromptless.ai/suggestions/93e7f407-2c53-4517-8fe4-2d48686c5096>)

Documents the optional `FieldValidationDirective` field added to the `action.Upgrade` Go SDK struct in helm/helm PR #32477.

In Helm 4, a force-replace upgrade (`ForceReplace = true`) applies `Strict` field validation to the underlying Kubernetes replace request, so forced upgrades of charts with minor schema discrepancies fail where Helm 3 only warned. The new field lets Go SDK consumers override that directive — for example, setting `kube.FieldValidationDirectiveWarn` restores Helm 3's warn-only behavior. When the field is left empty, Helm keeps the default `Strict` validation, so existing SDK integrations are unaffected.

The change adds a prose note to the Go SDK "Upgrade Action" example on the SDK Examples page and a matching commented example in the runnable `sdkexamples/upgrade.go` driver. This is a Go SDK-only addition; no CLI flag was introduced, so the auto-generated CLI reference is unchanged.

**Trigger Events**
- [helm/helm PR #32477: feat(action): expose FieldValidationDirective on Upgrade action](https://github.com/helm/helm/pull/32477)
