### PR TITLE
fix(i18n): resolve zh docs links relatively

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/developers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/developers.md
@@ -57,7 +57,7 @@ Go依赖管理在不断变化，而且在Helm生命周期中很可能发生变�
 从Helm 3开始，文档已经移动到了它自己的仓库中。当编制新特性时，请编写随附文档并提交到
 [helm-www](https://github.com/helm/helm-www) 仓库。
 
-有个例外：[Helm CLI 输出 (英文)](../../docusaurus-plugin-content-docs/version-3/helm/helm.md) 是 `helm` 程序自己生成的。
+有个例外：[Helm CLI 输出 (英文)](/docs/v3/helm/helm) 是 `helm` 程序自己生成的。
 查看 [更新Helm CLI参考文档](https://github.com/helm/helm-www#updating-the-helm-cli-reference-docs)
 来了解如何生成该输出。翻译后，不会生成CLI输出，但可以在 `/content/<lang>/docs/helm` 中找到。
 

--- a/i18n/zh/docusaurus-plugin-content-docs-community/current/developers.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-community/current/developers.md
@@ -57,7 +57,7 @@ Go依赖管理在不断变化，而且在Helm生命周期中很可能发生变�
 从Helm 3开始，文档已经移动到了它自己的仓库中。当编制新特性时，请编写随附文档并提交到
 [helm-www](https://github.com/helm/helm-www) 仓库。
 
-有个例外：[Helm CLI 输出 (英文)](/docs/helm) 是 `helm` 程序自己生成的。
+有个例外：[Helm CLI 输出 (英文)](../../docusaurus-plugin-content-docs/version-3/helm/helm.md) 是 `helm` 程序自己生成的。
 查看 [更新Helm CLI参考文档](https://github.com/helm/helm-www#updating-the-helm-cli-reference-docs)
 来了解如何生成该输出。翻译后，不会生成CLI输出，但可以在 `/content/<lang>/docs/helm` 中找到。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/chart_template_guide/getting_started.md
@@ -213,4 +213,4 @@ data:
 
 使用 `--dry-run` 可以更方便地测试代码，但无法保证 Kubernetes 会接受你生成的模板。不要仅因为 `--dry-run` 正常运行就认为 chart 可以成功安装。
 
-在 [Chart 模板指南](/docs/chart_template_guide/index.mdx)中，我们会以这里定义的基础 chart 为例，详细介绍 Helm 模板语言。接下来从内置对象开始。
+在 [Chart 模板指南](./index.mdx)中，我们会以这里定义的基础 chart 为例，详细介绍 Helm 模板语言。接下来从内置对象开始。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/howto/chart_repository_sync_example.md
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 ## 设置本地 chart 仓库目录
 
-参考 [chart 仓库指南](/zh/docs/topics/chart_repository)创建本地目录，并将打包好的 chart 放在该目录中。
+参考 [chart 仓库指南](../topics/chart_repository.md)创建本地目录，并将打包好的 chart 放在该目录中。
 
 例如：
 
@@ -85,5 +85,5 @@ Downloading file://local-dir/index.yaml:                              346 B/346 
 相关链接：
 
 * [gsutil rsync 文档](https://cloud.google.com/storage/docs/gsutil/commands/rsync#description)
-* [Chart 仓库指南](/zh/docs/topics/chart_repository)
+* [Chart 仓库指南](../topics/chart_repository.md)
 * Google Cloud Storage 的[对象版本控制和并发控制](https://cloud.google.com/storage/docs/gsutil/addlhelp/ObjectVersioningandConcurrencyControl#overview)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/advanced.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/advanced.md
@@ -53,7 +53,7 @@ type PostRenderer interface {
 
 ## Go SDK
 
-Helm 3 引入了全新重构的 Go SDK，为构建基于 Helm 的软件和工具提供更好的体验。完整文档可在 [Go SDK 部分](/zh/docs/sdk/gosdk/)查看。
+Helm 3 引入了全新重构的 Go SDK，为构建基于 Helm 的软件和工具提供更好的体验。完整文档可在 [Go SDK 部分](../sdk/gosdk.md)查看。
 
 ## 后端存储 {#storage-backends}
 
@@ -96,7 +96,7 @@ export HELM_DRIVER_SQL_CONNECTION_STRING=postgresql://helm-postgres:5432/helm?us
 
 **生产环境说明**：建议：
 - 确保数据库可用于生产环境。对于 PostgreSQL，请参阅 [Server Administration](https://www.postgresql.org/docs/12/admin.html) 文档了解更多详情
-- 启用[权限管理](/zh/docs/topics/permissions_sql_storage_backend/)，以镜像 Kubernetes RBAC 来控制 release 信息的访问权限
+- 启用[权限管理](./permissions_sql_storage_backend.md)，以镜像 Kubernetes RBAC 来控制 release 信息的访问权限
 
 如果要从默认后端切换到 SQL 后端，需要自行进行迁移。可以使用以下命令获取 release 信息：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/chart_repository.md
@@ -6,12 +6,12 @@ sidebar_position: 6
 
 本节介绍如何创建和使用 Helm chart 仓库。从较高层面来说，chart 仓库是用来存储和共享打包好的 chart 的位置。
 
-社区的 Helm chart 仓库位于 [Artifact Hub](https://artifacthub.io/packages/search?kind=0)，欢迎参与贡献。不过 Helm 也支持创建和运行你自己的 chart 仓库。本指南将介绍如何操作。如果你正在考虑创建 chart 仓库，也可以考虑使用 [OCI 注册中心](/zh/docs/topics/registries/)作为替代方案。
+社区的 Helm chart 仓库位于 [Artifact Hub](https://artifacthub.io/packages/search?kind=0)，欢迎参与贡献。不过 Helm 也支持创建和运行你自己的 chart 仓库。本指南将介绍如何操作。如果你正在考虑创建 chart 仓库，也可以考虑使用 [OCI 注册中心](./registries.md)作为替代方案。
 
 ## 先决条件
 
-* 阅读[快速开始](/zh/docs/intro/quickstart/)指南
-* 阅读 [Charts](/zh/docs/topics/charts/) 文档
+* 阅读[快速开始](../intro/quickstart.md)指南
+* 阅读 [Charts](./charts.md) 文档
 
 ## 创建 chart 仓库
 
@@ -23,7 +23,7 @@ _chart 仓库_ 是一个配置了 `index.yaml` 文件和一些已打包 chart �
 
 ### chart 仓库结构
 
-chart 仓库由 chart 包和一个名为 `index.yaml` 的特殊文件组成，该文件包含了仓库中所有 chart 的索引。通常 `index.yaml` 所描述的 chart 也托管在同一服务器上，[来源文件](/zh/docs/topics/provenance/)也是如此。
+chart 仓库由 chart 包和一个名为 `index.yaml` 的特殊文件组成，该文件包含了仓库中所有 chart 的索引。通常 `index.yaml` 所描述的 chart 也托管在同一服务器上，[来源文件](./provenance.md)也是如此。
 
 例如，仓库 `https://example.com/charts` 的布局可能是这样的：
 
@@ -148,7 +148,7 @@ $ git checkout -b gh-pages
 
 在这种配置下，你可以使用默认分支存储 chart 代码，并使用 **gh-pages branch** 作为 chart 仓库，例如：`https://USERNAME.github.io/REPONAME`。演示仓库 [TS Charts](https://github.com/technosophos/tscharts) 可以通过 `https://technosophos.github.io/tscharts/` 访问。
 
-如果你想使用 GitHub Pages 托管 chart 仓库，请查看 [Chart Releaser Action](/zh/docs/howto/chart_releaser_action/)。Chart Releaser Action 是一个 GitHub Action 工作流，可以使用 [helm/chart-releaser](https://github.com/helm/chart-releaser) CLI 工具将 GitHub 项目转换为自托管的 Helm chart 仓库。
+如果你想使用 GitHub Pages 托管 chart 仓库，请查看 [Chart Releaser Action](../howto/chart_releaser_action.md)。Chart Releaser Action 是一个 GitHub Action 工作流，可以使用 [helm/chart-releaser](https://github.com/helm/chart-releaser) CLI 工具将 GitHub 项目转换为自托管的 Helm chart 仓库。
 
 ### 普通 web 服务器
 
@@ -191,7 +191,7 @@ $ helm repo index fantastic-charts --url https://fantastic-charts.storage.google
 
 最后一条命令获取刚创建的本地目录路径和远程 chart 仓库的 URL，并在给定的目录路径中生成 `index.yaml` 文件。
 
-现在你可以使用同步工具或手动方式将 chart 和 index 文件上传到 chart 仓库。如果使用 Google Cloud Storage，可以使用 gsutil 客户端查看[示例工作流](/zh/docs/howto/chart_repository_sync_example/)。对于 GitHub，你可以简单地将 chart 放在合适的目标分支中。
+现在你可以使用同步工具或手动方式将 chart 和 index 文件上传到 chart 仓库。如果使用 Google Cloud Storage，可以使用 gsutil 客户端查看[示例工作流](../howto/chart_repository_sync_example.md)。对于 GitHub，你可以简单地将 chart 放在合适的目标分支中。
 
 ### 向现有仓库添加新 chart
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/chart_tests.md
@@ -22,7 +22,7 @@ Helm chart 中的**测试**位于 `templates/` 目录下，是一个 Job 定义�
 
 ## 测试示例
 
-[helm create](/zh/docs/helm/helm_create/) 命令会自动创建一些目录和文件。要尝试 Helm 测试功能，首先创建一个示例 Helm chart。
+[helm create](../helm/helm_create.md) 命令会自动创建一些目录和文件。要尝试 Helm 测试功能，首先创建一个示例 Helm chart。
 
 ```console
 $ helm create demo
@@ -83,4 +83,4 @@ Phase:          Succeeded
 
 - 可以在单个 yaml 文件中定义多个测试，也可以将测试分布在 `templates/` 目录下的多个 yaml 文件中。
 - 可以将测试套件嵌套放在 `tests/` 目录中（如 `<chart-name>/templates/tests/`）以获得更好的隔离。
-- 测试是一种 [Helm 钩子](/zh/docs/topics/charts_hooks/)，因此 `helm.sh/hook-weight` 和 `helm.sh/hook-delete-policy` 等注解也可以用于测试资源。
+- 测试是一种 [Helm 钩子](./charts_hooks.md)，因此 `helm.sh/hook-weight` 和 `helm.sh/hook-delete-policy` 等注解也可以用于测试资源。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-3/topics/charts_hooks.md
@@ -26,7 +26,7 @@ Helm 提供了钩子（hook）机制，允许 chart 开发者在 release 生命�
 | `post-upgrade`   | 在升级请求时、所有资源升级完成后执行                                                              |
 | `pre-rollback`   | 在回滚请求时、模板渲染后、任何资源回滚之前执行                                                     |
 | `post-rollback`  | 在回滚请求时、所有资源修改完成后执行                                                              |
-| `test`           | 在调用 Helm test 子命令时执行（[查看 test 文档](/zh/docs/topics/chart_tests/)）                   |
+| `test`           | 在调用 Helm test 子命令时执行（[查看 test 文档](./chart_tests.md)）                   |
 
 _注意：`crd-install` 钩子已在 Helm 3 中移除，改用 `crds/` 目录。_
 


### PR DESCRIPTION
## Summary

Fixes the unresolved Helm CLI reference in the Chinese developer guide. The link now targets the published Helm 3 documentation route.

Closes #2236

## Validation

- `git diff --check`
- `yarn build --locale zh` (passed)