### PR TITLE
fix(i18n): fix de locale broken anchors

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs-community/current/release_policy.md
+++ b/i18n/de/docusaurus-plugin-content-docs-community/current/release_policy.md
@@ -49,7 +49,7 @@ das angekündigte Release liegt weniger als 7 Tage entfernt.
 Gleichzeitig mit der Veröffentlichung eines Releases wird das Datum der nächsten
 Nebenversion angekündigt und auf Helms Hauptwebseite veröffentlicht.
 
-## Hauptversionen
+## Hauptversionen {#major-releases}
 
 Hauptversionen enthalten Breaking Changes. Solche Releases sind selten, aber
 manchmal notwendig, damit sich Helm in wichtigen neuen Richtungen weiterentwickeln

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -84,7 +84,7 @@ Helm 3 führte ein komplett umstrukturiertes Go SDK ein, das eine bessere Erfahr
 Erstellen von Software und Tools bietet, die Helm nutzen. Die vollständige Dokumentation finden Sie
 im [Go SDK-Abschnitt](/sdk/gosdk.md).
 
-## Speicher-Backends
+## Speicher-Backends {#storage-backends}
 
 Helm 3 hat den Standard-Speicherort für Release-Informationen auf Secrets im
 Namespace des Releases geändert. Helm 2 speicherte Release-Informationen standardmäßig als

--- a/i18n/de/docusaurus-plugin-content-docs/version-3/topics/charts.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-3/topics/charts.md
@@ -35,7 +35,7 @@ wordpress/
 
 Helm reserviert die Verwendung der Verzeichnisse `charts/`, `crds/` und `templates/` sowie der aufgelisteten Dateinamen. Andere Dateien bleiben unverändert.
 
-## Die Chart.yaml-Datei
+## Die Chart.yaml-Datei {#the-chartyaml-file}
 
 Die `Chart.yaml`-Datei ist für ein Chart erforderlich. Sie enthält die folgenden Felder:
 
@@ -675,7 +675,7 @@ Wenn ein Subchart eine globale Variable deklariert, wird diese _abwärts_ (an di
 
 Globale Variablen von übergeordneten Charts haben Vorrang vor den globalen Variablen von Subcharts.
 
-### Schema-Dateien
+### Schema-Dateien {#schema-files}
 
 Manchmal möchte ein Chart-Maintainer eine Struktur für seine Values definieren. Dies kann durch die Definition eines Schemas in der `values.schema.json`-Datei erfolgen. Ein Schema wird als [JSON Schema](https://json-schema.org/) dargestellt. Es könnte etwa so aussehen:
 


### PR DESCRIPTION
This PR fixes the broken anchors in the `de` locale.

All four links already target English anchor IDs; the translated headings were missing the explicit IDs. Added `{#english-source-slug}`. 

**Verification:** 
`yarn build --locale de` had 0 broken anchors after. 

Refs #2220.