### PR TITLE
docs: warn about YAML injection in chart templates

### DIFF
--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -374,7 +374,10 @@ the rendered YAML. This is called _YAML injection_.
 YAML injection can not only break installs, but can
 also inject extra keys into a Kubernetes manifest.
 
-Prefer helpers that encode or structure the data for you:
+### Best practices
+
+To avoid YAML injection when inserting Helm values,
+prefer helpers that encode or structure the data for you, as shown in the following table:
 
 | Goal | Prefer | Avoid |
 | ---- | ------ | ----- |
@@ -383,7 +386,16 @@ Prefer helpers that encode or structure the data for you:
 | Embed maps / lists | `{{ toYaml .Values.extraEnv \| nindent 8 }}`. `nindent` only adds indentation; it doesn't encode YAML. Pair it with `toYaml` for maps/lists, or use `quote` for a single scalar. Bare `nindent` on an untrusted string is still injectable. | `{{ .Values.extraEnv \| nindent 8 }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
 | Labels / annotations maps | `toYaml` + `nindent` (or chart helpers) | Concatenating free-form label lines from values |
 
-Example — safe nested object (map → YAML, then indent):
+The following describes general best practices for preventing YAML injection when inserting values:
+
+- Treat every `{{ ... }}` expression that is rendered inside YAML as untrusted input.
+- Use `quote`, `toYaml`, and `nindent`/`indent` together to preserve YAML structure. Avoid manually constructing YAML using string concatenation.
+- Run `helm template` and schema validation in CI so malformed values fail
+  before they reach the cluster.
+
+### Examples
+
+#### Safe nested object (map to YAML, then indent)
 
 ```yaml
 apiVersion: v1
@@ -396,7 +408,7 @@ data:
 {{- toYaml .Values.config | nindent 4 }}
 ```
 
-Example — unsafe patterns:
+#### Unsafe patterns
 
 ```yaml
 # BAD: a value of "x\n  evil: true" becomes an extra key
@@ -408,14 +420,6 @@ data:
   app.conf: |
 {{ .Values.appConf | nindent 4 }}
 ```
-
-When in doubt:
-
-1. Treat every `{{ ... }}` that lands inside YAML structure as untrusted input.
-2. Use `quote`, `toYaml`, and `nindent`/`indent` together rather than string
-   concatenation.
-3. Run `helm template` (and schema validation) in CI so malformed values fail
-   before they reach the cluster.
 
 For more information, see [Template Functions and Pipelines](functions_and_pipelines.mdx),
 [Indenting and Templates](#indenting-and-templates) on this page, and the

--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -382,9 +382,8 @@ prefer helpers that encode or structure the data for you, as shown in the follow
 | Goal | Prefer | Avoid |
 | ---- | ------ | ----- |
 | Quote a string scalar | `{{ .Values.name \| quote }}` | `{{ .Values.name }}` in a bare field |
-| Multi-line free-form string | Store structured data as a map/list and use `toYaml`, or treat the whole value as one quoted scalar with `quote` | `{{ .Values.config \| nindent 4 }}` — `nindent` only indents; newline-bearing values can still inject keys |
-| Embed maps / lists | `{{ toYaml .Values.extraEnv \| nindent 8 }}`. `nindent` only adds indentation; it doesn't encode YAML. Pair it with `toYaml` for maps/lists, or use `quote` for a single scalar. Bare `nindent` on an untrusted string is still injectable. | `{{ .Values.extraEnv \| nindent 8 }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
-| Labels / annotations maps | `toYaml` + `nindent` (or chart helpers) | Concatenating free-form label lines from values |
+| Insert a string as one YAML scalar | `quote`, or a block scalar header (`\|` / `>`) plus `{{- .Values.config \| nindent N }}` where `N` is greater than the parent indent (usually parent + 2) | Bare `{{ .Values.config }}` or `nindent` without a block header — a newline in the value can start a new key |
+| Embed maps / lists (collections) | `{{ toYaml .Values.extraEnv \| nindent N }}` so `toYaml` emits the collection and `nindent` only shifts it | `{{ .Values.extraEnv \| nindent N }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
 
 The following describes general best practices for preventing YAML injection when inserting values:
 
@@ -401,11 +400,20 @@ The following describes general best practices for preventing YAML injection whe
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "mychart.fullname" . }}
+  name: {{ include "mychart.fullname" . | quote }}
 data:
   # values.config is a map; toYaml emits nested YAML, nindent only indents it
   config.yaml: |
-{{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml .Values.config | nindent 4 }}
+```
+
+A string under a block scalar is the same idea — keep the `{{-` so you do
+not get an extra blank line, and pick `N` larger than the parent indent:
+
+```yaml
+data:
+  app.conf: |
+    {{- .Values.appConf | nindent 4 }}
 ```
 
 #### Unsafe patterns
@@ -415,10 +423,9 @@ data:
 data:
   app.conf: {{ .Values.appConf }}
 
-# BAD: nindent alone still injects — it only adds spaces
+# BAD: nindent without a block scalar header only adds spaces
 data:
-  app.conf: |
-{{ .Values.appConf | nindent 4 }}
+  app.conf: {{ .Values.appConf | nindent 4 }}
 ```
 
 For more information, see [Template Functions and Pipelines](functions_and_pipelines.mdx),

--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -9,6 +9,10 @@ we'll look at the YAML format. YAML has some useful features that we, as
 template authors, can use to make our templates less error prone and easier to
 read.
 
+When you embed chart values into manifests, also read
+[Safe embedding of values (YAML injection)](#safe-embedding-of-values-yaml-injection)
+so user-supplied strings cannot reshape the document.
+
 ## Scalars and Collections
 
 According to the [YAML spec](https://yaml.org/spec/1.2/spec.html), there are two
@@ -360,3 +364,62 @@ use [library charts](/topics/library_charts.md) instead of YAML anchors.
 Library charts are designed for reuse,
 and aren't subject to the round-trip pitfall described above.
 :::
+
+## Safe embedding of values (YAML injection)
+
+Chart values often come from untrusted or multi-tenant sources. If you splice a
+value into a template with raw `{{ .Values.foo }}`, a value that contains
+newlines, `:` mapping indicators, or list markers can change the structure of
+the rendered YAML (YAML injection). That can break installs—or worse, inject
+extra keys into a Kubernetes manifest.
+
+Prefer helpers that encode or structure the data for you:
+
+| Goal | Prefer | Avoid |
+| ---- | ------ | ----- |
+| Quote a string scalar | `{{ .Values.name | quote }}` | `{{ .Values.name }}` in a bare field |
+| Multi-line free-form string | Store structured data as a map/list and use `toYaml`, or treat the whole value as one quoted scalar with `quote` | `{{ .Values.config | nindent 4 }}` — `nindent` only indents; newline-bearing values can still inject keys |
+| Embed maps / lists | `{{ toYaml .Values.extraEnv | nindent 8 }}` | `{{ .Values.extraEnv | nindent 8 }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
+| Labels / annotations maps | `toYaml` + `nindent` (or chart helpers) | Concatenating free-form label lines from values |
+
+`nindent` only adds indentation; it does **not** encode YAML. Pair it with `toYaml`
+for maps/lists, or use `quote` for a single scalar. Bare `nindent` on an
+untrusted string is still injectable.
+
+Example — safe nested object (map → YAML, then indent):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mychart.fullname" . }}
+data:
+  # values.config is a map; toYaml emits nested YAML, nindent only indents it
+  config.yaml: |
+{{- toYaml .Values.config | nindent 4 }}
+```
+
+Example — unsafe patterns:
+
+```yaml
+# BAD: a value of "x\n  evil: true" becomes an extra key
+data:
+  app.conf: {{ .Values.appConf }}
+
+# BAD: nindent alone still injects — it only adds spaces
+data:
+  app.conf: |
+{{ .Values.appConf | nindent 4 }}
+```
+
+When in doubt:
+
+1. Treat every `{{ ... }}` that lands inside YAML structure as untrusted input.
+2. Use `quote`, `toYaml`, and `nindent`/`indent` together rather than string
+   concatenation.
+3. Run `helm template` (and schema validation) in CI so malformed values fail
+   before they reach the cluster.
+
+See also [Functions and Pipelines](functions_and_pipelines.mdx),
+[Indenting and Templates](#indenting-and-templates), and the
+[function list](function_list.mdx) (`toYaml`, `quote`, `nindent`).

--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -9,8 +9,8 @@ we'll look at the YAML format. YAML has some useful features that we, as
 template authors, can use to make our templates less error prone and easier to
 read.
 
-When you embed chart values into manifests, also read
-[Safe embedding of values (YAML injection)](#safe-embedding-of-values-yaml-injection)
+When you insert chart values into manifests, also read
+[Prevent YAML injection when inserting Helm values](#prevent-yaml-injection-when-inserting-helm-values)
 so user-supplied strings cannot reshape the document.
 
 ## Scalars and Collections
@@ -365,26 +365,23 @@ Library charts are designed for reuse,
 and aren't subject to the round-trip pitfall described above.
 :::
 
-## Safe embedding of values (YAML injection)
+## Prevent YAML injection when inserting Helm values
 
 Chart values often come from untrusted or multi-tenant sources. If you splice a
 value into a template with raw `{{ .Values.foo }}`, a value that contains
 newlines, `:` mapping indicators, or list markers can change the structure of
-the rendered YAML (YAML injection). That can break installs—or worse, inject
-extra keys into a Kubernetes manifest.
+the rendered YAML. This is called _YAML injection_.
+YAML injection can not only break installs, but can
+also inject extra keys into a Kubernetes manifest.
 
 Prefer helpers that encode or structure the data for you:
 
 | Goal | Prefer | Avoid |
 | ---- | ------ | ----- |
-| Quote a string scalar | `{{ .Values.name | quote }}` | `{{ .Values.name }}` in a bare field |
-| Multi-line free-form string | Store structured data as a map/list and use `toYaml`, or treat the whole value as one quoted scalar with `quote` | `{{ .Values.config | nindent 4 }}` — `nindent` only indents; newline-bearing values can still inject keys |
-| Embed maps / lists | `{{ toYaml .Values.extraEnv | nindent 8 }}` | `{{ .Values.extraEnv | nindent 8 }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
+| Quote a string scalar | `{{ .Values.name \| quote }}` | `{{ .Values.name }}` in a bare field |
+| Multi-line free-form string | Store structured data as a map/list and use `toYaml`, or treat the whole value as one quoted scalar with `quote` | `{{ .Values.config \| nindent 4 }}` — `nindent` only indents; newline-bearing values can still inject keys |
+| Embed maps / lists | `{{ toYaml .Values.extraEnv \| nindent 8 }}`. `nindent` only adds indentation; it doesn't encode YAML. Pair it with `toYaml` for maps/lists, or use `quote` for a single scalar. Bare `nindent` on an untrusted string is still injectable. | `{{ .Values.extraEnv \| nindent 8 }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
 | Labels / annotations maps | `toYaml` + `nindent` (or chart helpers) | Concatenating free-form label lines from values |
-
-`nindent` only adds indentation; it does **not** encode YAML. Pair it with `toYaml`
-for maps/lists, or use `quote` for a single scalar. Bare `nindent` on an
-untrusted string is still injectable.
 
 Example — safe nested object (map → YAML, then indent):
 
@@ -420,6 +417,6 @@ When in doubt:
 3. Run `helm template` (and schema validation) in CI so malformed values fail
    before they reach the cluster.
 
-See also [Functions and Pipelines](functions_and_pipelines.mdx),
-[Indenting and Templates](#indenting-and-templates), and the
-[function list](function_list.mdx) (`toYaml`, `quote`, `nindent`).
+For more information, see [Template Functions and Pipelines](functions_and_pipelines.mdx),
+[Indenting and Templates](#indenting-and-templates) on this page, and the
+[Template Function List](function_list.mdx) (`toYaml`, `quote`, `nindent`).

--- a/docs/chart_template_guide/yaml_techniques.md
+++ b/docs/chart_template_guide/yaml_techniques.md
@@ -383,7 +383,7 @@ prefer helpers that encode or structure the data for you, as shown in the follow
 | ---- | ------ | ----- |
 | Quote a string scalar | `{{ .Values.name \| quote }}` | `{{ .Values.name }}` in a bare field |
 | Insert a string as one YAML scalar | `quote`, or a block scalar header (`\|` / `>`) plus `{{- .Values.config \| nindent N }}` where `N` is greater than the parent indent (usually parent + 2) | Bare `{{ .Values.config }}` or `nindent` without a block header — a newline in the value can start a new key |
-| Embed maps / lists (collections) | `{{ toYaml .Values.extraEnv \| nindent N }}` so `toYaml` emits the collection and `nindent` only shifts it | `{{ .Values.extraEnv \| nindent N }}` without `toYaml`, or hand-rolled `key: {{ . }}` loops |
+| Embed maps / lists (collections) | `{{ toYaml .Values.extraEnv \| nindent N }}` where `N` is greater than the parent indent (usually parent + 2), so `toYaml` emits the collection and `nindent` only shifts it into place | `{{ .Values.extraEnv \| nindent N }}` without `toYaml`, an `N` that is not greater than the parent indent, or hand-rolled `key: {{ . }}` loops |
 
 The following describes general best practices for preventing YAML injection when inserting values:
 


### PR DESCRIPTION
The template guide shows `quote` / `toYaml` / `nindent` in places, but there wasn't a single warning about what happens if you skip them. Added a short section under YAML techniques (with a pointer from the intro) on safe embedding of values.

Fixes #2154