### PR TITLE
fix(i18n): fix zh locale broken anchors

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/chart_template_guide/functions_and_pipelines.md
@@ -158,7 +158,7 @@ drink: {{ .Values.favorite.drink | default (printf "%s-tea" (include "fullname" 
 模板函数和管道符是转换信息然后将其插入到YAML中的强有力方式。但是有些时候我们需要插入一些内容之前进行一些逻辑判断，而不仅仅是插入一个字符串。
 下一章节，我们会看到模板语言提供的控制结构。
 
-## 使用`lookup`函数
+## 使用`lookup`函数 {#using-the-lookup-function}
 
 `lookup` 函数可以用于在运行的集群中 _查找_ 资源。lookup函数简述为查找 `apiVersion, kind, namespace,name -> 资源或者资源列表`。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -160,7 +160,7 @@ $ git checkout -b gh-pages
 
 例如，如果你想在 `$WEBROOT/charts` 提供 chart，确保 web 根目录下有一个 `charts/` 目录，并将 index 文件和 chart 放在该目录中。
 
-### ChartMuseum 仓库服务器
+### ChartMuseum 仓库服务器 {#chartmuseum-repository-server}
 
 ChartMuseum 是一个用 Go (Golang) 编写的开源 Helm chart 仓库服务器，支持多种云存储后端，包括 [Google Cloud Storage](https://cloud.google.com/storage/)、[Amazon S3](https://aws.amazon.com/s3/)、[Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/)、[Alibaba Cloud OSS Storage](https://www.alibabacloud.com/product/oss)、[Openstack Object Storage](https://developer.openstack.org/api-ref/object-store/)、[Oracle Cloud Infrastructure Object Storage](https://cloud.oracle.com/storage)、[Baidu Cloud BOS Storage](https://cloud.baidu.com/product/bos.html)、[Tencent Cloud Object Storage](https://intl.cloud.tencent.com/product/cos)、[DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/)、[Minio](https://min.io/) 以及 [etcd](https://etcd.io/)。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -34,7 +34,7 @@ wordpress/
 
 Helm保留使用 `charts/`，`crds/`， `templates/`目录，以及列举出的文件名。其他文件保持原样。
 
-## Chart.yaml 文件
+## Chart.yaml 文件 {#the-chartyaml-file}
 
 `Chart.yaml`文件是chart必需的。包含了以下字段：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -219,7 +219,7 @@ helm env
 ln -s ~/GitHub/helm-mapkubeapis ./helm-mapkubeapis
 ```
 
-## 下载器插件
+## 下载器插件 {#downloader-plugins}
 
 默认情况下，Helm 可以使用 HTTP/S 拉取 Chart。从 Helm 2.4.0 开始，插件有一种特殊能力可以从任意来源下载 Chart。
 


### PR DESCRIPTION
This PR fixes the remaining broken anchors in the `zh` locale. 

All broken links already target English anchor IDs; the translated headings were missing the explicit IDs. Added `{#english-source-slug}` to each.

**Verification:** 
`yarn build --locale zh` had these 5 broken anchor warnings before (one was the shared `install → quickstart` anchor already fixed on `main`).

Refs #2220.

---

**Unrelated observation while verifying this PR:** several `zh` v3 pages use hardcoded absolute links with the locale prefix (e.g. `/zh/docs/topics/charts/`) instead of the file-relative form (`./charts.md`) used elsewhere in the repo.

These resolve fine in the full multi-locale build (CI/Netlify) and when I temporary set `onBrokenLinks: "warn"` locally, so nothing is broken. But without that, they fail in single-locale builds (`yarn build --locale zh`) locally, and because they bypass Docusaurus link resolution, they'd 404 silently rather than fail the build if a target page ever moves. I found 12 such links across 5 files while running the verification build above. See image below:

<img width="782" height="272" alt="Screenshot 2026-08-31 at 08 42 26" src="https://github.com/user-attachments/assets/88e4829c-e2da-4488-ba10-62d5f058f412" />


Happy to open a separate issue/PR to convert them to relative links if that's welcome. I just didn't want to mix it into this one.