### PR TITLE
fix(i18n): remove source tracking marker

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/version-3/index.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/index.mdx
@@ -2,7 +2,7 @@
 title: "Dokumentation"
 description: "Alles Wissenswerte zur Organisation der Dokumentation."
 sidebar_position: 1
-default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
+default_lang_commit: 2108a5269925a2e05a87838ab39e381ee43f3ed0
 ---
 
 # Willkommen

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/index.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/index.mdx
@@ -3,7 +3,7 @@ title: "Docs Inicio"
 description: "Todo lo que necesita saber sobre cómo está organizada la documentación."
 sidebar_position: 1
 hide_table_of_contents: true
-default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
+default_lang_commit: 2108a5269925a2e05a87838ab39e381ee43f3ed0
 ---
 
 # Bienvenidos
@@ -32,4 +32,4 @@ organizado lo ayudará a saber dónde buscar ciertas cosas:
 
 import DocCardList from '@theme/DocCardList';
 
-<DocCardList />  
+<DocCardList />

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/index.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accueil Documentations"
 description: "Tout ce que vous devez savoir sur l'organisation de la documentation."
-default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
+default_lang_commit: 2108a5269925a2e05a87838ab39e381ee43f3ed0
 ---
 
 # Bienvenue

--- a/versioned_docs/version-3/index.mdx
+++ b/versioned_docs/version-3/index.mdx
@@ -2,7 +2,6 @@
 title: Docs Home
 description: Everything you need to know about how the documentation is organized.
 sidebar_position: 1
-default_lang_commit: 9f8c5e5d797d2c708ffc948c00f56aead761013a
 ---
 
 # Welcome


### PR DESCRIPTION
## Summary

- remove the stray `default_lang_commit` from the English version 3 home page
- re-pin the German, Spanish, and French translations to the source correction
- normalize the touched files' trailing whitespace and final newlines

## Validation

- confirmed the three translated home pages report `in-sync`
- `yarn build --locale en`

Closes #2219