### PR TITLE
fix(i18n): fix es locale broken anchors

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/es/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -52,7 +52,7 @@ de 7 días para el release anunciado.
 Al mismo tiempo que se publica un release, se anunciará la fecha del próximo
 release menor y se publicará en la página web principal de Helm.
 
-## Releases Mayores
+## Releases Mayores {#major-releases}
 
 Los releases mayores contienen cambios incompatibles. Estos releases son poco
 frecuentes, pero a veces son necesarios para permitir que Helm continúe

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -215,7 +215,7 @@ Por ejemplo, si desea servir sus charts desde `$WEBROOT/charts`, asegúrese de
 que haya un directorio `charts/` en su raíz web, y coloque el archivo de índice
 y los charts dentro de esa carpeta.
 
-### Servidor de Repositorio ChartMuseum
+### Servidor de Repositorio ChartMuseum {#chartmuseum-repository-server}
 
 ChartMuseum es un servidor de repositorio de charts de Helm de código abierto
 escrito en Go (Golang), con soporte para backends de almacenamiento en la nube,

--- a/i18n/es/docusaurus-plugin-content-docs/version-3/topics/plugins.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3/topics/plugins.md
@@ -274,7 +274,7 @@ En este ejemplo lo hicimos para `mapkubeapis`.
 ln -s ~/GitHub/helm-mapkubeapis ./helm-mapkubeapis
 ```
 
-## Plugins de Descarga
+## Plugins de Descarga {#downloader-plugins}
 
 Por defecto, Helm puede descargar Charts usando HTTP/S. A partir de Helm 2.4.0,
 los plugins pueden tener una capacidad especial para descargar Charts desde


### PR DESCRIPTION
This PR fixes the broken anchors in the `es` locale. 

All three links already target English anchor IDs; the translated headings were missing the explicit IDs. Added `{#english-source-slug}`.

**Verification:** 
`yarn build --locale es` had 0 broken anchors after

Refs #2220.