### PR TITLE
docs: explain --take-ownership for install and upgrade

### DIFF
--- a/docs/topics/advanced.mdx
+++ b/docs/topics/advanced.mdx
@@ -107,6 +107,31 @@ type PostRenderer interface {
 
 For more information on using the Go SDK, See the [Go SDK section](#go-sdk)
 
+## Taking ownership of existing resources
+
+By default, Helm refuses to install or upgrade a chart if a target resource already exists in the cluster and is not already owned by the release. Ownership is tracked with Helm-managed annotations (and related labels such as `app.kubernetes.io/managed-by`). That check protects you from clobbering objects that another tool or release created.
+
+Use `--take-ownership` on `helm install` or `helm upgrade` when you intentionally want Helm to adopt those existing objects into the release:
+
+```shell
+helm install my-release ./mychart --take-ownership
+helm upgrade my-release ./mychart --take-ownership
+```
+
+With the flag set, Helm skips the "resource already exists and is not owned by this release" failure, adopts the live objects, and applies the chart's desired state. Subsequent upgrades and uninstalls then treat those objects as part of the release.
+
+### When to use it
+
+- Migrating a manually applied manifest (or another deployer) to a Helm chart without deleting the live resources first
+- Recovering after annotations were removed or a release history was lost, so Helm no longer recognizes its own objects
+- Aligning a chart with cluster objects that already match the desired names/kinds
+
+### Caveats
+
+- Adoption does **not** delete extra fields that were never in the chart. Three-way strategic merge (or server-side apply, if you use it) still controls how live and chart values are combined.
+- Taking ownership of the wrong objects can surprise other operators that still expect to manage them. Prefer matching names carefully and reviewing the dry-run output first (`--dry-run`).
+- `--take-ownership` is also accepted by `helm template` for flag parity; it does not contact the cluster.
+
 ## Go SDK
 Helm 3 debuted a completely restructured Go SDK for a better experience when
 building software and tools that leverage Helm. Full documentation can be found

--- a/docs/topics/advanced.mdx
+++ b/docs/topics/advanced.mdx
@@ -107,9 +107,13 @@ type PostRenderer interface {
 
 For more information on using the Go SDK, See the [Go SDK section](#go-sdk)
 
-## Taking ownership of existing resources
+## Allow Helm to take ownership of existing resources
 
-By default, Helm refuses to install or upgrade a chart if a target resource already exists in the cluster and is not already owned by the release. Ownership is tracked with Helm-managed annotations (and related labels such as `app.kubernetes.io/managed-by`). That check protects you from clobbering objects that another tool or release created.
+By default, Helm refuses to install or upgrade a chart if a resource that is not owned by the release already exists in the cluster.
+In this case, Helm would display the following error: "resource already exists and is not owned by this release".
+
+Helm tracks resource ownership in the cluster with both Helm-managed annotations and related labels such as `app.kubernetes.io/managed-by`.
+This ownership validation process protects you from unintentionally overwriting objects that another tool or release had created.
 
 Use `--take-ownership` on `helm install` or `helm upgrade` when you intentionally want Helm to adopt those existing objects into the release:
 
@@ -118,18 +122,21 @@ helm install my-release ./mychart --take-ownership
 helm upgrade my-release ./mychart --take-ownership
 ```
 
-With the flag set, Helm skips the "resource already exists and is not owned by this release" failure, adopts the live objects, and applies the chart's desired state. Subsequent upgrades and uninstalls then treat those objects as part of the release.
+With the flag set, Helm ignores the resource ownership checks and adopts the existing objects into the release.
+Subsequent upgrades and uninstalls then treat those objects as part of the release.
 
 ### When to use it
+
+Common use cases for the `--take-ownership` flag include:
 
 - Migrating a manually applied manifest (or another deployer) to a Helm chart without deleting the live resources first
 - Recovering after annotations were removed or a release history was lost, so Helm no longer recognizes its own objects
 - Aligning a chart with cluster objects that already match the desired names/kinds
 
-### Caveats
+### Limitations and best practices
 
-- Adoption does **not** delete extra fields that were never in the chart. Three-way strategic merge (or server-side apply, if you use it) still controls how live and chart values are combined.
-- Taking ownership of the wrong objects can surprise other operators that still expect to manage them. Prefer matching names carefully and reviewing the dry-run output first (`--dry-run`).
+- Taking ownership doesn't delete extra fields that were never in the chart. Three-way strategic merge (or server-side apply, if you use it) still controls how live and chart values are combined.
+- To avoid taking ownership of objects that Helm shouldn't manage, match names carefully and review the dry-run output first (`--dry-run`).
 - `--take-ownership` is also accepted by `helm template` for flag parity; it does not contact the cluster.
 
 ## Go SDK

--- a/versioned_docs/version-3/topics/advanced.md
+++ b/versioned_docs/version-3/topics/advanced.md
@@ -79,6 +79,38 @@ type PostRenderer interface {
 
 For more information on using the Go SDK, See the [Go SDK section](#go-sdk)
 
+## Allow Helm to take ownership of existing resources
+
+By default, Helm refuses to install or upgrade a chart if a resource that is not owned by the release already exists in the cluster.
+In this case, Helm would display the following error: "resource already exists and is not owned by this release".
+
+Helm tracks resource ownership in the cluster with both Helm-managed annotations and related labels such as `app.kubernetes.io/managed-by`.
+This ownership validation process protects you from unintentionally overwriting objects that another tool or release had created.
+
+Use `--take-ownership` on `helm install` or `helm upgrade` when you intentionally want Helm to adopt those existing objects into the release:
+
+```shell
+helm install my-release ./mychart --take-ownership
+helm upgrade my-release ./mychart --take-ownership
+```
+
+With the flag set, Helm ignores the resource ownership checks and adopts the existing objects into the release.
+Subsequent upgrades and uninstalls then treat those objects as part of the release.
+
+### When to use it
+
+Common use cases for the `--take-ownership` flag include:
+
+- Migrating a manually applied manifest (or another deployer) to a Helm chart without deleting the live resources first
+- Recovering after annotations were removed or a release history was lost, so Helm no longer recognizes its own objects
+- Aligning a chart with cluster objects that already match the desired names/kinds
+
+### Limitations and best practices
+
+- Taking ownership doesn't delete extra fields that were never in the chart. Three-way strategic merge (or server-side apply, if you use it) still controls how live and chart values are combined.
+- To avoid taking ownership of objects that Helm shouldn't manage, match names carefully and review the dry-run output first (`--dry-run`).
+- `--take-ownership` is also accepted by `helm template` for flag parity; it does not contact the cluster.
+
 ## Go SDK
 Helm 3 debuted a completely restructured Go SDK for a better experience when
 building software and tools that leverage Helm. Full documentation can be found


### PR DESCRIPTION
The flag is on install/upgrade but the only real description was the auto-generated help line.

Added a short Advanced section covering what ownership means, a couple of example commands, when it is useful, and the main gotchas.

Fixes #2157