### PR TITLE
fix(docs): en-locale(changed a install.mdx link to the current quick…

### DIFF
--- a/docs/intro/install.mdx
+++ b/docs/intro/install.mdx
@@ -26,8 +26,7 @@ and installed.
 1. Find the `helm` binary in the unpacked directory, and move it to its desired
    destination (`mv linux-amd64/helm /usr/local/bin/helm`)
 
-From there, you should be able to run the client and [add the stable
-chart repository](/intro/quickstart.md#initialize-a-helm-chart-repository):
+From there, you should be able to run the client and [find charts to install](/intro/quickstart.md#find-charts-to-install):
 `helm help`.
 
 **Note:** Helm automated tests are performed for Linux AMD64 only during
@@ -297,5 +296,4 @@ This document covers additional cases for those who want to do more
 sophisticated things with Helm.
 
 Once you have the Helm Client successfully installed, you can move on to using
-Helm to manage charts and [add the stable
-chart repository](/intro/quickstart.md#initialize-a-helm-chart-repository).
+Helm to manage charts and [find charts to install](/intro/quickstart.md#find-charts-to-install).


### PR DESCRIPTION
The Helm 4 quickstart restructure removed 'Initialize a Helm Chart Repository' section but `install.mdx` still linked to it in two places. Changed it to 'Find Charts to Install'. This clears the broken-anchor warning in the `en` locale build.

Refs #2220