### PR TITLE
fix(i18n): fix it locale broken anchors

### DIFF
--- a/i18n/it/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/it/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -41,7 +41,7 @@ wordpress/
 Helm si riserva l'uso delle directory `charts/`, `crds/` e `templates/` e dei nomi dei file elencati.
 Gli altri file saranno lasciati così come sono.
 
-## Il file Chart.yaml
+## Il file Chart.yaml {#the-chartyaml-file}
 
 Il file `Chart.yaml` è necessario per un chart. Contiene i seguenti campi:
 


### PR DESCRIPTION
This PR fixes the broken anchor in the `it` locale. 

`chart_template_guide/builtin_objects.md` links to `topics/charts.md#the-chartyaml-file`; the translated heading was missing the explicit English ID. Added `{#the-chartyaml-file}`.

**Verification:** 
`yarn build --locale it` had 0 broken anchors after. 

Refs #2220.