### PR TITLE
Add default_lang_commit to fr pages

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -1,6 +1,7 @@
 ---
 title: "Politique de planification des releases"
 description: "Décrit la politique de planification des releases de Helm."
+default_lang_commit: cd5ad1e1593c50677909d7c618cf31cd4036fac7
 ---
 
 Dans l'intérêt de ses utilisateurs, Helm définit et annonce les dates de release
@@ -36,6 +37,7 @@ Une release de correctif sera annulée pour l'une des raisons suivantes :
   première release candidate (RC1) d'une prochaine version mineure
 - si la date de la release de correctif tombe dans les quatre semaines suivant
   une release mineure
+- si une sortie majeure ou mineure est prévue pour le même mois  
 
 ## Releases mineures
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
@@ -2,6 +2,7 @@
 title: Conventions générales
 description: Conventions générales pour les charts.
 sidebar_position: 1
+default_lang_commit: 35e200fbcba7033358a6e2b414b6a5499da0282d
 ---
 
 Cette partie du guide des bonnes pratiques explique les conventions générales.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/custom_resource_definitions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/custom_resource_definitions.md
@@ -2,6 +2,7 @@
 title: Définitions de ressources personnalisées
 description: Comment créer et utiliser des CRDs.
 sidebar_position: 7
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Cette partie du guide des bonnes pratiques traite de la création et de l'utilisation

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/dependencies.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/dependencies.md
@@ -2,6 +2,7 @@
 title: Dépendances
 description: Couvre les bonnes pratiques pour les dépendances de chart.
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Cette partie du guide des bonnes pratiques couvre les `dependencies` déclarées dans

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/labels.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/labels.md
@@ -2,6 +2,7 @@
 title: Labels et annotations
 description: Couvre les bonnes pratiques pour l'utilisation des labels et annotations dans votre chart.
 sidebar_position: 5
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Cette partie du guide des bonnes pratiques traite de l'utilisation des labels et

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/pods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/pods.md
@@ -2,6 +2,7 @@
 title: Pods et PodTemplates
 description: Bonnes pratiques pour le formatage des sections Pod et PodTemplate dans les manifestes de chart.
 sidebar_position: 6
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Cette partie du guide des bonnes pratiques aborde le formatage des sections Pod et

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
@@ -2,6 +2,7 @@
 title: Contrôle d'accès basé sur les rôles
 description: Traite de la création et du formatage des ressources RBAC dans les manifestes de chart.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Cette partie du guide des bonnes pratiques traite de la création et du formatage des
@@ -60,9 +61,7 @@ par les ressources soumises au contrôle d'accès créées par le chart.
 
 - Si `serviceAccount.create` est true, un ServiceAccount avec ce nom doit être créé.
 - Si le nom n'est pas défini, un nom est généré en utilisant le template `fullname`.
-- Si `serviceAccount.create` est false, le ServiceAccount ne doit pas être créé, mais il doit
-  tout de même être associé aux mêmes ressources afin que les ressources RBAC créées
-  manuellement ultérieurement fonctionnent correctement.
+- Si `serviceAccount.create` est false, le ServiceAccount ne doit pas être créé, mais il doit tout de même être associé aux mêmes ressources afin que les ressources RBAC créées manuellement ultérieurement qui le référencent fonctionnent correctement.
 - Si `serviceAccount.create` est false et que le nom n'est pas spécifié, le
   ServiceAccount par défaut est utilisé.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/templates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/templates.md
@@ -2,6 +2,7 @@
 title: Templates
 description: Un examen approfondi des bonnes pratiques concernant les templates.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Cette partie du guide des bonnes pratiques se concentre sur les templates.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/values.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/values.md
@@ -2,6 +2,7 @@
 title: Values
 description: Se concentre sur la façon de structurer et d'utiliser vos values.
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Cette partie du guide des bonnes pratiques couvre l'utilisation des values. Dans cette section, nous fournissons des recommandations sur la façon de structurer et d'utiliser vos values, en mettant l'accent sur la conception du fichier `values.yaml` d'un chart.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
@@ -2,6 +2,7 @@
 title: Accéder aux fichiers dans les templates
 description: Comment accéder aux fichiers depuis un template.
 sidebar_position: 10
+default_lang_commit: ba97a18c9c46b74dd1578e6c5da00754e0a4ec34
 ---
 
 Dans la section précédente, nous avons examiné plusieurs façons de créer et d'accéder à des templates nommés. Cela facilite l'importation d'un template depuis un autre template. Mais parfois, il est souhaitable d'importer un _fichier qui n'est pas un template_ et d'injecter son contenu sans le faire passer par le moteur de rendu de templates.
@@ -20,16 +21,16 @@ Helm permet d'accéder aux fichiers via l'objet `.Files`. Avant de passer aux ex
 
 <!-- toc -->
 
-- [Exemple de base](#exemple-de-base)
-- [Fonctions d'aide pour les chemins](#fonctions-daide-pour-les-chemins)
-- [Motifs glob](#motifs-glob)
-- [Fonctions utilitaires pour ConfigMap et Secrets](#fonctions-utilitaires-pour-configmap-et-secrets)
-- [Encodage](#encodage)
-- [Lignes](#lignes)
+- [Exemple de base](#basic-example)
+- [Fonctions d'aide pour les chemins](#path-helpers)
+- [Motifs glob](#glob-patterns)
+- [Fonctions utilitaires pour ConfigMap et Secrets](#configmap-and-secrets-utility-functions)
+- [Encodage](#encoding)
+- [Lignes](#lines)
 
 <!-- tocstop -->
 
-## Exemple de base
+## Exemple de base {#basic-example}
 
 Ces points clarifiés, écrivons un template qui lit trois fichiers dans notre ConfigMap. Pour commencer, nous allons ajouter trois fichiers au chart, en les plaçant tous directement dans le répertoire `mychart/`.
 
@@ -87,7 +88,7 @@ data:
     message = "Goodbye from config 3"
 ```
 
-## Fonctions d'aide pour les chemins
+## Fonctions d'aide pour les chemins {#path-helpers}
 
 Lorsque vous travaillez avec des fichiers, il peut être très utile d'effectuer des opérations standard sur les chemins de fichiers eux-mêmes. Pour vous aider, Helm importe de nombreuses fonctions du package [path](https://golang.org/pkg/path/) de Go. Elles sont toutes accessibles avec les mêmes noms que dans le package Go, mais avec une première lettre en minuscule. Par exemple, `Base` devient `base`, etc.
 
@@ -98,7 +99,7 @@ Les fonctions importées sont :
 - IsAbs
 - Clean
 
-## Motifs glob
+## Motifs glob {#glob-patterns}
 
 À mesure que votre chart grandit, vous pourriez avoir besoin d'organiser davantage vos fichiers. Nous fournissons donc une méthode `Files.Glob(pattern string)` pour vous aider à extraire certains fichiers avec toute la flexibilité des [motifs glob](https://godoc.org/github.com/gobwas/glob).
 
@@ -133,7 +134,7 @@ Ou
 {{ end }}
 ```
 
-## Fonctions utilitaires pour ConfigMap et Secrets
+## Fonctions utilitaires pour ConfigMap et Secrets {#configmap-and-secrets-utility-functions}
 
 (Disponible depuis Helm 2.0.2)
 
@@ -161,7 +162,7 @@ data:
   {{- (.Files.Glob "bar/*").AsSecrets | nindent 2 }}
 ```
 
-## Encodage
+## Encodage {#encoding}
 
 Vous pouvez importer un fichier et demander au template de l'encoder en base64 pour garantir une transmission réussie :
 
@@ -190,7 +191,7 @@ data:
     bWVzc2FnZSA9ICJIZWxsbyBmcm9tIGNvbmZpZyAxIgo=
 ```
 
-## Lignes
+## Lignes {#lines}
 
 Parfois, il est souhaitable d'accéder à chaque ligne d'un fichier dans votre template. Nous fournissons une méthode `Lines` pratique pour cela.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/builtin_objects.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/builtin_objects.md
@@ -2,6 +2,7 @@
 title: Objets intégrés
 description: Les objets intégrés disponibles dans les templates.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Les objets sont passés dans un template par le moteur de template. Votre code peut également transmettre des objets (nous verrons des exemples lorsque nous examinerons les instructions `with` et `range`). Il existe même plusieurs façons de créer de nouveaux objets dans vos templates, comme avec la fonction `tuple` que nous verrons plus tard.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/control_structures.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/control_structures.md
@@ -2,6 +2,7 @@
 title: Structures de contrôle
 description: Un aperçu rapide des structures de contrôle dans les templates.
 sidebar_position: 7
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Les structures de contrôle (appelées « actions » dans le jargon des templates) vous permettent, en tant qu'auteur de template, de contrôler le flux de génération d'un template. Le langage de template de Helm fournit les structures de contrôle suivantes :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/data_types.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/data_types.md
@@ -2,6 +2,7 @@
 title: "Annexe : Types de données Go et Templates"
 description: Un bref aperçu des variables dans les templates.
 sidebar_position: 16
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Le langage de template Helm est implémenté dans le langage de programmation Go, qui est fortement typé. Pour cette raison, les variables dans les templates sont _typées_. Généralement, les variables seront exposées comme l'un des types suivants :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
@@ -2,6 +2,7 @@
 title: Débogage des templates
 description: Dépannage des charts dont le déploiement échoue.
 sidebar_position: 13
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Le débogage des templates peut être délicat, car les templates rendus sont envoyés au serveur d'API Kubernetes, qui peut rejeter les fichiers YAML pour des raisons autres que le formatage.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
@@ -2,31 +2,32 @@
 title: Liste des fonctions de template
 description: Une liste des fonctions de template disponibles dans Helm
 sidebar_position: 6
+default_lang_commit: 029d283b39851e790dd1756201af6aadb521ba2a
 ---
 
 Helm inclut de nombreuses fonctions de template que vous pouvez utiliser dans vos templates.
 Elles sont répertoriées ici et classées dans les catégories suivantes :
 
-* [Fonctions cryptographiques et de sécurité](#fonctions-cryptographiques-et-de-sécurité)
-* [Date](#fonctions-de-date)
-* [Dictionnaires](#dictionnaires-et-fonctions-dict)
-* [Encodage](#fonctions-dencodage)
-* [Chemins de fichiers](#fonctions-de-chemin-de-fichier)
-* [Kubernetes et Chart](#fonctions-kubernetes-et-chart)
-* [Logique et contrôle de flux](#fonctions-de-logique-et-de-contrôle-de-flux)
-* [Listes](#listes-et-fonctions-de-liste)
-* [Mathématiques](#fonctions-mathématiques)
-* [Mathématiques à virgule flottante](#fonctions-mathématiques-à-virgule-flottante)
-* [Réseau](#fonctions-réseau)
-* [Réflexion](#fonctions-de-réflexion)
-* [Expressions régulières](#expressions-régulières)
-* [Versions sémantiques](#fonctions-de-version-sémantique)
-* [Chaînes de caractères](#fonctions-de-chaînes-de-caractères)
-* [Conversion de types](#fonctions-de-conversion-de-types)
-* [URL](#fonctions-url)
-* [UUID](#fonctions-uuid)
+* [Cryptographic and Security](#cryptographic-and-security-functions)
+* [Date](#date-functions)
+* [Dictionaries](#dictionaries-and-dict-functions)
+* [Encoding](#encoding-functions)
+* [File Path](#file-path-functions)
+* [Kubernetes and Chart](#kubernetes-and-chart-functions)
+* [Logic and Flow Control](#logic-and-flow-control-functions)
+* [Lists](#lists-and-list-functions)
+* [Math](#math-functions)
+* [Float Math](#float-math-functions)
+* [Network](#network-functions)
+* [Reflection](#reflection-functions)
+* [Regular Expressions](#regular-expressions)
+* [Semantic Versions](#semantic-version-functions)
+* [String](#string-functions)
+* [Type Conversion](#type-conversion-functions)
+* [URL](#url-functions)
+* [UUID](#uuid-functions)
 
-## Fonctions de logique et de contrôle de flux
+## Logic and Flow Control Functions {#logic-and-flow-control-functions}
 
 Helm inclut de nombreuses fonctions de logique et de contrôle de flux, notamment [and](#and),
 [coalesce](#coalesce), [default](#default), [empty](#empty), [eq](#eq),
@@ -223,7 +224,7 @@ false | ternary "foo" "bar"
 
 L'exemple ci-dessus retourne `"bar"`.
 
-## Fonctions de chaînes de caractères
+## String Functions {#string-functions}
 
 Helm inclut les fonctions de chaînes suivantes : [abbrev](#abbrev),
 [abbrevboth](#abbrevboth), [camelcase](#camelcase), [cat](#cat),
@@ -679,7 +680,7 @@ shuffle "hello"
 
 L'exemple ci-dessus mélangera les lettres dans `hello`, produisant peut-être `oelhl`.
 
-## Fonctions de conversion de types
+## Type Conversion Functions {#type-conversion-functions}
 
 Les fonctions de conversion de types suivantes sont fournies par Helm :
 
@@ -870,7 +871,7 @@ greeting: |
 ```
 
 
-## Expressions régulières
+## Regular Expressions {#regular-expressions}
 
 Helm inclut les fonctions d'expressions régulières suivantes : [regexFind
 (mustRegexFind)](#regexfindall-mustregexfindall), [regexFindAll
@@ -972,7 +973,7 @@ L'exemple ci-dessus produit `[pi a]`
 `regexSplit` provoque un panic en cas de problème et `mustRegexSplit` retourne une erreur
 au moteur de template en cas de problème.
 
-## Fonctions cryptographiques et de sécurité
+## Cryptographic and Security Functions {#cryptographic-and-security-functions}
 
 Helm fournit des fonctions cryptographiques avancées. Elles incluent
 [adler32sum](#adler32sum), [buildCustomCert](#buildcustomcert),
@@ -1159,7 +1160,7 @@ et retourne le texte déchiffré.
 "30tEfhuJSVRhpG97XCuWgz2okj7L8vQ1s6V9zVUPeDQ=" | decryptAES "secretkey"
 ```
 
-## Fonctions de date
+## Date Functions {#date-functions}
 
 Helm inclut les fonctions de date suivantes que vous pouvez utiliser dans les templates :
 [ago](#ago), [date](#date), [dateInZone](#dateinzone), [dateModify
@@ -1295,7 +1296,7 @@ un pipe). L'exemple ci-dessous convertit "2017-12-31" en "31/12/2017".
 toDate "2006-01-02" "2017-12-31" | date "02/01/2006"
 ```
 
-## Dictionnaires et fonctions Dict
+## Dictionaries and Dict Functions {#dictionaries-and-dict-functions}
 
 Helm fournit un type de stockage clé/valeur appelé `dict` (abréviation de « dictionary »,
 comme en Python). Un `dict` est un type _non ordonné_.
@@ -1579,14 +1580,14 @@ Un `dict` est implémenté en Go comme un `map[string]interface{}`. Les dévelop
 passer des valeurs `map[string]interface{}` dans le contexte pour les rendre disponibles aux
 templates en tant que `dict`s.
 
-## Fonctions d'encodage
+## Encoding Functions {#encoding-functions}
 
 Helm dispose des fonctions d'encodage et de décodage suivantes :
 
 - `b64enc`/`b64dec` : Encoder ou décoder avec Base64
 - `b32enc`/`b32dec` : Encoder ou décoder avec Base32
 
-## Listes et fonctions de liste
+## Lists and List Functions {#lists-and-list-functions}
 
 Helm fournit un type `list` simple qui peut contenir des listes séquentielles arbitraires
 de données. C'est similaire aux tableaux ou aux slices, mais les listes sont conçues pour être utilisées
@@ -1828,7 +1829,7 @@ chunk 3 (list 1 2 3 4 5 6 7 8)
 
 Ceci produit une liste de listes `[ [ 1 2 3 ] [ 4 5 6 ] [ 7 8 ] ]`.
 
-## Fonctions mathématiques
+## Math Functions {#math-functions}
 
 Toutes les fonctions mathématiques opèrent sur des valeurs `int64` sauf indication contraire.
 
@@ -1892,7 +1893,7 @@ Retourne la longueur de l'argument en tant qu'entier.
 len .Arg
 ```
 
-## Fonctions mathématiques à virgule flottante
+## Float Math Functions {#float-math-functions}
 
 Toutes les fonctions mathématiques opèrent sur des valeurs `float64`.
 
@@ -1979,7 +1980,7 @@ après la virgule décimale.
 
 `round 123.555555 3` retournera `123.556`.
 
-## Fonctions réseau
+## Network Functions {#network-functions}
 
 Helm a une seule fonction réseau, `getHostByName`.
 
@@ -1989,7 +1990,7 @@ La fonction `getHostByName` reçoit un nom de domaine et retourne l'adresse IP.
 
 Cette fonction nécessite l'option `--enable-dns` à passer sur la ligne de commande helm.
 
-## Fonctions de chemin de fichier
+## File Path Functions {#file-path-functions}
 
 Bien que les fonctions de template Helm ne donnent pas accès au système de fichiers, elles fournissent
 des fonctions pour travailler avec des chaînes qui suivent les conventions de chemins de fichiers.
@@ -2035,7 +2036,7 @@ L'exemple ci-dessus retourne `.bar`.
 
 Pour vérifier si un chemin de fichier est absolu, utilisez `isAbs`.
 
-## Fonctions de réflexion
+## Reflection Functions {#reflection-functions}
 
 Helm fournit des outils de réflexion rudimentaires. Ceux-ci aident les développeurs de templates avancés
 à comprendre les informations de type Go sous-jacentes pour une valeur particulière.
@@ -2091,7 +2092,7 @@ deepEqual (list 1 2 3) (list 1 2 3)
 
 L'exemple ci-dessus retournera `true`.
 
-## Fonctions de version sémantique
+## Semantic Version Functions {#semantic-version-functions}
 
 Certains schémas de version sont facilement analysables et comparables. Helm fournit des
 fonctions pour travailler avec les versions [SemVer 2](http://semver.org). Celles-ci incluent
@@ -2246,7 +2247,7 @@ changement majeur casse l'API. Par exemple,
 - `^0.0` est équivalent à `>=0.0.0 <0.1.0`
 - `^0` est équivalent à `>=0.0.0 <1.0.0`
 
-## Fonctions URL
+## URL Functions {#url-functions}
 
 Helm inclut les fonctions [urlParse](#urlparse), [urlJoin](#urljoin), et
 [urlquery](#urlquery) vous permettant de travailler avec les parties d'URL.
@@ -2296,7 +2297,7 @@ adaptée à l'intégration dans la partie requête d'une URL.
 $var := urlquery "string for query"
 ```
 
-## Fonctions UUID
+## UUID Functions {#uuid-functions}
 
 Helm peut générer des UUID v4 universellement uniques.
 
@@ -2306,7 +2307,7 @@ uuidv4
 
 L'exemple ci-dessus retourne un nouvel UUID de type v4 (généré aléatoirement).
 
-## Fonctions Kubernetes et Chart
+## Kubernetes and Chart Functions {#kubernetes-and-chart-functions}
 
 Helm inclut des fonctions pour travailler avec Kubernetes, notamment
 [.Capabilities.APIVersions.Has](#capabilitiesapiversionshas),

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
@@ -2,6 +2,7 @@
 title: Fonctions de template et pipelines
 description: Utilisation des fonctions dans les templates.
 sidebar_position: 5
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Jusqu'à présent, nous avons vu comment insérer des informations dans un template. Mais ces informations sont insérées sans modification. Parfois, nous voulons transformer les données fournies de manière plus exploitable.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
@@ -2,6 +2,7 @@
 title: Premiers pas
 description: Un guide rapide sur les templates de chart.
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Dans cette section du guide, nous allons créer un chart et y ajouter un premier template. Le chart créé ici sera utilisé tout au long du reste du guide.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/helm_ignore_file.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/helm_ignore_file.md
@@ -2,6 +2,7 @@
 title: Le fichier .helmignore
 description: Le fichier `.helmignore` permet de spécifier les fichiers que vous ne souhaitez pas inclure dans votre chart Helm.
 sidebar_position: 12
+default_lang_commit: c4624cd8526f3d0927fa871facd19c9a0cf5b810
 ---
 
 Le fichier `.helmignore` permet de spécifier les fichiers que vous ne souhaitez

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/named_templates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/named_templates.md
@@ -2,6 +2,7 @@
 title: Templates Nommés
 description: Comment définir des templates nommés.
 sidebar_position: 9
+default_lang_commit: ba552a20cbe232493e23226f44bce119adb704e1
 ---
 
 Il est temps d'aller au-delà d'un seul template et de commencer à en créer d'autres. Dans cette section, nous verrons comment définir des _templates nommés_ dans un fichier, puis les utiliser ailleurs. Un _template nommé_ (parfois appelé _partial_ ou _sous-template_) est simplement un template défini à l'intérieur d'un fichier et auquel on donne un nom. Nous verrons deux façons de les créer et plusieurs façons de les utiliser.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/notes_files.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/notes_files.md
@@ -2,6 +2,7 @@
 title: Créer un fichier NOTES.txt
 description: Comment fournir des instructions aux utilisateurs de votre Chart.
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dans cette section, nous allons examiner l'outil Helm permettant de fournir des instructions aux utilisateurs de votre chart. À la fin d'un `helm install` ou d'un `helm upgrade`, Helm peut afficher un bloc d'informations utiles pour les utilisateurs. Ces informations sont entièrement personnalisables à l'aide des templates.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/subcharts_and_globals.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/subcharts_and_globals.md
@@ -2,6 +2,7 @@
 title: Sous-charts et Valeurs Globales
 description: Interaction avec les valeurs d'un sous-chart et les valeurs globales.
 sidebar_position: 11
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Jusqu'à présent, nous avons travaillé uniquement avec un seul chart. Cependant, les charts peuvent avoir des dépendances, appelées _sous-charts_, qui possèdent également leurs propres valeurs et templates. Dans cette section, nous allons créer un sous-chart et découvrir les différentes façons d'accéder aux valeurs depuis les templates.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/values_files.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/values_files.md
@@ -2,6 +2,7 @@
 title: Fichiers Values
 description: Instructions sur l'utilisation du flag --values.
 sidebar_position: 4
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dans la section précédente, nous avons examiné les objets intégrés que les templates Helm proposent. L'un de ces objets intégrés est `Values`. Cet objet donne accès aux valeurs passées dans le chart. Son contenu provient de plusieurs sources :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/variables.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/variables.md
@@ -2,6 +2,7 @@
 title: Variables
 description: Utilisation des variables dans les templates.
 sidebar_position: 8
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Après avoir abordé les fonctions, les pipelines, les objets et les structures de contrôle, nous pouvons nous tourner vers l'un des concepts les plus fondamentaux de nombreux langages de programmation : les variables. Dans les templates, elles sont moins fréquemment utilisées. Mais nous allons voir comment les utiliser pour simplifier le code et mieux exploiter `with` et `range`.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/wrapping_up.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/wrapping_up.md
@@ -2,6 +2,7 @@
 title: Prochaines étapes
 description: Conclusion - quelques liens utiles vers d'autres documentations qui vous aideront.
 sidebar_position: 14
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Ce guide est destiné à vous fournir, en tant que développeur de charts, une bonne maîtrise du langage de template de Helm. Il met l'accent sur les aspects techniques du développement de templates.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/yaml_techniques.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/yaml_techniques.md
@@ -2,6 +2,7 @@
 title: "Annexe : Techniques YAML"
 description: Un examen approfondi de la spécification YAML et de son application dans Helm.
 sidebar_position: 15
+default_lang_commit: ba552a20cbe232493e23226f44bce119adb704e1
 ---
 
 Ce guide s'est principalement concentré sur l'écriture du langage de template. Ici,

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/changes_since_helm2.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/changes_since_helm2.md
@@ -1,6 +1,7 @@
 ---
 title: Changements depuis Helm 2
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 ## Changements depuis Helm 2

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/installing.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/installing.md
@@ -1,6 +1,7 @@
 ---
 title: Installation
 sidebar_position: 2
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 ## Installation

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: Dépannage
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 ## Dépannage

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/uninstalling.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/faq/uninstalling.md
@@ -1,6 +1,7 @@
 ---
 title: Désinstallation
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 ## Désinstallation

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm.md
@@ -1,6 +1,7 @@
 ---
 title: helm
 slug: helm
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Helm, Le gestionnaire de paquets pour Kubernetes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 générer des scripts d'auto-complétion pour le shell spécifié
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_bash.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_bash.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion bash
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 générer des scripts d'auto-complétion pour bash
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_fish.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_fish.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion fish
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 générer des scripts d'auto-complétion pour fish
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_powershell.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_powershell.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion powershell
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 générer des scripts d'auto-complétion pour powershell
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_zsh.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_completion_zsh.md
@@ -1,5 +1,6 @@
 ---
 title: helm completion zsh
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 générer des scripts d'auto-complétion pour Zsh
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_create.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_create.md
@@ -1,5 +1,6 @@
 ---
 title: helm create
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 créer un nouveau chart avec le nom donné
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 gestion des dépendances d'un chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_build.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_build.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency build
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 reconstruire le répertoire charts/ à partir du fichier Chart.lock
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_list.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency list
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 liste les dépendances pour un chart donné
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_dependency_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm dependency update
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 met à jour le dossier charts/ basé sur le contenu du fichier Chart.yaml
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_env.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_env.md
@@ -1,5 +1,6 @@
 ---
 title: helm env
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 informations sur l'environnement du client Helm
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get.md
@@ -1,5 +1,6 @@
 ---
 title: helm get
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 télécharger les informations détaillées d'une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_all.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_all.md
@@ -1,5 +1,6 @@
 ---
 title: helm get all
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 télécharge toutes les informations pour une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_hooks.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_hooks.md
@@ -1,5 +1,6 @@
 ---
 title: helm get hooks
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 télécharge tous les hooks pour une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_manifest.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_manifest.md
@@ -1,5 +1,6 @@
 ---
 title: helm get manifest
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 télécharge le manifeste pour une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_metadata.md
@@ -1,5 +1,6 @@
 ---
 title: helm get metadata
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Cette commande récupère les métadonnées pour une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_notes.md
@@ -1,5 +1,6 @@
 ---
 title: helm get notes
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 télécharge les notes pour une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_values.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_get_values.md
@@ -1,5 +1,6 @@
 ---
 title: helm get values
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 télécharge le fichier de valeurs d'une version donnée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_history.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_history.md
@@ -1,5 +1,6 @@
 ---
 title: helm history
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 récupère l'historique des versions
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_install.md
@@ -1,5 +1,6 @@
 ---
 title: helm install
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 installe un chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_lint.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_lint.md
@@ -1,5 +1,6 @@
 ---
 title: helm lint
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 examine un chart pour détecter d'éventuels problèmes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_list.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm list
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 liste les publications
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_package.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_package.md
@@ -1,5 +1,6 @@
 ---
 title: helm package
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 emballe un dossier de chart dans une archive de chart 
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 installer, lister ou désinstaller des plugins Helm.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_install.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin install
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 installe un ou plusieurs plugins Helm
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_list.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin list
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 liste les plugins Helm installés
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_uninstall.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_uninstall.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin uninstall
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 désinstalle un ou plusieurs plugins Helm
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_plugin_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm plugin update
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 met à jour un ou plusieurs plugins Helm
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_pull.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_pull.md
@@ -1,5 +1,6 @@
 ---
 title: helm pull
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Télécharge un chart depuis un dépôt et (optionnellement) le décompresse dans un répertoire local.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_push.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_push.md
@@ -1,5 +1,6 @@
 ---
 title: helm push
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Pousse un chart à distance
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_registry.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_registry.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 
 Se connecter ou se déconnecter d'un registre

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_registry_login.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_registry_login.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry login
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Se connecter à un registre
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_registry_logout.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_registry_logout.md
@@ -1,5 +1,6 @@
 ---
 title: helm registry logout
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Se déconnecter d'un registre
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Ajoute, supprime, liste, met à jour et index les référentiels de charts
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_add.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_add.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo add
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Ajouter un répertoire de chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_index.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_index.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo index
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Génère un fichier index à partir d'un répertoire contenant des charts packagés
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_list.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_list.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo list
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Liste les répertoires de charts
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_remove.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_remove.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo remove
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 
 Supprime un ou plusieurs répertoires de charts

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_repo_update.md
@@ -1,5 +1,6 @@
 ---
 title: helm repo update
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Met à jour les informations sur les charts disponibles localement à partir des répertoires de charts
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md
@@ -1,5 +1,6 @@
 ---
 title: helm rollback
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Restaurer une release vers une révision précédente
 
@@ -9,7 +10,7 @@ Cette commande restaure une release vers une révision précédente.
 
 Le premier argument de cette commande est le nom de la release et le second est la révision (numéro de version). Si cet argument est omis ou défini sur 0, la release précédente sera restaurée.
 
-Pour voir les numéros de révision, lancez la commande `helm history <RELEASE>`.
+Pour voir les numéros de révision, lancez la commande `helm history RELEASE`.
 
 
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_search.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_search.md
@@ -1,5 +1,6 @@
 ---
 title: helm search
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Recherche un mot clé dans les charts
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_search_hub.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_search_hub.md
@@ -1,5 +1,6 @@
 ---
 title: helm search hub
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Recherche de charts dans l'Artifact Hub ou dans votre propre instance du hub
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_search_repo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_search_repo.md
@@ -1,5 +1,6 @@
 ---
 title: helm search repo
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Rechercher par mot clé dans les répertoires de charts
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show.md
@@ -1,5 +1,6 @@
 ---
 title: helm show
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche les informations sur le chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_all.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_all.md
@@ -1,5 +1,6 @@
 ---
 title: helm show all
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche toutes les informations sur un chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_chart.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_chart.md
@@ -1,5 +1,6 @@
 ---
 title: helm show chart
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche la définition du chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_crds.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_crds.md
@@ -1,5 +1,6 @@
 ---
 title: helm show crds
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche les CRDs du chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_readme.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_readme.md
@@ -1,5 +1,6 @@
 ---
 title: helm show readme
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 
 Affiche le README du chart

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_values.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_show_values.md
@@ -1,5 +1,6 @@
 ---
 title: helm show values
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche les values du chart
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_status.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_status.md
@@ -1,5 +1,6 @@
 ---
 title: helm status
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche le statut de la release nommée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_template.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_template.md
@@ -1,5 +1,6 @@
 ---
 title: helm template
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 
 Rendu local de modèles

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_test.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_test.md
@@ -1,5 +1,6 @@
 ---
 title: helm test
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Lance des tests sur une release
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_uninstall.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_uninstall.md
@@ -1,5 +1,6 @@
 ---
 title: helm uninstall
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 
 Désinstalle une release

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: helm upgrade
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 
 Met à niveau une release

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_verify.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_verify.md
@@ -1,5 +1,6 @@
 ---
 title: helm verify
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Vérifie que le chart à l'emplacement donné a été signé et est valide
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_version.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_version.md
@@ -1,5 +1,6 @@
 ---
 title: helm version
+default_lang_commit: aab1f270fe5c30541a77bdec647b2b3677eeea13
 ---
 Affiche les informations sur la version du client
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/index.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/helm/index.mdx
@@ -3,6 +3,7 @@ title: Commandes Helm
 description: Documentation de toute la liste des commandes CLI helm.
 sidebar_position: 6
 id: helm-category
+default_lang_commit: 7080576ef6855d44ce77a1076b3fc184dcc2a27c
 ---
 
 # Commandes Helm

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/chart_releaser_action.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/chart_releaser_action.md
@@ -2,6 +2,7 @@
 title: Action Chart Releaser pour automatiser les charts via GitHub Pages
 description: Décrit comment utiliser l'action Chart Releaser pour automatiser la publication de charts via GitHub Pages.
 sidebar_position: 3
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Ce guide décrit comment utiliser [Chart Releaser

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
@@ -2,6 +2,7 @@
 title: Synchroniser votre dépôt de charts
 description: Explique comment synchroniser vos dépôts de charts locaux et distants.
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 *Remarque : cet exemple est spécifiquement conçu pour un bucket Google Cloud Storage (GCS) qui héberge un dépôt de charts.*

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/charts_tips_and_tricks.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/charts_tips_and_tricks.md
@@ -2,6 +2,7 @@
 title: Trucs et astuces pour le développement de charts
 description: Présente des trucs et astuces que les développeurs de charts Helm ont appris lors de la création de charts de qualité production.
 sidebar_position: 1
+default_lang_commit: ba552a20cbe232493e23226f44bce119adb704e1
 ---
 
 Ce guide présente des trucs et astuces que les développeurs de charts Helm ont appris lors de la création de charts de qualité production.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/index.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/howto/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Comment faire
 sidebar_position: 2
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 # Comment faire

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/index.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Accueil Documentations"
 description: "Tout ce que vous devez savoir sur l'organisation de la documentation."
+default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 # Bienvenue
@@ -12,7 +13,7 @@ Bienvenue dans la documentation de [Helm](https://helm.sh/). Helm est le manageu
 Helm a beaucoup de documentation. Voici un aperçu de son organisation
 pour vous aider à chercher:
 
-- [Les Tutoriels](/intro/index.mdx) vous guide à travers une série d'étapes pour créer votre premier tableau Helm. Commencez ici si vous êtes nouveau dans Helm.
+- [Les Tutoriels](/chart_template_guide/getting_started.md) vous guide à travers une série d'étapes pour créer votre premier tableau Helm. Commencez ici si vous êtes nouveau dans Helm.
 - [Les Guides thématiques](/topics/index.mdx) abordent des sujets et concepts clés à un niveau assez élevé et fournissent des informations de base et des explications utiles.
 - [Le Guide de la communauté](/community) aborde des sujets centrés sur la communauté de Helm. Rendez-vous dessus si vous souhaitez en savoir plus sur le processus de développement de Helm en lui-même et comment vous pouvez y contribuer.
 - [Les Guides pratiques](/howto/index.mdx) sont des recettes. Ils vous guident à travers les étapes qui permettent de résoudre les problèmes clés et les cas d’utilisations. Ils sont plus avancés que les tutoriels et nécessitent une certaine connaissance du fonctionnement de Helm.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/CheatSheet.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/CheatSheet.md
@@ -2,6 +2,7 @@
 title: Cheat Sheet
 description: Helm cheatsheet
 sidebar_position: 4
+default_lang_commit: 5b891dc41e2912a6ffed8d478a1bd371e5921d4b
 ---
 
 La cheatsheet d'Helm contient toutes les commandes nécessaires pour gérer une application avec Helm.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/index.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 sidebar_position: 1
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Introduction à Helm

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/install.md
@@ -2,6 +2,7 @@
 title: Installation de Helm
 description: Apprenez à installer Helm et à le prendre en main.
 sidebar_position: 2
+default_lang_commit: 5b891dc41e2912a6ffed8d478a1bd371e5921d4b
 ---
 
 Ce guide vous explique comment installer la CLI (Interface de Ligne de Commande) Helm. Helm peut être installé soit à partir des sources, soit à partir des releases binaires pré-construites.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
@@ -2,6 +2,7 @@
 title: Guide de démarrage rapide
 description: Comment installer et débuter avec Helm, y compris les instructions pour les distributions, FAQ et plugins.
 sidebar_position: 1
+default_lang_commit: 5b891dc41e2912a6ffed8d478a1bd371e5921d4b
 ---
 
 Ce guide explique comment commencer rapidement à utiliser Helm.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
@@ -2,6 +2,7 @@
 title: Utilisation de Helm
 description: Explique la base de Helm.
 sidebar_position: 3
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Ce guide explique les bases de l'utilisation de Helm pour gérer les packages sur votre cluster Kubernetes. Nous partons du principe que vous avez déjà [installé](/intro/install.md) le client Helm.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/sdk/gosdk.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/sdk/gosdk.md
@@ -2,6 +2,7 @@
 title: Introduction
 description: Présente le SDK Go de Helm
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 Le SDK Go de Helm permet aux logiciels personnalisés d'exploiter les charts Helm et les fonctionnalités de Helm pour gérer le déploiement de logiciels sur Kubernetes.
 (En fait, la CLI Helm n'est qu'un exemple d'un tel outil !)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -2,6 +2,7 @@
 title: Techniques Helm avancées
 description: Explique diverses fonctionnalités avancées pour les utilisateurs expérimentés de Helm
 sidebar_position: 9
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Cette section présente diverses fonctionnalités et techniques avancées pour utiliser Helm.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -2,6 +2,7 @@
 title: Guide des dépôts de charts
 description: Comment créer et travailler avec les dépôts de charts Helm.
 sidebar_position: 6
+default_lang_commit: 944aeaca4df514e7c5ba091995fcbbc08e505f65
 ---
 
 Cette section explique comment créer et travailler avec les dépôts de charts Helm.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
@@ -2,6 +2,7 @@
 title: Tests de chart
 description: Décrit comment exécuter et tester vos charts.
 sidebar_position: 3
+default_lang_commit: 81fa9227414a9c99d74705bdc159c4c21c9aac7c
 ---
 
 Un chart contient de nombreuses ressources et composants Kubernetes qui

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -2,6 +2,7 @@
 title: Charts
 description: Explique le format des charts et fournit des conseils de base pour créer des charts avec Helm.
 sidebar_position: 1
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm utilise un format de packaging appelé _charts_. Un chart est une collection
@@ -20,7 +21,7 @@ l'installer, vous pouvez le faire avec `helm pull chartrepo/chartname`.
 Ce document explique le format des charts et fournit des conseils de base pour
 créer des charts avec Helm.
 
-## Structure des fichiers d'un chart
+## Structure des fichiers d'un chart {#the-chart-file-structure}
 
 Un chart est organisé comme une collection de fichiers dans un répertoire. Le nom
 du répertoire est le nom du chart (sans information de version). Ainsi, un chart
@@ -46,7 +47,7 @@ Helm réserve l'utilisation des répertoires `charts/`, `crds/` et `templates/`,
 ainsi que des noms de fichiers listés ci-dessus. Les autres fichiers sont laissés
 tels quels.
 
-## Le fichier Chart.yaml
+## Le fichier Chart.yaml {#the-chartyaml-file}
 
 Le fichier `Chart.yaml` est obligatoire pour un chart. Il contient les champs
 suivants :
@@ -88,7 +89,7 @@ annotations:
 supplémentaires ne sont plus autorisés. L'approche recommandée est d'ajouter des
 métadonnées personnalisées dans `annotations`.
 
-### Charts et versioning
+### Charts et versioning {#charts-and-versioning}
 
 Chaque chart doit avoir un numéro de version. Une version doit suivre le standard
 [SemVer 2](https://semver.org/spec/v2.0.0.html), mais ce n'est pas strictement
@@ -122,7 +123,7 @@ dans le nom du paquet. Le système suppose que le numéro de version dans le nom
 du paquet de chart correspond au numéro de version dans le `Chart.yaml`. Le
 non-respect de cette hypothèse provoquera une erreur.
 
-### Le champ `apiVersion`
+### Le champ `apiVersion` {#the-apiversion-field}
 
 Le champ `apiVersion` doit être `v2` pour les charts Helm nécessitant au moins
 Helm 3. Les charts supportant les versions précédentes de Helm ont un `apiVersion`
@@ -132,11 +133,11 @@ Changements de `v1` à `v2` :
 
 - Un champ `dependencies` définissant les dépendances du chart, qui étaient
   situées dans un fichier séparé `requirements.yaml` pour les charts `v1`
-  (voir [Dépendances des charts](#dependances-des-charts)).
+  (voir [Dépendances des charts](#chart-dependencies)).
 - Le champ `type`, distinguant les charts d'application et les charts de type
-  library (voir [Types de charts](#types-de-charts)).
+  library (voir [Types de charts](#chart-types)).
 
-### Le champ `appVersion`
+### Le champ `appVersion` {#the-appversion-field}
 
 Notez que le champ `appVersion` n'est pas lié au champ `version`. C'est un moyen
 de spécifier la version de l'application. Par exemple, le chart `drupal` peut
@@ -152,7 +153,7 @@ scientifique.
 À partir de Helm v3.5.0, `helm create` entoure le champ `appVersion` par défaut
 de guillemets.
 
-### Le champ `kubeVersion`
+### Le champ `kubeVersion` {#the-kubeversion-field}
 
 Le champ optionnel `kubeVersion` peut définir des contraintes semver sur les
 versions de Kubernetes supportées. Helm validera les contraintes de version lors
@@ -187,7 +188,7 @@ En plus des contraintes de version utilisant les opérateurs `=` `!=` `>` `<`
 Pour une explication détaillée des contraintes semver supportées, consultez
 [Masterminds/semver](https://github.com/Masterminds/semver).
 
-### Déprécier des charts
+### Déprécier des charts {#deprecating-charts}
 
 Lors de la gestion de charts dans un dépôt de charts, il est parfois nécessaire
 de déprécier un chart. Le champ optionnel `deprecated` dans `Chart.yaml` peut
@@ -195,14 +196,14 @@ de déprécier un chart. Le champ optionnel `deprecated` dans `Chart.yaml` peut
 d'un chart dans le dépôt est marquée comme dépréciée, alors le chart dans son
 ensemble est considéré comme déprécié. Le nom du chart peut être réutilisé
 ultérieurement en publiant une nouvelle version qui n'est pas marquée comme
-dépréciée. Le workflow pour déprécier des charts est :
+dépréciée. Le workflow pour déprécier des charts est:
 
 1. Mettre à jour le `Chart.yaml` du chart pour le marquer comme déprécié, en
    incrémentant la version
 2. Publier la nouvelle version du chart dans le dépôt de charts
 3. Supprimer le chart du dépôt source (par ex. git)
 
-### Types de charts
+### Types de charts {#chart-types}
 
 Le champ `type` définit le type de chart. Il existe deux types : `application`
 et `library`. Application est le type par défaut et c'est le chart standard sur
@@ -216,13 +217,13 @@ Cela s'active en définissant le type à `library`. Le chart sera alors rendu
 comme un chart de type library où tous les utilitaires et fonctions peuvent être
 exploités. Tous les objets ressources du chart ne seront pas rendus.
 
-## LICENSE, README et NOTES d'un chart
+## LICENSE, README et NOTES d'un chart {#chart-license-readme-and-notes}
 
 Les charts peuvent également contenir des fichiers décrivant l'installation, la
 configuration, l'utilisation et la licence d'un chart.
 
 Une LICENSE est un fichier texte brut contenant la
-[licence](https://fr.wikipedia.org/wiki/Licence_de_logiciel) du chart. Le chart
+[licence](https://en.wikipedia.org/wiki/Software_license) du chart. Le chart
 peut contenir une licence car il peut avoir une logique de programmation dans
 les templates et ne serait donc pas uniquement de la configuration. Il peut
 également y avoir des licences séparées pour l'application installée par le
@@ -242,7 +243,7 @@ chart, ces informations sont extraites du contenu du fichier `README.md`.
 
 Le chart peut également contenir un court fichier texte `templates/NOTES.txt`
 qui sera affiché après l'installation et lors de l'affichage du statut d'une
-release. Ce fichier est évalué comme un [template](#templates-et-values), et
+release. Ce fichier est évalué comme un [template](#templates-and-values), et
 peut être utilisé pour afficher des notes d'utilisation, les prochaines étapes,
 ou toute autre information pertinente pour une release du chart. Par exemple,
 des instructions pourraient être fournies pour se connecter à une base de
@@ -250,13 +251,13 @@ données ou accéder à une interface web. Comme ce fichier est affiché sur STD
 lors de l'exécution de `helm install` ou `helm status`, il est recommandé de
 garder le contenu bref et de pointer vers le README pour plus de détails.
 
-## Dépendances des charts
+## Dépendances des charts {#chart-dependencies}
 
 Dans Helm, un chart peut dépendre de n'importe quel nombre d'autres charts. Ces
 dépendances peuvent être liées dynamiquement en utilisant le champ `dependencies`
 dans `Chart.yaml` ou importées dans le répertoire `charts/` et gérées manuellement.
 
-### Gérer les dépendances avec le champ `dependencies`
+### Gérer les dépendances avec le champ `dependencies` {#managing-dependencies-with-the-dependencies-field}
 
 Les charts requis par le chart actuel sont définis comme une liste dans le champ
 `dependencies`.
@@ -449,7 +450,7 @@ liste YAML. Chaque élément de la liste est une clé qui est importée depuis l
 champ `exports` du chart enfant.
 
 Pour importer des values non contenues dans la clé `exports`, utilisez le format
-[child-parent](#utiliser-le-format-child-parent). Des exemples des deux formats
+[child-parent](#using-the-child-parent-format). Des exemples des deux formats
 sont décrits ci-dessous.
 
 ##### Utiliser le format exports
@@ -552,7 +553,7 @@ myimports:
 Les values finales du parent contiennent maintenant les champs `myint` et
 `mybool` importés de subchart1.
 
-### Gérer les dépendances manuellement via le répertoire `charts/`
+### Gérer les dépendances manuellement via le répertoire `charts/` {#managing-dependencies-manually-via-the-charts-directory}
 
 Si plus de contrôle sur les dépendances est souhaité, ces dépendances peuvent
 être exprimées explicitement en copiant les charts de dépendance dans le
@@ -584,7 +585,7 @@ envers Apache et MySQL en incluant ces charts dans son répertoire `charts/`.
 **CONSEIL :** _Pour placer une dépendance dans votre répertoire `charts/`,
 utilisez la commande `helm pull`_
 
-### Aspects opérationnels de l'utilisation des dépendances
+### Aspects opérationnels de l'utilisation des dépendances {#operational-aspects-of-using-dependencies}
 
 Les sections ci-dessus expliquent comment spécifier les dépendances de charts,
 mais comment cela affecte-t-il l'installation de charts avec `helm install` et
@@ -626,7 +627,7 @@ ses dépendances.
 L'ordre d'installation des types Kubernetes est donné par l'énumération
 InstallOrder dans kind_sorter.go (voir [le fichier source Helm](https://github.com/helm/helm/blob/484d43913f97292648c867b56768775a55e4bba6/pkg/releaseutil/kind_sorter.go)).
 
-## Templates et Values
+## Templates et Values {#templates-and-values}
 
 Les templates de charts Helm sont écrits dans le [langage de template
 Go](https://golang.org/pkg/text/template/), avec l'ajout d'une cinquantaine de
@@ -647,7 +648,7 @@ Les values pour les templates sont fournies de deux manières :
 Lorsqu'un utilisateur fournit des values personnalisées, ces values remplaceront
 les values du fichier `values.yaml` du chart.
 
-### Fichiers de template
+### Fichiers de template {#template-files}
 
 Les fichiers de template suivent les conventions standard pour écrire des
 templates Go (voir la [documentation du package Go text/template](https://golang.org/pkg/text/template/)
@@ -698,7 +699,7 @@ dicte de paramètres.
 Pour voir de nombreux charts fonctionnels, consultez le [Artifact Hub](https://artifacthub.io/packages/search?kind=0)
 de la CNCF.
 
-### Values prédéfinies
+### Values prédéfinies {#predefined-values}
 
 Les values fournies via un fichier `values.yaml` (ou via le flag `--set`) sont
 accessibles depuis l'objet `.Values` dans un template. Mais il existe d'autres
@@ -732,7 +733,7 @@ accessible dans l'objet `Chart`. Ainsi, `Chart.yaml` ne peut pas être utilisé
 pour passer des données structurées arbitraires dans le template. Le fichier
 values peut être utilisé à cette fin.
 
-### Fichiers values
+### Fichiers values {#values-files}
 
 En considérant le template de la section précédente, un fichier `values.yaml`
 fournissant les values nécessaires ressemblerait à ceci :
@@ -815,7 +816,7 @@ spec:
               value: {{ default "minio" .Values.storage }}
 ```
 
-### Portée, dépendances et values
+### Portée, dépendances et values {#scope-dependencies-and-values}
 
 Les fichiers values peuvent déclarer des values pour le chart de niveau
 supérieur, ainsi que pour tous les charts inclus dans le répertoire `charts/`
@@ -902,7 +903,7 @@ Il n'y a aucun moyen pour un sous-chart d'influencer les values du chart parent.
 De plus, les variables globales des charts parents ont la priorité sur les
 variables globales des sous-charts.
 
-### Fichiers de schéma
+### Fichiers de schéma {#schema-files}
 
 Parfois, un mainteneur de chart peut vouloir définir une structure pour ses
 values. Cela peut être fait en définissant un schéma dans le fichier
@@ -992,7 +993,7 @@ JSON Schema d'un chart contient des références distantes.
 helm install --skip-schema-validation
 ```
 
-### Références
+### Références {#references}
 
 En ce qui concerne l'écriture de templates, values et fichiers de schéma, il
 existe plusieurs références standard qui vous aideront.
@@ -1002,7 +1003,7 @@ existe plusieurs références standard qui vous aideront.
 - [Le format YAML](https://yaml.org/spec/)
 - [JSON Schema](https://json-schema.org/)
 
-## Custom Resource Definitions (CRDs)
+## Custom Resource Definitions (CRDs) {#custom-resource-definitions-crds}
 
 Kubernetes fournit un mécanisme pour déclarer de nouveaux types d'objets
 Kubernetes. En utilisant les CustomResourceDefinitions (CRDs), les développeurs
@@ -1074,7 +1075,7 @@ Helm s'assurera que le type `CronTab` a été installé et est disponible depuis
 le serveur API Kubernetes avant de procéder à l'installation des éléments dans
 `templates/`.
 
-### Limitations des CRDs
+### Limitations des CRDs {#limitations-on-crds}
 
 Contrairement à la plupart des objets dans Kubernetes, les CRDs sont installées
 globalement. Pour cette raison, Helm adopte une approche très prudente dans la
@@ -1092,7 +1093,7 @@ gestion des CRDs. Les CRDs sont soumises aux limitations suivantes :
 Les opérateurs qui souhaitent mettre à niveau ou supprimer des CRDs sont
 encouragés à le faire manuellement et avec beaucoup de précaution.
 
-## Utiliser Helm pour gérer les charts
+## Utiliser Helm pour gérer les charts {#using-helm-to-manage-charts}
 
 L'outil `helm` dispose de plusieurs commandes pour travailler avec les charts.
 
@@ -1119,7 +1120,7 @@ $ helm lint mychart
 No issues found
 ```
 
-## Dépôts de charts
+## Dépôts de charts {#chart-repositories}
 
 Un _dépôt de charts_ est un serveur HTTP qui héberge un ou plusieurs charts
 empaquetés. Bien que `helm` puisse être utilisé pour gérer des répertoires de
@@ -1141,7 +1142,7 @@ dépôt distants. En effet, cela ajouterait des exigences substantielles à un
 serveur implémentant cette fonctionnalité, et augmenterait donc la barrière
 pour mettre en place un dépôt.
 
-## Packs de démarrage de charts
+## Packs de démarrage de charts {#chart-starter-packs}
 
 La commande `helm create` prend une option optionnelle `--starter` qui vous
 permet de spécifier un "chart de démarrage". De plus, l'option starter a un

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
@@ -2,6 +2,7 @@
 title: Hooks de chart
 description: Décrit comment utiliser les hooks de chart.
 sidebar_position: 2
+default_lang_commit: 6bf4b4cb62bb3952a17b68b3cd8b832bcede390c
 ---
 
 Helm fournit un mécanisme de _hook_ permettant aux développeurs de charts

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/index.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Thèmes
 sidebar_position: 3
+default_lang_commit: 32156809d1ef7c7445cabb92c46ffcea328ac6be
 ---
 
 # Guides par thème

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md
@@ -1,6 +1,7 @@
 ---
 title: APIs Kubernetes dépréciées
 description: Explique les APIs Kubernetes dépréciées dans Helm
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Kubernetes est un système basé sur les APIs, et l'API évolue au fil du temps
@@ -36,7 +37,7 @@ les utilisateurs de Helm et les mainteneurs de charts doivent être attentifs au
 versions d'API Kubernetes qui ont été dépréciées et dans quelle version de
 Kubernetes elles seront supprimées.
 
-## Mainteneurs de charts
+## Mainteneurs de charts {#chart-maintainers}
 
 Vous devez auditer vos charts pour vérifier les versions d'API Kubernetes qui
 sont dépréciées ou supprimées dans une version de Kubernetes. Les versions d'API
@@ -51,10 +52,10 @@ apiVersion: apps/v1beta1
 kind: Deployment
 ```
 
-## Utilisateurs de Helm
+## Utilisateurs de Helm {#helm-users}
 
 Vous devez auditer les charts que vous utilisez (de la même manière que les
-[mainteneurs de charts](#mainteneurs-de-charts)) et identifier ceux dont les
+[mainteneurs de charts](#chart-maintainers)) et identifier ceux dont les
 versions d'API sont dépréciées ou supprimées dans une version de Kubernetes.
 Pour les charts identifiés, vous devez vérifier si une version plus récente du
 chart (avec des versions d'API supportées) existe ou mettre à jour le chart
@@ -86,7 +87,7 @@ de vos constatations :
     - Vous devez modifier le manifeste de release stocké dans le cluster pour
       mettre à jour les versions d'API vers des APIs supportées. Consultez
       [Mise à jour des versions d'API d'un manifeste de
-      release](#mise-à-jour-des-versions-dapi-dun-manifeste-de-release) pour
+      release](#updating-api-versions-of-a-release-manifest) pour
       plus de détails
 
 > Remarque : Dans tous les cas de mise à jour d'une release Helm avec des APIs
@@ -118,10 +119,10 @@ Kubernetes supprime une version d'API, la bibliothèque client Go de Kubernetes
 ne peut plus parser les objets dépréciés, et Helm échoue donc lors de l'appel à
 la bibliothèque. Helm ne peut malheureusement pas récupérer de cette situation
 et n'est plus en mesure de gérer une telle release. Consultez [Mise à jour des
-versions d'API d'un manifeste de release](#mise-à-jour-des-versions-dapi-dun-manifeste-de-release)
+versions d'API d'un manifeste de release](#updating-api-versions-of-a-release-manifest)
 pour savoir comment récupérer de ce scénario.
 
-## Mise à jour des versions d'API d'un manifeste de release
+## Mise à jour des versions d'API d'un manifeste de release {#updating-api-versions-of-a-release-manifest}
 
 Le manifeste est une propriété de l'objet release Helm qui est stockée dans le
 champ data d'un Secret (par défaut) ou d'un ConfigMap dans le cluster. Le champ

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/kubernetes_distros.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/kubernetes_distros.md
@@ -2,6 +2,7 @@
 title: Guide des Distributions Kubernetes
 description: Fournit des informations sur l'utilisation de Helm dans des environnements Kubernetes spécifiques.
 sidebar_position: 10
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Helm devrait fonctionner avec toute [version conforme de

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/library_charts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/library_charts.md
@@ -2,6 +2,7 @@
 title: Charts de type Library
 description: Explique les charts de type library et fournit des exemples d'utilisation
 sidebar_position: 4
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Un chart de type library est un type de [chart Helm](/topics/charts.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/permissions_sql_storage_backend.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/permissions_sql_storage_backend.md
@@ -1,6 +1,7 @@
 ---
 title: Gestion des permissions pour le backend de stockage SQL
 description: Découvrez comment configurer les permissions lors de l'utilisation du backend de stockage SQL.
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Ce document explique comment configurer et gérer les permissions lors de

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -2,6 +2,7 @@
 title: Guide des plugins Helm
 description: Présente comment utiliser et créer des plugins pour étendre les fonctionnalités de Helm.
 sidebar_position: 12
+default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 Un plugin Helm est un outil accessible via la CLI `helm`, mais qui ne fait pas partie du code source intégré de Helm.
@@ -10,7 +11,7 @@ Les plugins existants peuvent être trouvés dans la section [associée](/commun
 
 Ce guide explique comment utiliser et créer des plugins.
 
-## Vue d'ensemble
+## Vue d'ensemble {#an-overview}
 
 Les plugins Helm sont des outils complémentaires qui s'intègrent parfaitement à Helm. Ils permettent d'étendre les fonctionnalités de base de Helm, sans nécessiter que chaque nouvelle fonctionnalité soit écrite en Go et ajoutée à l'outil principal.
 
@@ -24,7 +25,7 @@ Les plugins Helm résident dans `$HELM_PLUGINS`. Vous pouvez trouver la valeur a
 
 Le modèle de plugin Helm est partiellement basé sur le modèle de plugin de Git. De ce fait, vous pouvez parfois entendre `helm` désigné comme la couche _porcelaine_, et les plugins comme la _plomberie_. C'est une façon abrégée de suggérer que Helm fournit l'expérience utilisateur et la logique de traitement de haut niveau, tandis que les plugins effectuent le « travail de fond » pour réaliser une action souhaitée.
 
-## Installer un plugin
+## Installer un plugin {#installing-a-plugin}
 
 Les plugins sont installés à l'aide de la commande `$ helm plugin install <path|url>`. Vous pouvez passer un chemin vers un plugin sur votre système de fichiers local ou une URL d'un dépôt VCS distant. La commande `helm plugin install` clone ou copie le plugin situé au chemin/URL donné dans `$HELM_PLUGINS`. Si vous installez depuis un VCS, vous pouvez spécifier la version avec l'argument `--version`.
 
@@ -34,7 +35,7 @@ $ helm plugin install https://github.com/adamreese/helm-env
 
 Si vous avez une distribution tar d'un plugin, extrayez simplement le plugin dans le répertoire `$HELM_PLUGINS`. Vous pouvez également installer des plugins tarball directement depuis une URL en exécutant `helm plugin install https://domain/path/to/plugin.tar.gz`
 
-## Structure de fichiers d'un plugin
+## Structure de fichiers d'un plugin {#the-plugin-file-structure}
 
 À bien des égards, un plugin est similaire à un chart. Chaque plugin possède un répertoire de premier niveau contenant un fichier `plugin.yaml`. D'autres fichiers peuvent être présents, mais seul le fichier `plugin.yaml` est requis.
 
@@ -44,7 +45,7 @@ $HELM_PLUGINS/
       |- plugin.yaml
 ```
 
-## Le fichier plugin.yaml
+## Le fichier plugin.yaml {#the-pluginyaml-file}
 
 Le fichier plugin.yaml est requis pour un plugin. Il contient les champs suivants :
 
@@ -86,7 +87,7 @@ downloaders: # Configure downloaders capability
       - Protocol schema supported
 ```
 
-### Le champ `name`
+### Le champ `name` {#the-name-field}
 
 Le champ `name` est le nom du plugin. Lorsque Helm exécute ce plugin, c'est le nom qu'il utilisera (par exemple, `helm NAME` invoquera ce plugin).
 
@@ -97,15 +98,15 @@ Restrictions sur `name` :
 - `name` ne peut pas dupliquer l'une des commandes de premier niveau existantes de `helm`.
 - `name` doit être limité aux caractères ASCII a-z, A-Z, 0-9, `_` et `-`.
 
-### Le champ `version`
+### Le champ `version` {#the-version-field}
 
 Le champ `version` est la version SemVer 2 du plugin. `usage` et `description` sont tous deux utilisés pour générer le texte d'aide d'une commande.
 
-### Le champ `ignoreFlags`
+### Le champ `ignoreFlags` {#the-ignoreflags-field}
 
 Le paramètre `ignoreFlags` indique à Helm de _ne pas_ transmettre les flags au plugin. Ainsi, si un plugin est appelé avec `helm myplugin --foo` et que `ignoreFlags: true`, alors `--foo` est ignoré silencieusement.
 
-### Le champ `platformCommand`
+### Le champ `platformCommand` {#the-platformcommand-field}
 
 Le champ `platformCommand` configure la commande que le plugin exécutera lorsqu'il sera appelé. Vous ne pouvez pas définir à la fois `platformCommand` et `command`, cela entraînerait une erreur. Les règles suivantes s'appliquent pour déterminer quelle commande utiliser :
 
@@ -117,7 +118,7 @@ Le champ `platformCommand` configure la commande que le plugin exécutera lorsqu
 - Si `platformCommand` n'est pas présent et que la commande dépréciée `command` est présente, elle sera utilisée.
   - Si la commande est vide, Helm se terminera avec une erreur.
 
-### Le champ `platformHooks`
+### Le champ `platformHooks` {#the-platformhooks-field}
 
 Le champ `platformHooks` configure les commandes que le plugin exécutera pour les événements du cycle de vie. Vous ne pouvez pas définir à la fois `platformHooks` et `hooks`, cela entraînerait une erreur. Les règles suivantes s'appliquent pour déterminer quelle commande de hook utiliser :
 
@@ -129,7 +130,7 @@ Le champ `platformHooks` configure les commandes que le plugin exécutera pour l
 - Si `platformHooks` n'est pas présent et que le hook déprécié `hooks` est présent, la commande pour l'événement du cycle de vie sera utilisée.
   - Si la commande est vide, Helm ignorera l'événement.
 
-## Créer un plugin
+## Créer un plugin {#building-a-plugin}
 
 Voici le YAML de plugin pour un plugin simple qui aide à obtenir le nom de la dernière release :
 
@@ -192,7 +193,7 @@ platformHooks:
 
 Les variables d'environnement sont interpolées avant l'exécution du plugin. Le modèle ci-dessus illustre la méthode préférée pour indiquer où se trouve le programme du plugin.
 
-### Commandes de plugin
+### Commandes de plugin {#plugin-commands}
 
 Il existe quelques stratégies pour travailler avec les commandes de plugin :
 
@@ -203,7 +204,7 @@ Il existe quelques stratégies pour travailler avec les commandes de plugin :
 - Helm ne fait aucune supposition sur le langage du plugin. Vous pouvez l'écrire dans le langage de votre choix.
 - Les commandes sont responsables d'implémenter un texte d'aide spécifique pour `-h` et `--help`. Helm utilisera `usage` et `description` pour `helm help` et `helm help myplugin`, mais ne gérera pas `helm myplugin --help`.
 
-### Tester un plugin local
+### Tester un plugin local {#testing-a-local-plugin}
 
 Vous devez d'abord trouver votre chemin `HELM_PLUGINS`. Pour ce faire, exécutez la commande suivante :
 
@@ -219,7 +220,7 @@ Maintenant vous pouvez ajouter un lien symbolique vers la sortie de build de vot
 ln -s ~/GitHub/helm-mapkubeapis ./helm-mapkubeapis
 ```
 
-## Plugins téléchargeurs
+## Plugins téléchargeurs {#downloader-plugins}
 
 Par défaut, Helm est capable de télécharger des charts via HTTP/S. À partir de Helm 2.4.0, les plugins peuvent avoir une capacité spéciale pour télécharger des charts depuis des sources arbitraires.
 
@@ -239,7 +240,7 @@ La commande définie sera invoquée avec le schéma suivant : `command certFile 
 
 La commande de téléchargement supporte également les sous-commandes ou arguments, vous permettant de spécifier par exemple `bin/mydownloader subcommand -d` dans le `plugin.yaml`. Ceci est utile si vous souhaitez utiliser le même exécutable pour la commande principale du plugin et la commande de téléchargement, mais avec une sous-commande différente pour chacune.
 
-## Variables d'environnement
+## Variables d'environnement {#environment-variables}
 
 Lorsque Helm exécute un plugin, il transmet l'environnement externe au plugin et injecte également quelques variables d'environnement supplémentaires.
 
@@ -260,7 +261,7 @@ Les variables suivantes sont garanties d'être définies :
 
 De plus, si un fichier de configuration Kubernetes a été explicitement spécifié, il sera défini comme variable `KUBECONFIG`.
 
-## Note sur l'analyse des flags
+## Note sur l'analyse des flags {#a-note-on-flag-parsing}
 
 Lors de l'exécution d'un plugin, Helm analyse les flags globaux pour son propre usage. Aucun de ces flags n'est transmis au plugin.
 - `--burst-limit` : Converti en `$HELM_BURST_LIMIT`
@@ -282,11 +283,11 @@ Lors de l'exécution d'un plugin, Helm analyse les flags globaux pour son propre
 
 Les plugins _devraient_ afficher un texte d'aide et se terminer pour `-h` et `--help`. Dans tous les autres cas, les plugins peuvent utiliser les flags comme approprié.
 
-## Fournir l'auto-complétion shell
+## Fournir l'auto-complétion shell {#providing-shell-auto-completion}
 
 À partir de Helm 3.2, un plugin peut optionnellement fournir le support de l'auto-complétion shell dans le cadre du mécanisme d'auto-complétion existant de Helm.
 
-### Auto-complétion statique
+### Auto-complétion statique {#static-auto-completion}
 
 Si un plugin fournit ses propres flags et/ou sous-commandes, il peut en informer Helm via un fichier `completion.yaml` situé dans le répertoire racine du plugin. Le fichier `completion.yaml` a la forme suivante :
 
@@ -317,7 +318,7 @@ Notes :
 1. Les flags courts et longs peuvent et doivent être spécifiés. Un flag court n'a pas besoin d'être associé à sa forme longue correspondante, mais les deux formes doivent être listées.
 1. Les flags n'ont pas besoin d'être ordonnés d'une manière particulière, mais doivent être listés au bon endroit dans la hiérarchie des sous-commandes du fichier.
 1. Les flags globaux existants de Helm sont déjà gérés par le mécanisme d'auto-complétion de Helm, les plugins n'ont donc pas besoin de spécifier les flags suivants : `--debug`, `--namespace` ou `-n`, `--kube-context`, et `--kubeconfig`, ou tout autre flag global.
-1. La liste `validArgs` fournit une liste statique des complétions possibles pour le premier paramètre suivant une sous-commande. Il n'est pas toujours possible de fournir une telle liste à l'avance (voir la section [Complétion dynamique](#complétion-dynamique) ci-dessous), auquel cas la section `validArgs` peut être omise.
+1. La liste `validArgs` fournit une liste statique des complétions possibles pour le premier paramètre suivant une sous-commande. Il n'est pas toujours possible de fournir une telle liste à l'avance (voir la section [Complétion dynamique](#dynamic-completion) ci-dessous), auquel cas la section `validArgs` peut être omise.
 
 Le fichier `completion.yaml` est entièrement optionnel. S'il n'est pas fourni, Helm ne fournira simplement pas d'auto-complétion shell pour le plugin (sauf si la [Complétion dynamique](#complétion-dynamique) est supportée par le plugin). De plus, l'ajout d'un fichier `completion.yaml` est rétro-compatible et n'impactera pas le comportement du plugin lors de l'utilisation de versions plus anciennes de Helm.
 
@@ -368,7 +369,7 @@ commands:
     - dry-run
 ```
 
-### Complétion dynamique
+### Complétion dynamique {#dynamic-completion}
 
 Également à partir de Helm 3.2, les plugins peuvent fournir leur propre auto-complétion shell dynamique. L'auto-complétion shell dynamique est la complétion des valeurs de paramètres ou de flags qui ne peuvent pas être définies à l'avance. Par exemple, la complétion des noms des releases Helm actuellement disponibles sur le cluster.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/provenance.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/provenance.md
@@ -2,6 +2,7 @@
 title: Provenance et intégrité dans Helm
 description: Décrit comment vérifier l'intégrité et l'origine d'un Chart.
 sidebar_position: 5
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Helm dispose d'outils de provenance qui aident les utilisateurs de charts à

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/rbac.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/rbac.md
@@ -2,6 +2,7 @@
 title: Contrôle d'accès basé sur les rôles
 description: Explique comment Helm interagit avec le contrôle d'accès basé sur les rôles (RBAC) de Kubernetes.
 sidebar_position: 11
+default_lang_commit: 07caa4dd6e58a47e79ac2ec7949e57157f1a2b2a
 ---
 
 Dans Kubernetes, attribuer des rôles à un utilisateur ou à un compte de service

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/registries.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/registries.md
@@ -2,6 +2,7 @@
 title: Utiliser des registres basés sur OCI
 description: Décrit comment utiliser OCI pour la distribution de charts.
 sidebar_position: 7
+default_lang_commit: 2e15490c82d246093e11e418a7c23907a4afa89e
 ---
 
 À partir de Helm 3, vous pouvez utiliser des registres de conteneurs compatibles [OCI](https://www.opencontainers.org/) pour stocker et partager des packages de charts. À partir de Helm v3.8.0, le support OCI est activé par défaut.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/v2_v3_migration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/v2_v3_migration.md
@@ -2,6 +2,7 @@
 title: Migration de Helm v2 vers v3
 description: Apprenez comment migrer Helm v2 vers v3.
 sidebar_position: 13
+default_lang_commit: f1c342d7bbd8fca5494262a93699b27012859e24
 ---
 
 Ce guide explique comment migrer de Helm v2 vers v3. Helm v2 doit être installé

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
@@ -1,6 +1,7 @@
 ---
 title: "Politique de Prise en Charge des Versions Helm"
 description: "Décrit la politique de publication des correctifs de Helm ainsi que le décalage de version maximal pris en charge entre Helm et Kubernetes."
+default_lang_commit: cae045901bf4c67e0bc19063ec893782f60a52ea
 ---
 
 Ce document décrit le décalage de version maximal pris en charge entre Helm et

--- a/versioned_docs/version-3/chart_best_practices/rbac.md
+++ b/versioned_docs/version-3/chart_best_practices/rbac.md
@@ -59,7 +59,8 @@ controls themselves can set this value to `false` (in which case see below).
 `serviceAccount.name` should be set to the name of the ServiceAccount to be used
 by access-controlled resources created by the chart.
 
-- If `serviceAccount.create` is true, then a ServiceAccount with this name should be created.- If the name is not set, then a name is generated using the `fullname` template.
+- If `serviceAccount.create` is true, then a ServiceAccount with this name should be created.
+- If the name is not set, then a name is generated using the `fullname` template.
 - If `serviceAccount.create` is false, then it should not be created, but it should
 still be associated with the same resources so that manually-created RBAC
 resources created later that reference it will function correctly.

--- a/versioned_docs/version-3/chart_best_practices/rbac.md
+++ b/versioned_docs/version-3/chart_best_practices/rbac.md
@@ -57,13 +57,13 @@ controls themselves can set this value to `false` (in which case see below).
 ## Using RBAC Resources
 
 `serviceAccount.name` should be set to the name of the ServiceAccount to be used
-by access-controlled resources created by the chart.  If `serviceAccount.create`
-is true, then a ServiceAccount with this name should be created.  If the name is
-not set, then a name is generated using the `fullname` template, If
-`serviceAccount.create` is false, then it should not be created, but it should
+by access-controlled resources created by the chart.
+
+- If `serviceAccount.create` is true, then a ServiceAccount with this name should be created.- If the name is not set, then a name is generated using the `fullname` template.
+- If `serviceAccount.create` is false, then it should not be created, but it should
 still be associated with the same resources so that manually-created RBAC
-resources created later that reference it will function correctly.  If
-`serviceAccount.create` is false and the name is not specified, then the default
+resources created later that reference it will function correctly.
+- If `serviceAccount.create` is false and the name is not specified, then the default
 ServiceAccount is used.
 
 The following helper template should be used for the ServiceAccount.

--- a/versioned_docs/version-3/index.mdx
+++ b/versioned_docs/version-3/index.mdx
@@ -2,6 +2,7 @@
 title: Docs Home
 description: Everything you need to know about how the documentation is organized.
 sidebar_position: 1
+default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 # Welcome


### PR DESCRIPTION
Follow up to https://github.com/helm/helm-www/pull/2156

This PR adds the `default_lang_commit` field to the front matter of all the translated files for the `fr` locale.

To test, run `npm run check:i18n-drift -- --locale fr` and see `Untracked: 0`:
```
Locales checked: fr
Localized Markdown files checked: 115
In sync: 106
Drifted: 8
Untracked: 0
Source missing: 1
Invalid commit: 0

drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/conventions.md
  source: versioned_docs/version-3/chart_best_practices/conventions.md (latest source commit: cd6112565cf10522d4f1bd0928165cb5a91922c5)
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md
  source: versioned_docs/version-3/chart_best_practices/rbac.md (latest source commit: 2878e04eb5108db1119546dac5bd6458d6af58e6)
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/debugging.md
  source: versioned_docs/version-3/chart_template_guide/debugging.md (latest source commit: a0c2d06add5dfa2d547b8628f6daf6c68c7ea499)
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/faq/troubleshooting.md
  source: versioned_docs/version-3/faq/troubleshooting.md (latest source commit: fbc65567d1bdb5fd618454c232bd82358adf4ef3)
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/index.mdx
  source: versioned_docs/version-3/index.mdx (latest source commit: 2878e04eb5108db1119546dac5bd6458d6af58e6)
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/intro/using_helm.md
  source: versioned_docs/version-3/intro/using_helm.md (latest source commit: 5b891dc41e2912a6ffed8d478a1bd371e5921d4b)
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/topics/advanced.md
  source: versioned_docs/version-3/topics/advanced.md (latest source commit: fec429357937b35ef9cefe26675dfc61db4049f4)
source-missing: i18n/fr/docusaurus-plugin-content-docs/version-3/topics/architecture.md
  source: versioned_docs/version-3/topics/architecture.md
drifted: i18n/fr/docusaurus-plugin-content-docs/version-3/topics/version_skew.md
  source: versioned_docs/version-3/topics/version_skew.md (latest source commit: d9bd24cdc719cd5ddef925552a7049cfbd6f469e)
```
## Summary of changes

- Most pages were able to be pinned to the latest english language source commit
- There were 8 pages pinned to earlier commits from the english language source commit
- I also manually updates some pages to bring them up to date with the latest english language version (where the changes were minimal like a missing bullet point or link):
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md`: Added English language anchor ids
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md`:  Added English language anchor ids
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/chart_best_practices/rbac.md`: Updated the English language source content to change the paragraph into bullet points instead (this matches the french version and is better formatting for the content). Then, I updated the translation of the third bullet point in French to include the missing “that reference it” part
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/helm/helm_rollback.md`: Removed carets wrapped around the RELEASE word on the French version
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/index.mdx`: Updated a mismatched link in the French version
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts.md`: Fixed the wikipedia link in french version and added english language anchor ids
  - `i18n/fr/docusaurus-plugin-content-docs/version-3/topics/kubernetes_apis.md`: Added English language anchor ids