### PR TITLE
fix: restore French headings in function_list.md while keeping English anchor IDs (#2218)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/function_list.md
@@ -8,26 +8,26 @@ default_lang_commit: 029d283b39851e790dd1756201af6aadb521ba2a
 Helm inclut de nombreuses fonctions de template que vous pouvez utiliser dans vos templates.
 Elles sont répertoriées ici et classées dans les catégories suivantes :
 
-* [Cryptographic and Security](#cryptographic-and-security-functions)
+* [Cryptographie et sécurité](#cryptographic-and-security-functions)
 * [Date](#date-functions)
-* [Dictionaries](#dictionaries-and-dict-functions)
-* [Encoding](#encoding-functions)
-* [File Path](#file-path-functions)
-* [Kubernetes and Chart](#kubernetes-and-chart-functions)
-* [Logic and Flow Control](#logic-and-flow-control-functions)
-* [Lists](#lists-and-list-functions)
-* [Math](#math-functions)
-* [Float Math](#float-math-functions)
-* [Network](#network-functions)
-* [Reflection](#reflection-functions)
-* [Regular Expressions](#regular-expressions)
-* [Semantic Versions](#semantic-version-functions)
-* [String](#string-functions)
-* [Type Conversion](#type-conversion-functions)
+* [Dictionnaires](#dictionaries-and-dict-functions)
+* [Encodage](#encoding-functions)
+* [Chemin de fichier](#file-path-functions)
+* [Kubernetes et Chart](#kubernetes-and-chart-functions)
+* [Logique et contrôle de flux](#logic-and-flow-control-functions)
+* [Listes](#lists-and-list-functions)
+* [Mathématiques](#math-functions)
+* [Mathématiques flottantes](#float-math-functions)
+* [Réseau](#network-functions)
+* [Réflexion](#reflection-functions)
+* [Expressions régulières](#regular-expressions)
+* [Versions sémantiques](#semantic-version-functions)
+* [Chaînes de caractères](#string-functions)
+* [Conversion de type](#type-conversion-functions)
 * [URL](#url-functions)
 * [UUID](#uuid-functions)
 
-## Logic and Flow Control Functions {#logic-and-flow-control-functions}
+## Logique et contrôle de flux {#logic-and-flow-control-functions}
 
 Helm inclut de nombreuses fonctions de logique et de contrôle de flux, notamment [and](#and),
 [coalesce](#coalesce), [default](#default), [empty](#empty), [eq](#eq),
@@ -224,7 +224,7 @@ false | ternary "foo" "bar"
 
 L'exemple ci-dessus retourne `"bar"`.
 
-## String Functions {#string-functions}
+## Chaînes de caractères {#string-functions}
 
 Helm inclut les fonctions de chaînes suivantes : [abbrev](#abbrev),
 [abbrevboth](#abbrevboth), [camelcase](#camelcase), [cat](#cat),
@@ -680,7 +680,7 @@ shuffle "hello"
 
 L'exemple ci-dessus mélangera les lettres dans `hello`, produisant peut-être `oelhl`.
 
-## Type Conversion Functions {#type-conversion-functions}
+## Conversion de type {#type-conversion-functions}
 
 Les fonctions de conversion de types suivantes sont fournies par Helm :
 
@@ -871,7 +871,7 @@ greeting: |
 ```
 
 
-## Regular Expressions {#regular-expressions}
+## Expressions régulières {#regular-expressions}
 
 Helm inclut les fonctions d'expressions régulières suivantes : [regexFind
 (mustRegexFind)](#regexfindall-mustregexfindall), [regexFindAll
@@ -973,7 +973,7 @@ L'exemple ci-dessus produit `[pi a]`
 `regexSplit` provoque un panic en cas de problème et `mustRegexSplit` retourne une erreur
 au moteur de template en cas de problème.
 
-## Cryptographic and Security Functions {#cryptographic-and-security-functions}
+## Cryptographie et sécurité {#cryptographic-and-security-functions}
 
 Helm fournit des fonctions cryptographiques avancées. Elles incluent
 [adler32sum](#adler32sum), [buildCustomCert](#buildcustomcert),
@@ -1160,7 +1160,7 @@ et retourne le texte déchiffré.
 "30tEfhuJSVRhpG97XCuWgz2okj7L8vQ1s6V9zVUPeDQ=" | decryptAES "secretkey"
 ```
 
-## Date Functions {#date-functions}
+## Fonctions de date {#date-functions}
 
 Helm inclut les fonctions de date suivantes que vous pouvez utiliser dans les templates :
 [ago](#ago), [date](#date), [dateInZone](#dateinzone), [dateModify
@@ -1296,7 +1296,7 @@ un pipe). L'exemple ci-dessous convertit "2017-12-31" en "31/12/2017".
 toDate "2006-01-02" "2017-12-31" | date "02/01/2006"
 ```
 
-## Dictionaries and Dict Functions {#dictionaries-and-dict-functions}
+## Dictionnaires et fonctions dict {#dictionaries-and-dict-functions}
 
 Helm fournit un type de stockage clé/valeur appelé `dict` (abréviation de « dictionary »,
 comme en Python). Un `dict` est un type _non ordonné_.
@@ -1580,14 +1580,14 @@ Un `dict` est implémenté en Go comme un `map[string]interface{}`. Les dévelop
 passer des valeurs `map[string]interface{}` dans le contexte pour les rendre disponibles aux
 templates en tant que `dict`s.
 
-## Encoding Functions {#encoding-functions}
+## Fonctions d'encodage {#encoding-functions}
 
 Helm dispose des fonctions d'encodage et de décodage suivantes :
 
 - `b64enc`/`b64dec` : Encoder ou décoder avec Base64
 - `b32enc`/`b32dec` : Encoder ou décoder avec Base32
 
-## Lists and List Functions {#lists-and-list-functions}
+## Listes et fonctions de liste {#lists-and-list-functions}
 
 Helm fournit un type `list` simple qui peut contenir des listes séquentielles arbitraires
 de données. C'est similaire aux tableaux ou aux slices, mais les listes sont conçues pour être utilisées
@@ -1829,7 +1829,7 @@ chunk 3 (list 1 2 3 4 5 6 7 8)
 
 Ceci produit une liste de listes `[ [ 1 2 3 ] [ 4 5 6 ] [ 7 8 ] ]`.
 
-## Math Functions {#math-functions}
+## Fonctions mathématiques {#math-functions}
 
 Toutes les fonctions mathématiques opèrent sur des valeurs `int64` sauf indication contraire.
 
@@ -1893,7 +1893,7 @@ Retourne la longueur de l'argument en tant qu'entier.
 len .Arg
 ```
 
-## Float Math Functions {#float-math-functions}
+## Fonctions mathématiques flottantes {#float-math-functions}
 
 Toutes les fonctions mathématiques opèrent sur des valeurs `float64`.
 
@@ -1980,7 +1980,7 @@ après la virgule décimale.
 
 `round 123.555555 3` retournera `123.556`.
 
-## Network Functions {#network-functions}
+## Fonctions réseau {#network-functions}
 
 Helm a une seule fonction réseau, `getHostByName`.
 
@@ -1990,7 +1990,7 @@ La fonction `getHostByName` reçoit un nom de domaine et retourne l'adresse IP.
 
 Cette fonction nécessite l'option `--enable-dns` à passer sur la ligne de commande helm.
 
-## File Path Functions {#file-path-functions}
+## Fonctions de chemin de fichier {#file-path-functions}
 
 Bien que les fonctions de template Helm ne donnent pas accès au système de fichiers, elles fournissent
 des fonctions pour travailler avec des chaînes qui suivent les conventions de chemins de fichiers.
@@ -2036,7 +2036,7 @@ L'exemple ci-dessus retourne `.bar`.
 
 Pour vérifier si un chemin de fichier est absolu, utilisez `isAbs`.
 
-## Reflection Functions {#reflection-functions}
+## Fonctions de réflexion {#reflection-functions}
 
 Helm fournit des outils de réflexion rudimentaires. Ceux-ci aident les développeurs de templates avancés
 à comprendre les informations de type Go sous-jacentes pour une valeur particulière.
@@ -2092,7 +2092,7 @@ deepEqual (list 1 2 3) (list 1 2 3)
 
 L'exemple ci-dessus retournera `true`.
 
-## Semantic Version Functions {#semantic-version-functions}
+## Fonctions de version sémantique {#semantic-version-functions}
 
 Certains schémas de version sont facilement analysables et comparables. Helm fournit des
 fonctions pour travailler avec les versions [SemVer 2](http://semver.org). Celles-ci incluent
@@ -2247,7 +2247,7 @@ changement majeur casse l'API. Par exemple,
 - `^0.0` est équivalent à `>=0.0.0 <0.1.0`
 - `^0` est équivalent à `>=0.0.0 <1.0.0`
 
-## URL Functions {#url-functions}
+## Fonctions URL {#url-functions}
 
 Helm inclut les fonctions [urlParse](#urlparse), [urlJoin](#urljoin), et
 [urlquery](#urlquery) vous permettant de travailler avec les parties d'URL.
@@ -2297,7 +2297,7 @@ adaptée à l'intégration dans la partie requête d'une URL.
 $var := urlquery "string for query"
 ```
 
-## UUID Functions {#uuid-functions}
+## Fonctions UUID {#uuid-functions}
 
 Helm peut générer des UUID v4 universellement uniques.
 
@@ -2307,7 +2307,7 @@ uuidv4
 
 L'exemple ci-dessus retourne un nouvel UUID de type v4 (généré aléatoirement).
 
-## Kubernetes and Chart Functions {#kubernetes-and-chart-functions}
+## Fonctions Kubernetes et Chart {#kubernetes-and-chart-functions}
 
 Helm inclut des fonctions pour travailler avec Kubernetes, notamment
 [.Capabilities.APIVersions.Has](#capabilitiesapiversionshas),


### PR DESCRIPTION
## Summary
Restores French section headings and TOC entries in the French localization of function_list.md while keeping the English anchor IDs.

## Problem
PR #2216 added anchor IDs to headings but accidentally changed all 18 section headings and 18 TOC entries from French to English. The page body remained French, creating an inconsistent mix of English headings over French prose.

## Changes
- Restored all 18 TOC entries to French (e.g. 'String' -> 'Chaînes de caractères')
- Restored all 18 section headings to French (e.g. 'String Functions' -> 'Chaînes de caractères')
- Kept the {#english-id} anchors as-is for cross-referencing

Closes #2218