### PR TITLE
fix(i18n/fr): retarget missed French heading anchors

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/chart_template_guide/accessing_files.md
@@ -142,7 +142,7 @@ Il est très courant de vouloir placer le contenu de fichiers dans des ConfigMap
 
 Pour une meilleure organisation, il est particulièrement utile d'utiliser ces méthodes en conjonction avec la méthode `Glob`.
 
-Avec la structure de répertoires de l'exemple [Glob](#motifs-glob) ci-dessus :
+Avec la structure de répertoires de l'exemple [Glob](#glob-patterns) ci-dessus :
 
 ```yaml
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -493,7 +493,7 @@ Veuillez noter que la clé parente `data` n'est pas contenue dans les values
 finales du parent. Si vous avez besoin de spécifier la clé parente, utilisez le
 format 'child-parent'.
 
-##### Utiliser le format child-parent
+##### Utiliser le format child-parent {#using-the-child-parent-format}
 
 Pour accéder aux values qui ne sont pas contenues dans la clé `exports` des
 values du chart enfant, vous devrez spécifier la clé source des values à

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -320,7 +320,7 @@ Notes :
 1. Les flags globaux existants de Helm sont déjà gérés par le mécanisme d'auto-complétion de Helm, les plugins n'ont donc pas besoin de spécifier les flags suivants : `--debug`, `--namespace` ou `-n`, `--kube-context`, et `--kubeconfig`, ou tout autre flag global.
 1. La liste `validArgs` fournit une liste statique des complétions possibles pour le premier paramètre suivant une sous-commande. Il n'est pas toujours possible de fournir une telle liste à l'avance (voir la section [Complétion dynamique](#dynamic-completion) ci-dessous), auquel cas la section `validArgs` peut être omise.
 
-Le fichier `completion.yaml` est entièrement optionnel. S'il n'est pas fourni, Helm ne fournira simplement pas d'auto-complétion shell pour le plugin (sauf si la [Complétion dynamique](#complétion-dynamique) est supportée par le plugin). De plus, l'ajout d'un fichier `completion.yaml` est rétro-compatible et n'impactera pas le comportement du plugin lors de l'utilisation de versions plus anciennes de Helm.
+Le fichier `completion.yaml` est entièrement optionnel. S'il n'est pas fourni, Helm ne fournira simplement pas d'auto-complétion shell pour le plugin (sauf si la [Complétion dynamique](#dynamic-completion) est supportée par le plugin). De plus, l'ajout d'un fichier `completion.yaml` est rétro-compatible et n'impactera pas le comportement du plugin lors de l'utilisation de versions plus anciennes de Helm.
 
 Par exemple, pour le plugin [`fullstatus`](https://github.com/marckhouzam/helm-fullstatus) qui n'a pas de sous-commandes mais accepte les mêmes flags que la commande `helm status`, le fichier `completion.yaml` est :
 
@@ -406,7 +406,7 @@ Le vrai script du plugin `fullstatus` (`status.sh`) doit alors rechercher le fla
 ### Astuces et conseils
 
 1. Le shell filtrera automatiquement les choix de complétion qui ne correspondent pas à l'entrée de l'utilisateur. Un plugin peut donc retourner toutes les complétions pertinentes sans supprimer celles qui ne correspondent pas à l'entrée de l'utilisateur. Par exemple, si la ligne de commande est `helm fullstatus ngin<TAB>`, le script `plugin.complete` peut afficher *tous* les noms de release (du namespace `default`), pas seulement ceux commençant par `ngin` ; le shell ne conservera que ceux commençant par `ngin`.
-1. Pour simplifier le support de la complétion dynamique, surtout si vous avez un plugin complexe, vous pouvez faire en sorte que votre script `plugin.complete` appelle votre script principal du plugin et demande les choix de complétion. Voir la section [Complétion dynamique](#complétion-dynamique) ci-dessus pour un exemple.
+1. Pour simplifier le support de la complétion dynamique, surtout si vous avez un plugin complexe, vous pouvez faire en sorte que votre script `plugin.complete` appelle votre script principal du plugin et demande les choix de complétion. Voir la section [Complétion dynamique](#dynamic-completion) ci-dessus pour un exemple.
 1. Pour déboguer la complétion dynamique et le fichier `plugin.complete`, vous pouvez exécuter ce qui suit pour voir les résultats de complétion :
     - `helm __complete <pluginName> <arguments to complete>`. Par exemple :
     - `helm __complete fullstatus --output js<ENTER>`,


### PR DESCRIPTION
Fixes #2217

## Summary

PR #2216 added English `{#anchor-id}` suffixes to French headings, but four in-page links were missed (or pointed at an ID that was never added). Those hashes render as dead links in the French v3 docs.

This change retargets the three stale French slugs to the English IDs from #2216, and adds the missing `{#using-the-child-parent-format}` ID on the child-parent heading (the maintainer’s preferred option in the issue). Scope is limited to those four broken links.

## Changes Made

- `i18n/fr/.../chart_template_guide/accessing_files.md`: `[Glob](#motifs-glob)` → `[Glob](#glob-patterns)` (heading is `## Motifs glob {#glob-patterns}`)
- `i18n/fr/.../topics/plugins.md`: two `[Complétion dynamique](#complétion-dynamique)` links → `#dynamic-completion` (heading is `### Complétion dynamique {#dynamic-completion}`)
- `i18n/fr/.../topics/charts.md`: add `{#using-the-child-parent-format}` to `##### Utiliser le format child-parent` so the existing `#using-the-child-parent-format` link resolves

## Related Issue

- https://github.com/helm/helm-www/issues/2217

## Testing Steps

1. `yarn build --locale fr --no-minify` then `yarn serve`
2. Open `/docs/v3/chart_template_guide/accessing_files/` — the in-body “Glob” link should jump to **Motifs glob**
3. Open `/docs/v3/topics/plugins/` — both “Complétion dynamique” links should jump to that heading
4. Open `/docs/v3/topics/charts/` — the “child-parent” link should jump to **Utiliser le format child-parent**