### PR TITLE
fix(i18n/community): fix pt locale broken anchors

### DIFF
--- a/i18n/pt/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/pt/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -51,7 +51,7 @@ esteja a menos de 7 dias.
 Ao mesmo tempo em que um release é publicado, a data do próximo release secundário
 será anunciada e publicada na página principal do Helm.
 
-## Releases Principais
+## Releases Principais {#major-releases}
 
 Os releases principais contêm mudanças incompatíveis. Tais releases são raros,
 mas às vezes são necessários para permitir que o Helm continue a evoluir em

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -92,7 +92,7 @@ O Helm 3 introduziu um Go SDK completamente reestruturado para uma melhor
 experiência ao construir software e ferramentas que aproveitam o Helm.
 Documentação completa pode ser encontrada na [Seção Go SDK](/sdk/gosdk.md).
 
-## Backends de armazenamento
+## Backends de armazenamento {#storage-backends}
 
 O Helm 3 mudou o armazenamento padrão de informações de release para Secrets no
 namespace da release. O Helm 2 armazenava por padrão informações de release como

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -215,7 +215,7 @@ Por exemplo, se você quiser servir seus charts a partir de `$WEBROOT/charts`,
 certifique-se de que existe um diretório `charts/` na raiz web, e coloque o
 arquivo de índice e os charts dentro dessa pasta.
 
-### Servidor de Repositório ChartMuseum
+### Servidor de Repositório ChartMuseum {#chartmuseum-repository-server}
 
 O ChartMuseum é um servidor de Repositório de Charts Helm de código aberto
 escrito em Go (Golang), com suporte para backends de armazenamento em nuvem,

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -45,7 +45,7 @@ wordpress/
 O Helm reserva o uso dos diretórios `charts/`, `crds/` e `templates/`, e dos
 nomes de arquivos listados. Outros arquivos serão deixados como estão.
 
-## O Arquivo Chart.yaml
+## O Arquivo Chart.yaml {#the-chartyaml-file}
 
 O arquivo `Chart.yaml` é obrigatório para um chart. Ele contém os seguintes
 campos:
@@ -893,7 +893,7 @@ Não há como um subchart influenciar os values do chart pai.
 Além disso, variáveis globais de charts pais têm precedência sobre as variáveis
 globais de subcharts.
 
-### Arquivos de Schema
+### Arquivos de Schema {#schema-files}
 
 Às vezes, um mantenedor de chart pode querer definir uma estrutura em seus
 values. Isso pode ser feito definindo um schema no arquivo `values.schema.json`.

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
@@ -186,7 +186,7 @@ Pesos de hook podem ser números positivos ou negativos, mas devem ser
 representados como strings. Quando o Helm inicia o ciclo de execução de hooks de
 um tipo particular, ele ordenará esses hooks em ordem crescente.
 
-### Políticas de exclusão de hook
+### Políticas de exclusão de hook {#hook-deletion-policies}
 
 É possível definir políticas que determinam quando deletar os recursos de hook
 correspondentes. Políticas de exclusão de hook são definidas usando a seguinte

--- a/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -276,7 +276,7 @@ Neste exemplo, fizemos isso para o `mapkubeapis`.
 ln -s ~/GitHub/helm-mapkubeapis ./helm-mapkubeapis
 ```
 
-## Plugins de Download
+## Plugins de Download {#downloader-plugins}
 
 Por padrão, o Helm pode baixar Charts usando HTTP/S. A partir do Helm 2.4.0,
 plugins podem ter uma capacidade especial de baixar Charts de fontes


### PR DESCRIPTION
This PR fixes the broken anchors in the `pt` locale. 

All seven broken links already target English anchor IDs; the translated headings were missing the explicit IDs. Added `{#english-source-slug}` to each.

| File | Heading | ID added |
|---|---|---|
| `topics/plugins.md` | Plugins de Download | `downloader-plugins` |
| `topics/charts.md` | O Arquivo Chart.yaml | `the-chartyaml-file` |
| `topics/charts.md` | Arquivos de Schema | `schema-files` |
| `topics/advanced.md` | Backends de armazenamento | `storage-backends` |
| `topics/charts_hooks.md` | Políticas de exclusão de hook | `hook-deletion-policies` |
| `topics/chart_repository.md` | Servidor de Repositório ChartMuseum | `chartmuseum-repository-server` |
| `community/release_policy.md` | Releases Principais | `major-releases` |

The `release_policy.md` fix also clears the warning reported on the (English, untranslated) `/blog/path-to-helm-v4` page, which links to `#major-releases`.

**Verification:** 
`yarn build --locale pt` had 0 broken anchors after the fix.

Refs #2220.