### PR TITLE
fix(i18n/ko): fix ko-locale broken anchors

### DIFF
--- a/i18n/ko/docusaurus-plugin-content-docs/current/plugins/overview.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/plugins/overview.md
@@ -71,7 +71,7 @@ example-plugin
 - [서브프로세스 런타임](#plugin-runtimes)에는 선택적으로 (노드, 파이썬, Go, 그 외 등등) 플러그인 코드가 담긴 한 가지 이상의 실행 파일을 넣을 수 있습니다. 이 런타임에서는 `plugin.yaml` [런타임 설정](#runtime-configuration)의 `platformCommand` 필드를 통해 사용자의 PATH에서 이미 사용 가능한 실행 파일을 직접 호출할 수도 있습니다.
 - [Wasm 런타임](#plugin-runtimes)의 경우 `.wasm` 파일을 포함해야 합니다. 이는 Wasm으로 컴파일된 플러그인 코드입니다(Node, Python, Go 등 가능).
 
-## Plugin.yaml {#plugin-yaml}
+## Plugin.yaml {#pluginyaml}
 
 `plugin.yaml` 파일은 플러그인에 필수 요소입니다. 이 파일은 플러그인에 관한 메타데이터와 구성을 담은 YAML 파일입니다.
 

--- a/i18n/ko/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -208,7 +208,7 @@ Helm 차트를 서비스하도록 일반 웹 서버를 설정하려면
 웹 루트에 `charts/` 디렉토리가 있는지 확인하고 인덱스 파일과
 차트를 해당 폴더 안에 넣자.
 
-### ChartMuseum 저장소 서버
+### ChartMuseum 저장소 서버 {#chartmuseum-repository-server}
 
 ChartMuseum은 Go 언어로 작성된 오픈소스 Helm 차트 저장소 서버로,
 [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon

--- a/i18n/ko/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -264,7 +264,7 @@ helm env
 ln -s ~/GitHub/helm-mapkubeapis ./helm-mapkubeapis
 ```
 
-## 다운로더 플러그인
+## 다운로더 플러그인 {#downloader-plugins}
 
 기본적으로 Helm은 HTTP/S를 사용하여 차트를 가져올 수 있다.
 Helm 2.4.0부터 플러그인은 임의의 소스에서 차트를 다운로드하는

--- a/i18n/ko/docusaurus-plugin-content-docs/version-3/topics/registries.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/version-3/topics/registries.md
@@ -115,7 +115,7 @@ Digest: sha256:ec5f08ee7be8b557cd1fc5ae1a0ac985e8538da7c93f51a51eff4b277509a723
 
 [출처 파일](/topics/provenance.md) (`.prov`)을 생성했고, 이 파일이 차트 `.tgz` 파일 옆에 있으면 `push` 시 자동으로 레지스트리에 업로드된다. 이 경우 [Helm 차트 매니페스트](#helm-차트-매니페스트)에 추가 레이어가 생성된다.
 
-[helm-push 플러그인](https://github.com/chartmuseum/helm-push) (차트를 [ChartMuseum](/topics/chart_repository.md#chartmuseum-리포지토리-서버)에 업로드하기 위한) 사용자는 이 플러그인이 새로운 내장 `push`와 충돌하기 때문에 문제가 발생할 수 있다. v0.10.0 버전부터 플러그인은 `cm-push`로 이름이 변경되었다.
+[helm-push 플러그인](https://github.com/chartmuseum/helm-push) (차트를 [ChartMuseum](/topics/chart_repository.md#chartmuseum-repository-server)에 업로드하기 위한) 사용자는 이 플러그인이 새로운 내장 `push`와 충돌하기 때문에 문제가 발생할 수 있다. v0.10.0 버전부터 플러그인은 `cm-push`로 이름이 변경되었다.
 
 ### 기타 하위 명령
 


### PR DESCRIPTION
This PR fixes the remaining broken anchors in the `ko` locale. 
| File | Change |
|---|---|
| `i18n/ko/docusaurus-plugin-content-docs/version-3/topics/plugins.md` | Added `{#downloader-plugins}` to the `다운로더 플러그인` heading (English ID missing, linked from `chart_best_practices/dependencies.md`) |
| `i18n/ko/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md` | Added `{#chartmuseum-repository-server}` to the `ChartMuseum 저장소 서버` heading |
| `i18n/ko/docusaurus-plugin-content-docs/version-3/topics/registries.md` | Updated link from the Korean slug `#chartmuseum-리포지토리-서버` to `#chartmuseum-repository-server` |
| `i18n/ko/docusaurus-plugin-content-docs/current/plugins/overview.md` | Corrected heading ID `{#plugin-yaml}` → `{#pluginyaml}` to match the English auto-slug; the in-page links already use `#pluginyaml` |

This follows the convention from #2217/#2225: translated headings get the English source anchor ID, links point to the English ID.

**Verification:**  
`yarn build --locale ko` 

Refs #2220.
