### PR TITLE
fix(deps): bump uuid to 14.0.1 to patch CVE-2026-41907

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "serialize-javascript": ">=7.0.5",
     "path-to-regexp": "0.1.13",
     "minimatch": ">=3.1.3",
-    "browserslist": "^4.28.1"
+    "browserslist": "^4.28.1",
+    "uuid": "14.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10101,10 +10101,10 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@14.0.1, uuid@^8.3.2:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
+  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What

Adds a `resolutions` override pinning `uuid` to `14.0.1`.

## Why

The `uuid` package is pulled in transitively (`@docusaurus/core` → `webpack-dev-server` → `sockjs` → `uuid@^8.3.2`) and was resolving to `8.3.2`, which is affected by:

- **GHSA-w5hq-g745-h8pq** / **CVE-2026-41907** (medium): the `v3()`, `v5()`, and `v6()` API methods perform a **silent out-of-bounds write** when given a too-small `buf` or too-large `offset`, instead of throwing `RangeError` like `v4()`/`v1()`/`v7()` do.

Since `sockjs` requests `^8.3.2` (which can't reach the patched `11.1.1`+), a `resolutions` entry is used to force the patched version. `14.0.1` is the current latest and is outside all vulnerable ranges. Per the repo's guidance to pin security-critical deps to exact versions, it is pinned exactly.

## Testing

- `yarn install` — resolves `uuid` to `14.0.1` (`yarn why uuid` confirms sockjs now uses it)
- `yarn build --locale en` — builds successfully

Fixes Dependabot alert #93.