### PR TITLE
fix(config): set onbrokenanchors to throw

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,6 +64,7 @@ const config = {
   projectName: "helm-www", // Usually your repo name.
 
   onBrokenLinks: "throw",
+  onBrokenAnchors: "throw",
 
   i18n: {
     defaultLocale: "en",


### PR DESCRIPTION
Sets `onBrokenAnchors: "throw"` so broken anchors fail the build the same way broken links already do. This PR fixes #2220.

### Why it's safe to flip now

All broken anchors surfaced by `yarn build` have been fixed in the preceding PRs (verified per-locale, all builds now at zero broken-anchor warnings):

### Verification

Full `yarn build` on this branch (all 12 locales): completes with **zero** broken-anchor warnings and exits successfully with the new setting. Going forward, any new broken anchor on same-page or cross-page in any locale — fails CI instead of scrolling by as a warning.

See image below for the log tail of the current `yarn build` output.
<img width="1272" height="649" alt="Screenshot 2026-09-01 at 11 39 29" src="https://github.com/user-attachments/assets/ea4f4a91-0b65-46c5-99d5-8ef8da82ad63" />
