### PR TITLE
fix(i18n): fix fr locale broken anchors

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -55,7 +55,7 @@ celle-ci est prévue dans moins de 7 jours.
 Au moment de la publication d'une release, la date de la prochaine release
 mineure sera annoncée et publiée sur la page principale du site web de Helm.
 
-## Releases majeures
+## Releases majeures {#major-releases}
 
 Les releases majeures contiennent des changements non rétrocompatibles. Ces
 releases sont rares mais parfois nécessaires pour permettre à Helm de continuer

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/intro/quickstart.md
@@ -28,7 +28,7 @@ Téléchargez le binaire de la release de Helm. Vous pouvez utiliser des outils 
 
 Pour plus de détails ou d'autres options, consultez [le guide d'installation](/intro/install.md).
 
-## Initialiser un dépôt de charts Helm
+## Initialiser un dépôt de charts Helm {#initialize-a-helm-chart-repository}
 
 Une fois Helm prêt, vous pouvez ajouter un dépôt de charts. Consultez [Artifact Hub](https://artifacthub.io/packages/search?kind=0) pour voir les dépôts de charts Helm disponibles.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -76,7 +76,7 @@ Helm 3 a introduit un SDK Go entièrement restructuré pour une meilleure expér
 de la création de logiciels et d'outils exploitant Helm. La documentation complète se trouve
 dans la [section SDK Go](/sdk/gosdk.md).
 
-## Backends de stockage
+## Backends de stockage {#storage-backends}
 
 Helm 3 a changé le stockage par défaut des informations de release vers les Secrets dans le
 namespace de la release. Helm 2 stockait par défaut les informations de release sous forme de

--- a/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -211,7 +211,7 @@ Par exemple, si vous voulez servir vos charts depuis `$WEBROOT/charts`, assurez-
 qu'il y a un répertoire `charts/` dans votre racine web, et placez le fichier index
 et les charts dans ce dossier.
 
-### Serveur de dépôt ChartMuseum
+### Serveur de dépôt ChartMuseum {#chartmuseum-repository-server}
 
 ChartMuseum est un serveur de dépôt de charts Helm open-source écrit en Go (Golang),
 avec support pour les backends de stockage cloud, notamment [Google Cloud


### PR DESCRIPTION
This PR fixes the broken anchors in the `fr` locale (follow-up to #2217/#2225, which covered the same-page cases). 

All four links already target English anchor IDs; the translated headings were missing the explicit IDs. Added `{#english-source-slug}` to each of them.

**Verification:** 
`yarn build --locale fr`,  0 broken anchors after.

Refs #2220.